### PR TITLE
(SIMP-1595) Provide complete dependency boundaries

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -1,14 +1,21 @@
 {
-  "name":    "simp-compliance_markup",
-  "version": "1.0.1",
-  "author":  "simp",
+  "name": "simp-compliance_markup",
+  "version": "1.0.2",
+  "author": "simp",
   "summary": "Compliance-mapping annotation for Puppet code",
   "license": "Apache-2.0",
-  "source":  "https://github.com/simp/compliance_markup",
+  "source": "https://github.com/simp/compliance_markup",
   "project_page": "https://github.com/simp/compliance_markup",
-  "issues_url":   "https://github.com/simp/compliance_markup/issues",
-  "tags": [ "simp", "security", "compliance", "reporting"],
-  "dependencies": [],
+  "issues_url": "https://simp-project.atlassian.net",
+  "tags": [
+    "simp",
+    "security",
+    "compliance",
+    "reporting"
+  ],
+  "dependencies": [
+
+  ],
   "operatingsystem_support": [
     {
       "operatingsystem": "CentOS",


### PR DESCRIPTION
Before this patch, dependencies in `metadata.json` and
`build/rpm_metadata/requires` were missing upper boundaries and often
listed inaccurate lower boundaries.  This created an extremely fragile
5.2.X/4.3.X module ecosystem on the Forge, as a major release in any
dependency would be certain to break the module.

This commit resolves the issue by introducing upper and lower boundaries
for each dependency in `metadata.json` and propagates those dependencies
to the RPM dependencies listed in `build/rpm_metadata/requires`.

The minimum version boundaries were determined from the modules as they
were checked out in `simp-core` for the latest SIMP 5.2.X/4.3.X release
(with the addition recent z-version bumps from Forge-readiness patches).

SIMP-1595 #comment Fixed `pupmod-simp-compliance_markup`
SIMP-1643 #close