### PR TITLE
(SIMP-1866) Catch errors if no compliance_map

### DIFF
--- a/lib/puppet/parser/functions/compliance_map.rb
+++ b/lib/puppet/parser/functions/compliance_map.rb
@@ -251,6 +251,11 @@ module Puppet::Parser::Functions
       end
     end
 
+    # If we still don't have a reference map, we need to let the user know!
+    if !reference_map || (reference_map.respond_to?(:empty) && reference_map.empty?)
+      raise(Puppet::ParseError, %(compliance_map(): Could not find the 'compliance_map' Hash at the global level, in Hiera, or via Lookup))
+    end
+
     # Pick up our compiler hitchhiker
     # This is only needed when passing arguments. Users should no longer call
     # compliance_map() without arguments directly inside their classes or

--- a/lib/puppetx/simp/compliance_map.rb
+++ b/lib/puppetx/simp/compliance_map.rb
@@ -26,7 +26,7 @@ unless PuppetX.const_get("SIMP#{Puppet[:environment]}").const_defined?('Complian
       # @param compliance_profiles (Array) Compliance_profile strings that are
       #   valid for this ComplianceMap
       #
-      # @param ref_map (Hash) Data that represents the full compliance
+      # @param compliance_mapping (Hash) Data that represents the full compliance
       #   mapping
       #
       #   Example:
@@ -38,7 +38,7 @@ unless PuppetX.const_get("SIMP#{Puppet[:environment]}").const_defined?('Complian
       #       }
       #     }
       #
-      def initialize(valid_profiles, ref_map, config={})
+      def initialize(valid_profiles, compliance_mapping, config={})
         return if @initialized
 
         @initialized = true
@@ -62,11 +62,11 @@ unless PuppetX.const_get("SIMP#{Puppet[:environment]}").const_defined?('Complian
         @valid_profiles.each do |valid_profile|
           @ref_map[valid_profile] = Hash.new()
 
-          if ref_map[valid_profile]
-            raise @err_msg unless ref_map[valid_profile].respond_to?(:keys)
+          if compliance_mapping[valid_profile]
+            raise @err_msg unless compliance_mapping[valid_profile].respond_to?(:keys)
 
-            ref_map[valid_profile].keys.each do |key|
-              @ref_map[valid_profile] = ref_map[valid_profile]
+            compliance_mapping[valid_profile].keys.each do |key|
+              @ref_map[valid_profile] = compliance_mapping[valid_profile]
             end
           end
         end

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -303,6 +303,45 @@ describe 'compliance_markup' do
                 expect( invalid_entry['system_value'] ).to eq('foo3_1')
               end
             end
+
+            context 'without a compliance_profile variable set' do
+              let(:pre_condition) {
+                <<-EOM
+                  include 'compliance_markup'
+                EOM
+              }
+
+              let(:hieradata) { 'passing_checks' }
+
+              it { is_expected.to(compile.with_all_deps) }
+            end
+
+            context 'with an unknown compliance_profile variable set' do
+              let(:pre_condition) {
+                <<-EOM
+                  $compliance_profile = 'FOO BAR'
+                EOM
+              }
+
+              let(:hieradata) { 'passing_checks' }
+
+              it { is_expected.to(compile.with_all_deps) }
+            end
+
+=begin
+# This should work, but it does not
+            context 'without valid compliance data in Hiera' do
+              let(:pre_condition) {''}
+              # Note: No hieradata set!
+              # let(:hieradata) { 'passing_checks' }
+
+              it 'should fail' do
+                expect {
+                  compile.with_all_deps
+                }.to raise_error(/Could not find/)
+              end
+            end
+=end
           end
         end
       end


### PR DESCRIPTION
The compliance_map function would fail if there was no compliance_map
Hash available in the lookup sources.

This outputs a proper error instead of just crashing.

SIMP-1866 #close