### PR TITLE
(SIMP-1698) compliance_mapper should use puppet_vardir

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,8 +19,6 @@ group :test do
   gem "puppetlabs_spec_helper"
   gem "metadata-json-lint"
   gem "simp-rspec-puppet-facts", "~> 1.3"
-
-
   # simp-rake-helpers does not suport puppet 2.7.X
   if "#{ENV['PUPPET_VERSION']}".scan(/\d+/).first != '2' &&
       # simp-rake-helpers and ruby 1.8.7 bomb Travis tests
@@ -35,6 +33,7 @@ group :development do
   gem "travis-lint"
   gem "travish"
   gem "puppet-blacksmith"
+  gem "puppet-strings"
   gem "guard-rake"
   gem 'pry'
   gem 'pry-doc'

--- a/lib/puppet/parser/functions/compliance_map.rb
+++ b/lib/puppet/parser/functions/compliance_map.rb
@@ -16,42 +16,42 @@ module Puppet::Parser::Functions
             super
             @keys = []
           end
-    
+
           def self.[](*args)
             ordered_hash = new
-    
+
             if (args.length == 1 && args.first.is_a?(Array))
               args.first.each do |key_value_pair|
                 next unless (key_value_pair.is_a?(Array))
                 ordered_hash[key_value_pair[0]] = key_value_pair[1]
               end
-    
+
               return ordered_hash
             end
-    
+
             unless (args.size % 2 == 0)
               raise ArgumentError.new("odd number of arguments for Hash")
             end
-    
+
             args.each_with_index do |val, ind|
               next if (ind % 2 != 0)
               ordered_hash[val] = args[ind + 1]
             end
-    
+
             ordered_hash
           end
-    
+
           def initialize_copy(other)
             super
             # make a deep copy of keys
             @keys = other.keys
           end
-    
+
           def []=(key, value)
             @keys << key if !has_key?(key)
             super
           end
-    
+
           def delete(key)
             if has_key? key
               index = @keys.index(key)
@@ -59,80 +59,80 @@ module Puppet::Parser::Functions
             end
             super
           end
-          
+
           def delete_if
             super
             sync_keys!
             self
           end
-    
+
           def reject!
             super
             sync_keys!
             self
           end
-    
+
           def reject(&block)
             dup.reject!(&block)
           end
-    
+
           def keys
             @keys.dup
           end
-    
+
           def values
             @keys.collect { |key| self[key] }
           end
-    
+
           def to_hash
             self
           end
-    
+
           def to_a
             @keys.map { |key| [ key, self[key] ] }
           end
-    
+
           def each_key
             @keys.each { |key| yield key }
           end
-    
+
           def each_value
             @keys.each { |key| yield self[key]}
           end
-    
+
           def each
             @keys.each {|key| yield [key, self[key]]}
           end
-    
+
           alias_method :each_pair, :each
-    
+
           def clear
             super
             @keys.clear
             self
           end
-    
+
           def shift
             k = @keys.first
             v = delete(k)
             [k, v]
           end
-    
+
           def merge!(other_hash)
             other_hash.each {|k,v| self[k] = v }
             self
           end
-    
+
           def merge(other_hash)
             dup.merge!(other_hash)
           end
-    
+
           def inspect
             "#<OrderedHash #{super}>"
           end
-    
+
         private
-    
+
           def sync_keys!
             @keys.delete_if {|k| !has_key?(k)}
           end
@@ -377,7 +377,7 @@ module Puppet::Parser::Functions
 
     # This will be useful for a future iteration of the software.
     #if generate_report
-      compliance_report_target = %(#{Puppet[:vardir]}/compliance_report.yaml)
+      compliance_report_target = %(#{Facter.value(:vardir)}/compliance_report.yaml)
 
       # Retrieve the catalog resource if it already exists, create one if it
       # does not

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -25,34 +25,31 @@ describe 'compliance' do
         let(:facts) { facts }
 
         before(:each) do
-          Puppet[:vardir] = @tmpdir
+          Facter.stubs(:value).with(:puppet_vardir).returns(@tmpdir)
         end
 
         context 'parameter-only compliance map test' do
           let(:pre_condition) do
             "include 'compliance'"
           end
-
           it { is_expected.to compile.with_all_deps }
-          it { is_expected.not_to contain_file("#{Puppet[:vardir]}/compliance_report.yaml") }
+          it { is_expected.not_to contain_file("#{Facter.value(:vardir)}/compliance_report.yaml") }
         end
 
         context 'one parameter required compliance map test' do
           let(:pre_condition) do
-           %(
-            include 'compliance::test2'
-            )
+            "include 'compliance::test2'"
           end
 
           it { is_expected.to compile.with_all_deps }
-          it { is_expected.not_to contain_file("#{Puppet[:vardir]}/compliance_report.yaml") }
+          it { is_expected.not_to contain_file("#{Facter.value(:vardir)}/compliance_report.yaml") }
         end
 
         shared_examples_for "a deviation run" do |profile, test_run, use_custom_content = false, extra_profiles = []|
           it {
             is_expected.to compile.with_all_deps
-            is_expected.to contain_file("#{Puppet[:vardir]}/compliance_report.yaml")
-            report = YAML.load(@catalogue.resource("File[#{Puppet[:vardir]}/compliance_report.yaml]")[:content])
+            is_expected.to contain_file("#{Facter.value(:vardir)}/compliance_report.yaml")
+            report = YAML.load(@catalogue.resource("File[#{Facter.value(:vardir)}/compliance_report.yaml]")[:content])
 
             expect( report['compliance_profiles'][profile][test_run]['parameters'].size ).to eq(1)
             expect( report['compliance_profiles'][profile][test_run]['parameters'].first['compliant_param'] ).to eq('1')


### PR DESCRIPTION
Puppet[:vardir] causes issues with Puppet 4, and sometimes the
compliance report can't be put down. This update changes how $vardir is
discovered to use the `puppet_vardir` fact from stblib.

SIMP-1698 #close
