### PR TITLE
(SIMP-3784) Replace the compliance mapper's report generator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ spec/rp_env/
 .rspec_system
 .vagrant/
 .bundle/
+.idea/
 Gemfile.lock
 vendor/
 junit/

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,31 +41,6 @@ jobs:
 
     - stage: spec
       rvm: 2.1.9
-      env: STRICT_VARIABLES=yes TRUSTED_NODE_DATA=yes PUPPET_VERSION="~> 4.8.2"
-      script:
-        - bundle exec rake spec
-      before_deploy:
-        - "export PUPMOD_METADATA_VERSION=`ruby -r json -e \"puts JSON.parse(File.read('metadata.json')).fetch('version')\"`"
-        - '[[ $TRAVIS_TAG =~ ^simp-${PUPMOD_METADATA_VERSION}$|^${PUPMOD_METADATA_VERSION}$ ]]'
-      deploy:
-        - provider: puppetforge
-          user: simp
-          password:
-              secure: "vL1MNFrE7aazh/rEsSaHugCYYWXrJmsBuhMIP27CQ/EpBQ6wfWZhukZdkikZrmkIiJHHLi1HaQycKdW2AzcqN932iXOdjYtEA9eE/hO1VtGMYVobZFS4sh2Wtt8saVOg0tMPq45hjFHUe8FmgyrsjHBB+kl/fdfLVr+TiFCmWGXtZkjMlJxqPp+fyZZDrMoKoB7eSm3edOtqX7gONP3MEJ/wcHgCUTyspxI8sSXGl8IPwWNxU4LSgCwbvr/JzmDmKiK2AbSc7Q2+g7NrvZV39CbcV0IH4Uy4A+3fBBli/nPaidm/dvIvcYDacWF0UiXZTMvqd8tL4Z3Sf4vvB6NZ328ml97w233fLSHdLGn8qaIjmkK5x1UN9BRmA/WZbmkSSLWqwr6Cz+c4unik1NeQF2shpNZw8cGyh6IFnpIUbBsXPgxiIbb1HfoQCRFocTgkqpsbH7n8WpJkEdPpVgtJh51xILlbZibsI9U1YsfDjpZWXxUUObsANbAK0Z0Ep0wkzv31+9fSD7FlGOJ//GjqFRjW4inekCeUNyRbXTGIlDMeZyRKs/JZVndKr9AFestwkiM7AWWNFUKfSX5RE0oRNwQDAKAa8HDPtErNhfoAtBCYEcBTB6GoXhnyX/1gwrDb8zeEtbc50PLBnJT6gJIp2M2IiAeXHgGuMLiDbNzgThQ="
-          on:
-            tags: true
-            rvm: 2.1.9
-            condition: '($SKIP_FORGE_PUBLISH != true)'
-        - provider: releases
-          api_key:
-              secure: "c/QadLPTz3GBOL8ZPjHlxVMcicavnVVwnaFORMFf1qQYI3zCADLoqSGPaSOWSLXOFgOOKLuz2PTofqtKy/muDK0t8gl8dEFnyrUGRyRMfzvmH88DUihJ5H7Tuj1aqtUEYUgMUvA3552rf93/zyGPmsi2HKx65mg0pM1ubdz3TuDbPmxD3KdWu5DZRpF+WgLwB9yaAi1q44bXfS1QP8G5YcXzmSxXccEg1H+wwR96CnvgxQ/mL6S6H3w3bQOFciprw99J2eXXZXrbTsjlp9Sm3kb3p32mdThZYyTxTmtqVRpyqf/YEM9a9XYFNfAVl4VltiTCjTtTaQqn+4dS7UWuEi4BjEMr6erB2WLtnBISSoOXyhhgYynhtRG006a5xSc+R0iwcEqZbPQgG0rDEgkSXH7P9SxsUcwYvE5ceKphI3HDFf/9r0h0nOQ82hcbAE3hwshMbM+s+dGiv6xlaWo2v9Sr7SCUdGHkEYryggTh2cdtsgGnNPRIrQHTa1HQe303YjSR9MqqdFB2v5lAt8EfHl8iR+y2/do6udj5KsaHDMtxVKnwHXcSf1mNCVSaL4nffMt96h0QBLCGhNibTNjk6zOKoKTkf/+Xuv6WR9tmHHeAULsYzmyFiAoqGBBulBDeBZgsw/zSxkKeXSX9r+JP7p9abEjOd3EoruvvNGr2XS4="
-          skip_cleanup: true
-          on:
-            tags: true
-            condition: '($SKIP_FORGE_PUBLISH != true)'
-
-    - stage: spec
-      rvm: 2.1.9
       env: STRICT_VARIABLES=yes TRUSTED_NODE_DATA=yes PUPPET_VERSION="~> 5.0"
       script:
         - bundle exec rake spec
@@ -96,3 +71,29 @@ jobs:
       script:
         - bundle exec rake beaker:suites[default,docker]
       env: PUPPET_VERSION"~> 4.8.2"
+
+    # This needs to be last since we have an acceptance test
+    - stage: deploy
+      rvm: 2.1.9
+      env: STRICT_VARIABLES=yes TRUSTED_NODE_DATA=yes PUPPET_VERSION="~> 4.8.2"
+      script:
+        - bundle exec rake spec
+      before_deploy:
+        - "export PUPMOD_METADATA_VERSION=`ruby -r json -e \"puts JSON.parse(File.read('metadata.json')).fetch('version')\"`"
+        - '[[ $TRAVIS_TAG =~ ^simp-${PUPMOD_METADATA_VERSION}$|^${PUPMOD_METADATA_VERSION}$ ]]'
+      deploy:
+        - provider: releases
+          api_key:
+              secure: "c/QadLPTz3GBOL8ZPjHlxVMcicavnVVwnaFORMFf1qQYI3zCADLoqSGPaSOWSLXOFgOOKLuz2PTofqtKy/muDK0t8gl8dEFnyrUGRyRMfzvmH88DUihJ5H7Tuj1aqtUEYUgMUvA3552rf93/zyGPmsi2HKx65mg0pM1ubdz3TuDbPmxD3KdWu5DZRpF+WgLwB9yaAi1q44bXfS1QP8G5YcXzmSxXccEg1H+wwR96CnvgxQ/mL6S6H3w3bQOFciprw99J2eXXZXrbTsjlp9Sm3kb3p32mdThZYyTxTmtqVRpyqf/YEM9a9XYFNfAVl4VltiTCjTtTaQqn+4dS7UWuEi4BjEMr6erB2WLtnBISSoOXyhhgYynhtRG006a5xSc+R0iwcEqZbPQgG0rDEgkSXH7P9SxsUcwYvE5ceKphI3HDFf/9r0h0nOQ82hcbAE3hwshMbM+s+dGiv6xlaWo2v9Sr7SCUdGHkEYryggTh2cdtsgGnNPRIrQHTa1HQe303YjSR9MqqdFB2v5lAt8EfHl8iR+y2/do6udj5KsaHDMtxVKnwHXcSf1mNCVSaL4nffMt96h0QBLCGhNibTNjk6zOKoKTkf/+Xuv6WR9tmHHeAULsYzmyFiAoqGBBulBDeBZgsw/zSxkKeXSX9r+JP7p9abEjOd3EoruvvNGr2XS4="
+          skip_cleanup: true
+          on:
+            tags: true
+            condition: '($SKIP_FORGE_PUBLISH != true)'
+        - provider: puppetforge
+          user: simp
+          password:
+              secure: "vL1MNFrE7aazh/rEsSaHugCYYWXrJmsBuhMIP27CQ/EpBQ6wfWZhukZdkikZrmkIiJHHLi1HaQycKdW2AzcqN932iXOdjYtEA9eE/hO1VtGMYVobZFS4sh2Wtt8saVOg0tMPq45hjFHUe8FmgyrsjHBB+kl/fdfLVr+TiFCmWGXtZkjMlJxqPp+fyZZDrMoKoB7eSm3edOtqX7gONP3MEJ/wcHgCUTyspxI8sSXGl8IPwWNxU4LSgCwbvr/JzmDmKiK2AbSc7Q2+g7NrvZV39CbcV0IH4Uy4A+3fBBli/nPaidm/dvIvcYDacWF0UiXZTMvqd8tL4Z3Sf4vvB6NZ328ml97w233fLSHdLGn8qaIjmkK5x1UN9BRmA/WZbmkSSLWqwr6Cz+c4unik1NeQF2shpNZw8cGyh6IFnpIUbBsXPgxiIbb1HfoQCRFocTgkqpsbH7n8WpJkEdPpVgtJh51xILlbZibsI9U1YsfDjpZWXxUUObsANbAK0Z0Ep0wkzv31+9fSD7FlGOJ//GjqFRjW4inekCeUNyRbXTGIlDMeZyRKs/JZVndKr9AFestwkiM7AWWNFUKfSX5RE0oRNwQDAKAa8HDPtErNhfoAtBCYEcBTB6GoXhnyX/1gwrDb8zeEtbc50PLBnJT6gJIp2M2IiAeXHgGuMLiDbNzgThQ="
+          on:
+            tags: true
+            rvm: 2.1.9
+            condition: '($SKIP_FORGE_PUBLISH != true)'

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,52 +8,89 @@
 # PE 2017.2   4.10  2.1.9  TBD
 ---
 language: ruby
-sudo: false
 cache: bundler
-before_script:
-  - bundle update
+sudo: false
+
 bundler_args: --without development system_tests --path .vendor
-before_install:
-  - rm Gemfile.lock || true
-  - rvm @global do gem uninstall bundler -a -x
-  - rvm @global do gem install bundler -v '~> 1.14.0'
-script:
-  - bundle exec rake compare_latest_tag
-  - bundle exec rake test
+
 notifications:
   email: false
-rvm:
-  - 2.1.9
-env:
-  global:
-    - STRICT_VARIABLES=yes
-  matrix:
-    - PUPPET_VERSION="~> 4.8.2" FORGE_PUBLISH=true
-    - PUPPET_VERSION="~> 4.10.0"
-    - PUPPET_VERSION="~> 4.9.2"
-    - PUPPET_VERSION="~> 4.7.0"
-matrix:
-  fast_finish: true
 
-before_deploy:
-  - 'bundle exec rake metadata_lint'
-  - 'bundle exec rake clobber'
-  - 'bundle exec rake spec_clean'
-  - "export PUPMOD_METADATA_VERSION=`ruby -r json -e \"puts JSON.parse(File.read('metadata.json')).fetch('version')\"`"
-  - '[[ $TRAVIS_TAG =~ ^${PUPMOD_METADATA_VERSION}$ ]]'
-deploy:
-  - provider: puppetforge
-    user: simp
-    password:
-        secure: "vL1MNFrE7aazh/rEsSaHugCYYWXrJmsBuhMIP27CQ/EpBQ6wfWZhukZdkikZrmkIiJHHLi1HaQycKdW2AzcqN932iXOdjYtEA9eE/hO1VtGMYVobZFS4sh2Wtt8saVOg0tMPq45hjFHUe8FmgyrsjHBB+kl/fdfLVr+TiFCmWGXtZkjMlJxqPp+fyZZDrMoKoB7eSm3edOtqX7gONP3MEJ/wcHgCUTyspxI8sSXGl8IPwWNxU4LSgCwbvr/JzmDmKiK2AbSc7Q2+g7NrvZV39CbcV0IH4Uy4A+3fBBli/nPaidm/dvIvcYDacWF0UiXZTMvqd8tL4Z3Sf4vvB6NZ328ml97w233fLSHdLGn8qaIjmkK5x1UN9BRmA/WZbmkSSLWqwr6Cz+c4unik1NeQF2shpNZw8cGyh6IFnpIUbBsXPgxiIbb1HfoQCRFocTgkqpsbH7n8WpJkEdPpVgtJh51xILlbZibsI9U1YsfDjpZWXxUUObsANbAK0Z0Ep0wkzv31+9fSD7FlGOJ//GjqFRjW4inekCeUNyRbXTGIlDMeZyRKs/JZVndKr9AFestwkiM7AWWNFUKfSX5RE0oRNwQDAKAa8HDPtErNhfoAtBCYEcBTB6GoXhnyX/1gwrDb8zeEtbc50PLBnJT6gJIp2M2IiAeXHgGuMLiDbNzgThQ="
-    on:
-      tags: true
+addons:
+  apt:
+    packages:
+      - rpm
+
+before_install:
+  - rm -f Gemfile.lock
+
+jobs:
+  allow_failures:
+    - env: STRICT_VARIABLES=yes TRUSTED_NODE_DATA=yes PUPPET_VERSION="~> 5.0"
+
+  include:
+    - stage: lint
       rvm: 2.1.9
-      condition: '($SKIP_FORGE_PUBLISH != true) && ($FORGE_PUBLISH = true)'
-  - provider: releases
-    api_key:
-        secure: "c/QadLPTz3GBOL8ZPjHlxVMcicavnVVwnaFORMFf1qQYI3zCADLoqSGPaSOWSLXOFgOOKLuz2PTofqtKy/muDK0t8gl8dEFnyrUGRyRMfzvmH88DUihJ5H7Tuj1aqtUEYUgMUvA3552rf93/zyGPmsi2HKx65mg0pM1ubdz3TuDbPmxD3KdWu5DZRpF+WgLwB9yaAi1q44bXfS1QP8G5YcXzmSxXccEg1H+wwR96CnvgxQ/mL6S6H3w3bQOFciprw99J2eXXZXrbTsjlp9Sm3kb3p32mdThZYyTxTmtqVRpyqf/YEM9a9XYFNfAVl4VltiTCjTtTaQqn+4dS7UWuEi4BjEMr6erB2WLtnBISSoOXyhhgYynhtRG006a5xSc+R0iwcEqZbPQgG0rDEgkSXH7P9SxsUcwYvE5ceKphI3HDFf/9r0h0nOQ82hcbAE3hwshMbM+s+dGiv6xlaWo2v9Sr7SCUdGHkEYryggTh2cdtsgGnNPRIrQHTa1HQe303YjSR9MqqdFB2v5lAt8EfHl8iR+y2/do6udj5KsaHDMtxVKnwHXcSf1mNCVSaL4nffMt96h0QBLCGhNibTNjk6zOKoKTkf/+Xuv6WR9tmHHeAULsYzmyFiAoqGBBulBDeBZgsw/zSxkKeXSX9r+JP7p9abEjOd3EoruvvNGr2XS4="
-    skip_cleanup: true
-    on:
-      tags: true
-      condition: '($SKIP_FORGE_PUBLISH != true) && ($FORGE_PUBLISH = true)'
+        - bundle exec rake metadata_lint
+
+    - stage: compare_tag
+      rvm: 2.1.9
+        - bundle exec rake compare_latest_tag
+
+    - stage: spec
+      rvm: 2.1.9
+      env: STRICT_VARIABLES=yes TRUSTED_NODE_DATA=yes PUPPET_VERSION="~> 4.8.2"
+      script:
+        - bundle exec rake spec
+      before_deploy:
+        - "export PUPMOD_METADATA_VERSION=`ruby -r json -e \"puts JSON.parse(File.read('metadata.json')).fetch('version')\"`"
+        - '[[ $TRAVIS_TAG =~ ^simp-${PUPMOD_METADATA_VERSION}$|^${PUPMOD_METADATA_VERSION}$ ]]'
+      deploy:
+        - provider: puppetforge
+          user: simp
+          password:
+              secure: "vL1MNFrE7aazh/rEsSaHugCYYWXrJmsBuhMIP27CQ/EpBQ6wfWZhukZdkikZrmkIiJHHLi1HaQycKdW2AzcqN932iXOdjYtEA9eE/hO1VtGMYVobZFS4sh2Wtt8saVOg0tMPq45hjFHUe8FmgyrsjHBB+kl/fdfLVr+TiFCmWGXtZkjMlJxqPp+fyZZDrMoKoB7eSm3edOtqX7gONP3MEJ/wcHgCUTyspxI8sSXGl8IPwWNxU4LSgCwbvr/JzmDmKiK2AbSc7Q2+g7NrvZV39CbcV0IH4Uy4A+3fBBli/nPaidm/dvIvcYDacWF0UiXZTMvqd8tL4Z3Sf4vvB6NZ328ml97w233fLSHdLGn8qaIjmkK5x1UN9BRmA/WZbmkSSLWqwr6Cz+c4unik1NeQF2shpNZw8cGyh6IFnpIUbBsXPgxiIbb1HfoQCRFocTgkqpsbH7n8WpJkEdPpVgtJh51xILlbZibsI9U1YsfDjpZWXxUUObsANbAK0Z0Ep0wkzv31+9fSD7FlGOJ//GjqFRjW4inekCeUNyRbXTGIlDMeZyRKs/JZVndKr9AFestwkiM7AWWNFUKfSX5RE0oRNwQDAKAa8HDPtErNhfoAtBCYEcBTB6GoXhnyX/1gwrDb8zeEtbc50PLBnJT6gJIp2M2IiAeXHgGuMLiDbNzgThQ="
+          on:
+            tags: true
+            rvm: 2.1.9
+            condition: '($SKIP_FORGE_PUBLISH != true)'
+        - provider: releases
+          api_key:
+              secure: "c/QadLPTz3GBOL8ZPjHlxVMcicavnVVwnaFORMFf1qQYI3zCADLoqSGPaSOWSLXOFgOOKLuz2PTofqtKy/muDK0t8gl8dEFnyrUGRyRMfzvmH88DUihJ5H7Tuj1aqtUEYUgMUvA3552rf93/zyGPmsi2HKx65mg0pM1ubdz3TuDbPmxD3KdWu5DZRpF+WgLwB9yaAi1q44bXfS1QP8G5YcXzmSxXccEg1H+wwR96CnvgxQ/mL6S6H3w3bQOFciprw99J2eXXZXrbTsjlp9Sm3kb3p32mdThZYyTxTmtqVRpyqf/YEM9a9XYFNfAVl4VltiTCjTtTaQqn+4dS7UWuEi4BjEMr6erB2WLtnBISSoOXyhhgYynhtRG006a5xSc+R0iwcEqZbPQgG0rDEgkSXH7P9SxsUcwYvE5ceKphI3HDFf/9r0h0nOQ82hcbAE3hwshMbM+s+dGiv6xlaWo2v9Sr7SCUdGHkEYryggTh2cdtsgGnNPRIrQHTa1HQe303YjSR9MqqdFB2v5lAt8EfHl8iR+y2/do6udj5KsaHDMtxVKnwHXcSf1mNCVSaL4nffMt96h0QBLCGhNibTNjk6zOKoKTkf/+Xuv6WR9tmHHeAULsYzmyFiAoqGBBulBDeBZgsw/zSxkKeXSX9r+JP7p9abEjOd3EoruvvNGr2XS4="
+          skip_cleanup: true
+          on:
+            tags: true
+            condition: '($SKIP_FORGE_PUBLISH != true)'
+
+    - stage: spec
+      rvm: 2.1.9
+      env: STRICT_VARIABLES=yes TRUSTED_NODE_DATA=yes PUPPET_VERSION="~> 5.0"
+      script:
+        - bundle exec rake spec
+
+    - stage: spec
+      rvm: 2.1.9
+      env: STRICT_VARIABLES=yes TRUSTED_NODE_DATA=yes PUPPET_VERSION="~> 4.10.0"
+      script:
+        - bundle exec rake spec
+
+    - stage: spec
+      rvm: 2.1.9
+      env: STRICT_VARIABLES=yes TRUSTED_NODE_DATA=yes PUPPET_VERSION="~> 4.9.2"
+      script:
+        - bundle exec rake spec
+
+    - stage: spec
+      rvm: 2.1.9
+      env: STRICT_VARIABLES=yes TRUSTED_NODE_DATA=yes PUPPET_VERSION="~> 4.7.0"
+      script:
+        - bundle exec rake spec
+
+    - stage: acceptance
+      sudo: required
+      rvm: 2.1.9
+      services:
+        - docker
+      script:
+        - bundle exec rake beaker:suites[default,docker]
+      env: PUPPET_VERSION"~> 4.8.2"

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,10 +31,12 @@ jobs:
   include:
     - stage: lint
       rvm: 2.1.9
+      script:
         - bundle exec rake metadata_lint
 
     - stage: compare_tag
       rvm: 2.1.9
+      script:
         - bundle exec rake compare_latest_tag
 
     - stage: spec

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,4 @@
-* Fri Sep 22 2017 Dylan Cochran <dylan.cochran@onyxpoint.com> - 2.3.2-0
+* Fri Sep 22 2017 Dylan Cochran <dylan.cochran@onyxpoint.com> - 2.3.1-0
 - Refactor report generator to use a shared file format parser/compiler.
 - Add vendored 'profiles-in-modules' support
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+* Fri Sep 22 2017 Dylan Cochran <dylan.cochran@onyxpoint.com> - 2.3.2-0
+- Refactor report generator to use a shared file format parser/compiler.
+- Add vendored 'profiles-in-modules' support
+
 * Tue Sep 19 2017 Liz Nemsick <lnemsick.simp@gmail.com> - 2.3.1-0
 - Remove test link to allow module to be published to PuppetForge
 

--- a/Gemfile
+++ b/Gemfile
@@ -39,5 +39,5 @@ end
 group :system_tests do
   gem 'beaker'
   gem 'beaker-rspec'
-  gem 'simp-beaker-helpers', ENV.fetch('SIMP_BEAKER_HELPERS_VERSION', '~> 1.7')
+  gem 'simp-beaker-helpers', ENV.fetch('SIMP_BEAKER_HELPERS_VERSION', ['>= 1.8.4', '< 2.0'])
 end

--- a/lib/puppetx/compliance/compliance_markup/v1/test.yaml
+++ b/lib/puppetx/compliance/compliance_markup/v1/test.yaml
@@ -1,0 +1,8 @@
+---
+version: 1.0.0
+disa:
+        compliance_markup::test::vendoredvariable:
+                value: 'disa'
+nist:
+        compliance_markup::test::vendoredvariable:
+                value: 'nist'

--- a/lib/puppetx/simp/compliance_map.rb
+++ b/lib/puppetx/simp/compliance_map.rb
@@ -263,7 +263,9 @@ def compliance_map(args, context)
     report["version"] = '1.0.1';
     report["compliance_profiles"] = {}
     profile_list = get_compliance_profiles
-    if profile_list.class.to_s == "Array"
+    unless profile_list.class.to_s == "Array"
+      profile_list = [ profile_list ]
+    end
       profile_list.each do |profile|
         profile_report = {}
         report["compliance_profiles"][profile] = profile_report
@@ -351,7 +353,6 @@ def compliance_map(args, context)
             profile_report.delete(key);
           end
         end
-      end
     end
     write_server_report(main_config, report)
     add_file_to_client(main_config, report)

--- a/lib/puppetx/simp/compliance_map.rb
+++ b/lib/puppetx/simp/compliance_map.rb
@@ -1,88 +1,10 @@
 # vim: set expandtab ts=2 sw=2:
 
-#
-# XXX TODO: We need to replace this code with one that uses the abstract compiler
-# in the enforcement system. It also needs to be exportable because we have other
-# downstream consumers of the compliance profile compilation system
-#
-# If we have one single codebase that can parse and handle the compilance profile
-# system, it will be much easier for us to maintain moving forward
-#
+
 #
 # BEGIN COMPLIANCE_PROFILE
 #
 
-@profile_info = Class.new(Object) do
-
-  def ordered_hash
-    Hash.new
-  end
-
-  attr_reader :api_version
-  attr_accessor :config
-
-  def initialize(valid_profiles, config)
-    @err_msg = "Error: malformed compliance map, see the function documentation for details."
-
-    @config = config
-
-    @api_version = '1.0.1'
-
-    @valid_profiles ||= Array(valid_profiles)
-
-    # Collect all cache misses to sticking onto the end of the profile reports
-    @ref_misses = Hash.new()
-
-    # Collect any resources that are in our mapping but have not been included
-    @unmapped_resources = Hash.new()
-
-    # Static Information
-    @compliance_map = ordered_hash
-    @compliance_map['version'] = @api_version
-
-    @compliance_map.merge!(@config[:extra_data]) if @config[:extra_data]
-
-    @compliance_map['compliance_profiles'] = ordered_hash
-    @compliance_map['site_data'] = Hash.new()
-
-    @valid_profiles.each do |profile|
-      @compliance_map['compliance_profiles'][profile] ||= Hash.new()
-    end
-  end
-
-  # Set up the main data structures
-  #
-  # @param compliance_profiles (Array) Compliance_profile strings that are
-  #   valid for this ComplianceMap
-  #
-  # @param compliance_mapping (Hash) Data that represents the full compliance
-  #   mapping
-  #
-  #   Example:
-  #     {
-  #       'compliance' => {
-  #         '<profile>' => {
-  #           '<fully_qualified_class_parameter>' => '<value'
-  #         }
-  #       }
-  #     }
-  #
-  def setup_compliance_map(compliance_mapping)
-    @compliance_map['site_data'] = @config[:site_data] if @config[:site_data]
-
-    @valid_profiles.sort.each do |profile|
-      @compliance_map['compliance_profiles'][profile] ||= ordered_hash
-      @compliance_map['compliance_profiles'][profile]['summary'] ||= ordered_hash
-      @compliance_map['compliance_profiles'][profile]['compliant'] ||= ordered_hash
-      @compliance_map['compliance_profiles'][profile]['non_compliant'] ||= ordered_hash
-      @compliance_map['compliance_profiles'][profile]['documented_missing_resources'] ||= Array.new()
-      @compliance_map['compliance_profiles'][profile]['documented_missing_parameters'] ||= Array.new()
-      @compliance_map['compliance_profiles'][profile]['custom_entries'] ||= ordered_hash
-
-      @ref_misses[profile] ||= Array.new()
-      @unmapped_resources[profile] ||= Array.new()
-    end
-  end
 
   def catalog_to_map(catalog)
     catalog_map = Hash.new()
@@ -117,219 +39,6 @@
     return catalog_map.to_yaml
   end
 
-  # Get all of the parts together for proper reporting and return the
-  # result
-  def format_map
-    formatted_map = @compliance_map.dup
-    report_types = @config[:report_types]
-
-    @valid_profiles.each do |profile|
-
-      # Create the summary report
-      num_compliant     = formatted_map['compliance_profiles'][profile]['compliant'] ? formatted_map['compliance_profiles'][profile]['compliant'].keys.count : 0
-      num_non_compliant = formatted_map['compliance_profiles'][profile]['non_compliant'] ? formatted_map['compliance_profiles'][profile]['non_compliant'].keys.count : 0
-
-      total_checks = num_non_compliant + num_compliant
-      percent_compliant = total_checks == 0 ? 0 : ((num_compliant.to_f/total_checks) * 100).round(0)
-
-      formatted_map['compliance_profiles'][profile]['summary'] = {
-        'compliant'                     => num_compliant,
-        'non_compliant'                 => num_non_compliant,
-        'percent_compliant'             => percent_compliant,
-        'documented_missing_resources'  => @unmapped_resources[profile].count,
-        'documented_missing_parameters' => @ref_misses[profile].count
-      }
-
-      unless report_types.include?('full')
-        # Remove the built up content that does not apply to this system
-        ['compliant', 'non_compliant', 'custom_entries'].each do |report_type|
-          unless report_types.include?(report_type)
-            formatted_map['compliance_profiles'][profile][report_type] = {}
-          end
-        end
-      end
-
-      if report_types.include?('full') || report_types.include?('unknown_resources')
-        if @unmapped_resources[profile] && !@unmapped_resources[profile].empty?
-          formatted_map['compliance_profiles'][profile]['documented_missing_resources'] = @unmapped_resources[profile].sort
-        end
-      end
-
-      if report_types.include?('full') || report_types.include?('unknown_parameters')
-        if @ref_misses && !@ref_misses[profile].empty?
-          formatted_map['compliance_profiles'][profile]['documented_missing_parameters'] = @ref_misses[profile].sort
-        end
-      end
-
-      # Strip out anything not relevant to the report
-      formatted_map['compliance_profiles'][profile].delete_if{|k|
-        val = formatted_map['compliance_profiles'][profile][k]
-
-        val.nil? || val.empty?
-      }
-    end
-
-    return formatted_map
-  end
-
-  def to_hash
-    return format_map
-  end
-
-  def to_json
-    require 'json'
-
-    output = JSON.pretty_generate(format_map)
-
-    return output
-  end
-
-  def to_yaml
-    require 'yaml'
-
-    output = format_map.to_yaml
-
-    # Get rid of the ordered hash object information
-    output.gsub!(%r( !ruby/.+CMOrderedHash), '')
-
-    return output
-  end
-
-  # Add a custom entry to the Map
-  #
-  # @param resource_name (String) The name of the Puppet resource
-  #
-  # @param profile (String) The compliance profile under which this entry
-  #   falls. The entry will not be added if this is not included in
-  #   @valid_profiles
-  #
-  # @param identifiers (String) The compliance identifierss for the entry
-  #
-  # @param location (String) The 'file:line' formatted location of the
-  #   function call
-  #
-  # @param opts (String) Custom Options
-  #   * 'notes' (String) => Arbitrary notes about the entry
-  #
-  def add(resource_name, profile, identifiers, location, opts=ordered_hash)
-    if @valid_profiles.include?(profile)
-      data_hash = ordered_hash
-
-      data_hash['location'] = location
-      data_hash['identifiers'] = Array(identifiers)
-
-      data_hash.merge!(opts)
-
-      @compliance_map['compliance_profiles'][profile] ||= ordered_hash
-      @compliance_map['compliance_profiles'][profile]['custom_entries'] ||= ordered_hash
-      @compliance_map['compliance_profiles'][profile]['custom_entries'][resource_name] ||= []
-
-      @compliance_map['compliance_profiles'][profile]['custom_entries'][resource_name] << data_hash
-    end
-  end
-
-  def process_catalog(catalog, reference_map)
-    setup_compliance_map(reference_map)
-
-    target_resources = catalog.resources.select{|x| !x.parameters.empty?}
-
-    @valid_profiles.each do |profile|
-      next unless reference_map[profile]
-
-      @unmapped_resources[profile] = reference_map[profile].keys.collect do |x|
-        _tmp = x.split('::')
-        _tmp.pop
-        x = _tmp.join('::')
-      end.sort.uniq
-
-      # Gather up all of the possible keys in this profile
-      #
-      # Any items that remain are things that had a resource in Hiera but
-      # were not found on the system
-      @ref_misses[profile] = reference_map[profile].keys
-
-      target_resources.each do |resource|
-        human_name = resource.to_s
-        resource_name = resource.name.downcase
-
-        @unmapped_resources[profile].delete(resource_name)
-
-        resource.parameters.keys.sort.each do |param|
-          resource_ref = [resource_name, param].join('::')
-          ref_entry = reference_map[profile][resource_ref]
-
-          if ref_entry
-            @ref_misses[profile].delete(resource_ref)
-          else
-            # If we didn't find an entry for this parameter, just skip it
-            next
-          end
-
-          # Fail if the entry doesn't have the proper format
-          required_metadata = ['identifiers','value']
-          required_metadata.each do |md|
-            raise "#{@err_msg} Failed on #{profile} profile, #{resource_ref} #{ref_entry}, metadata #{md}" if ref_entry[md].nil?
-          end
-
-          # Perform the actual matching
-          ref_value = ref_entry['value']
-          tgt_value = resource.parameters[param].value
-
-          compliance_status = 'non_compliant'
-
-          # Regular expression match
-          if ref_value =~ /^re:(.+)/
-            comparator = Regexp.new($1)
-
-            if tgt_value =~ comparator
-              compliance_status = 'compliant'
-            end
-            # Default match
-          elsif ref_value.to_s.strip == tgt_value.to_s.strip
-            compliance_status = 'compliant'
-          end
-
-          report_data = ordered_hash
-          report_data['identifiers'] = Array(reference_map[profile][resource_ref]['identifiers'])
-          report_data['compliant_value'] = ref_value
-          report_data['system_value'] = tgt_value
-
-          # If we have other optional items, sort them, and stick them
-          # into the report data
-          (ref_entry.keys - required_metadata).sort.each do |extra_param|
-            next if extra_param.nil?
-            report_data[extra_param] = ref_entry[extra_param]
-          end
-
-          @compliance_map['compliance_profiles'][profile][compliance_status][human_name] ||= ordered_hash
-          @compliance_map['compliance_profiles'][profile][compliance_status][human_name]['parameters'] ||= ordered_hash
-          @compliance_map['compliance_profiles'][profile][compliance_status][human_name]['parameters'][resource_ref.split('::').last] = report_data
-        end
-      end
-
-      # Strip anything out of @ref_misses that has an immediate parent in
-      # @unmapped_resources
-
-      @unmapped_resources[profile].each do |to_check|
-        @ref_misses[profile].delete_if do |ref|
-          ref_parts = ref.split('::')
-          ref_parts.pop
-          ref_parts.join('::') == to_check
-        end
-      end
-    end
-  end
-
-  private
-
-end
-
-#
-# END COMPLIANCE PROFILE
-#
-def profile_info
-  @profile_info
-end
 
 # There is no way to silence the global warnings on looking up a qualified
 # variable, so we're going to hack around it here.
@@ -454,84 +163,6 @@ def get_compliance_profiles
   return compliance_profiles
 end
 
-def get_reference_map
-  reference_map = lookup_global_silent('compliance_map')
-  reference_map ||= Hash.new
-
-  if ( !reference_map || reference_map.empty? )
-    # If not using an ENC, need to dig deeper
-
-    # First, check the backwards-compatible lookup entry
-    if @context.respond_to?(:call_function)
-      reference_map = @context.call_function('lookup',['compliance_map', {'merge' => 'deep', 'default_value' => nil}])
-    end
-
-    # If lookup didn't find it, fish it out of the resource directly
-    if ( !reference_map || reference_map.empty? )
-      compliance_resource = @context.catalog.resource('Class[compliance_markup]')
-
-      unless compliance_resource
-        compliance_resource = @context.catalog.resource('Class[compliance_markup]')
-      end
-
-      if compliance_resource
-        catalog_resource_map = compliance_resource['compliance_map']
-
-        if catalog_resource_map && !catalog_resource_map.empty?
-          reference_map = catalog_resource_map
-        end
-      end
-    end
-  end
-
-  return reference_map
-end
-
-def validate_reference_map(reference_map)
-  # If we still don't have a reference map, we need to let the user know!
-  if !reference_map || (reference_map.respond_to?(:empty) && reference_map.empty?)
-    if main_config[:default_map] && !main_config[:default_map].empty?
-      reference_map = main_config[:default_map]
-    else
-      raise(Puppet::ParseError, %(compliance_map(): Could not find the 'compliance_map' Hash at the global level or via Lookup))
-    end
-  end
-end
-
-def custom_call_file_info
-  file_info = {
-    :file => @context.source.file,
-    # We may not know the line number if this is at Top Scope
-    :line => @context.source.line || '<unknown>',
-  }
-
-  # If we don't know the filename, guess....
-  # This is probably because we're running in Puppet 4
-  if @context.is_topscope?
-    # Cast this to a string because it could potentially be a symbol from
-    # the bowels of Puppet, or 'nil', or whatever and is purely
-    # informative.
-    env_manifest = "#{@context.environment.manifest}"
-
-    if env_manifest =~ /\.pp$/
-      file = env_manifest
-    else
-      file = File.join(env_manifest,'site.pp')
-    end
-  else
-    filename = @context.source.name.split('::')
-    filename[-1] = filename[-1] + '.pp'
-
-    file = File.join(
-      '<estimate>',
-      "#{@context.environment.modulepath.first}",
-      filename
-    )
-  end
-
-  return file_info
-end
-
 def add_file_to_client(config, compliance_map)
   if config[:client_report]
     client_vardir = @context.lookupvar('puppet_vardir')
@@ -584,92 +215,239 @@ def add_file_to_client(config, compliance_map)
   end
 end
 
-def write_server_report(config, compliance_map)
+
+def write_server_report(config, report)
   report_dir = File.join(config[:server_report_dir], @context.lookupvar('fqdn'))
   FileUtils.mkdir_p(report_dir)
 
   if config[:server_report]
     File.open(File.join(report_dir,"compliance_report.#{config[:format]}"),'w') do |fh|
       if config[:format] == 'json'
-        fh.puts(compliance_map.to_json)
+        fh.puts(report.to_json)
       elsif config[:format] == 'yaml'
-        fh.puts(compliance_map.to_yaml)
+        fh.puts(report.to_yaml)
       end
     end
   end
-
   if config[:catalog_to_compliance_map]
     File.open(File.join(report_dir,'catalog_compliance_map.yaml'),'w') do |fh|
-      fh.puts(compliance_map.catalog_to_map(@context.resource.scope.catalog))
+      fh.puts(catalog_to_map(@context.resource.scope.catalog))
     end
   end
 end
 
 def compliance_map(args, context)
-  ### BEGIN MAIN PROCESSING ###
   @context = context
+  if (@custom_entries == nil)
+    @custom_entries = {}
+  end
+  @catalog = @context.resource.scope.catalog
+  profile_compiler = compiler_class.new(self)
+  profile_compiler.load do |key, default|
+    @context.call_function('lookup', [key, {"default_value" => default}])
+  end
+
   main_config = process_options(args)
-
-  # Pick up our compiler hitchhiker
-  # This is only needed when passing arguments. Users should no longer call
-  # compliance_map() without arguments directly inside their classes or
-  # definitions.
-  hitchhiker = @context.compiler.instance_variable_get(:@compliance_map_function_data)
-
-  if hitchhiker
-    compliance_map = hitchhiker
-
-    # Need to update the config for further processing options
-    compliance_map.config = main_config
-  else
-    compliance_profiles = get_compliance_profiles
-
-    # If we didn't find any profiles to map, bail
-    return unless compliance_profiles
-
-    # Create the validation report object
-    # Have to break things out because jruby can't handle '::' in const_get
-    compliance_map = profile_info.new(compliance_profiles, main_config)
-  end
-
-  # If we've gotten this far, we're ready to process *everything* and update
-  # the file object.
   if main_config[:custom_call]
-    # Here, we will only be adding custom items inside of classes or defined
-    # types.
-
-    resource_name = %(#{@context.resource.type}::#{@context.resource.title})
-
-    # Add in custom materials if they exist
-
-    _entry_opts = {}
-    if main_config[:custom][:notes]
-      _entry_opts['notes'] = main_config[:custom][:notes]
-    end
-
-    file_info = custom_call_file_info
-
-    compliance_map.add(
-      resource_name,
-      main_config[:custom][:profile],
-      main_config[:custom][:identifier],
-      %(#{file_info[:file]}:#{file_info[:line]}),
-      _entry_opts
-    )
+    add_custom_entries(main_config);
   else
-    reference_map = get_reference_map
-    validate_reference_map(reference_map)
+    report_types = main_config[:report_types]
+    if report_types.include?('full')
+      report_types << 'unknown_resources'
+      report_types << 'unknown_parameters'
+      report_types << 'compliant'
+      report_types << 'non_compliant'
+      report_types << 'custom_entries'
+    end
+    report = main_config[:extra_data].dup
+    report["version"] = '1.0.1';
+    report["compliance_profiles"] = {}
+    profile_list = get_compliance_profiles
+    if profile_list.class.to_s == "Array"
+      profile_list.each do |profile|
+        profile_report = {}
+        report["compliance_profiles"][profile] = profile_report
+        profile_report["documented_missing_parameters"] = []
+        profile_report["compliant"] = {}
+        profile_report["non_compliant"] = {}
+        profile_map = profile_compiler.list_puppet_params([profile]).cook do |data|
+          {"value" => data["value"], "identifiers" => data["identifiers"]}
+        end
+        parameters = {}
+        classes = {}
+        @catalog.resources.each do |obj|
+          classname = obj.title.downcase
+          obj.parameters.each do |parameter, data|
+            fully_qualified_parameter = classname + "::" + parameter.to_s
+            if (profile_map.key?(fully_qualified_parameter))
+              profile_settings = profile_map[fully_qualified_parameter]
+              current_value = data.value
+              # XXX ToDo This should be improved to allow for validators to be specified
+              # instead of forcing regexes to be in values (as it breaks enforcement)
+              # ie, functions or built ins.
+              if (profile_settings.key?("value"))
+                expected_value = profile_settings["value"]
+                result = {
+                    "compliant_value" => expected_value,
+                    "system_value" => current_value,
+                }
+                if (profile_settings.key?("identifiers"))
+                 result["identifiers"] = profile_settings["identifiers"]
+                end
+                classkey = "#{obj.type}[#{obj.title}]"
+                if (expected_value =~ /^re:(.+)/)
+                  if (current_value =~ Regexp.new($1))
+                    section = "compliant"
+                  else
+                    section = "non_compliant"
+                  end
+                else
+                  if (current_value == expected_value)
+                    section = "compliant"
+                  else
+                    section = "non_compliant"
+                  end
+                end
+                if report_types.include?(section)
+                  unless (profile_report[section].key?(classkey))
+                    profile_report[section][classkey] = {}
+                    profile_report[section][classkey]["parameters"] = {}
+                  end
+                    profile_report[section][classkey]["parameters"][parameter.to_s] = result
 
-    compliance_map.process_catalog(@context.resource.scope.catalog, reference_map)
+                end
+              end
+            else
+               parameters[fully_qualified_parameter] = true
+               classes[classname] = true
+            end
+          end
+        end
 
-    # Drop an entry on the server so that it can be processed when applicable.
-    write_server_report(main_config, compliance_map)
+        {
+            'unknown_parameters' => 'documented_missing_parameters',
+            'unknown_resources' => 'documented_missing_resources'
+        }.each do |type, name|
+          if report_types.include?(type)
+            profile_report[name] = []
+            profile_map.select do |key, value|
+              unless parameters.key?(key)
+                profile_report[name] << key
+              end
+            end
+          end
+        end
 
-    # Embed a File resource that will place the report on the client.
-    add_file_to_client(main_config, compliance_map)
+        profile_report["custom_entries"] = @custom_entries[profile]
+
+        profile_report['summary'] = summary(profile_report)
+
+        # Clean up empty arrays and hashes
+        [ 'non_compliant', 'compliant', 'documented_missing_parameters', "documented_missing_resources"].each do |key|
+          if profile_report[key] == {}
+            profile_report.delete(key);
+          end
+          if profile_report[key] == []
+            profile_report.delete(key);
+          end
+        end
+      end
+    end
+    write_server_report(main_config, report)
+    add_file_to_client(main_config, report)
+  end
+end
+
+#
+# Create a summary from a profile report.
+#
+
+def summary(profile_report)
+  num_compliant = profile_report['compliant'] ? profile_report['compliant'].keys.count : 0
+  num_non_compliant = profile_report['non_compliant'] ? profile_report['non_compliant'].keys.count : 0
+
+  total_checks = num_non_compliant + num_compliant
+  percent_compliant = total_checks == 0 ? 0 : ((num_compliant.to_f/total_checks) * 100).round(0)
+
+  {
+      'compliant' => num_compliant,
+      'non_compliant' => num_non_compliant,
+      'percent_compliant' => percent_compliant,
+      'documented_missing_parameters' => profile_report["documented_missing_parameters"].count
+  }
+end
+
+def add_custom_entries(main_config)
+  # XXX ToDo
+  # We need to decide if this is actually necessary. If the compliance profiles are authoritative
+  # then having to evaluate a catalog to get all values makes no sense
+  file_info = custom_call_file_info
+  value = {
+      "identifiers" => main_config[:custom][:identifier],
+      "location" => %(#{file_info[:file]}:#{file_info[:line]})
+  }
+  if main_config[:custom][:notes]
+    value['notes'] = main_config[:custom][:notes]
+  end
+  profile = main_config[:custom][:profile]
+  resource_name = %(#{@context.resource.type}::#{@context.resource.title})
+  unless (@custom_entries.key?(profile))
+    @custom_entries[profile] = {}
+  end
+  unless (@custom_entries[profile].key?(resource_name))
+    @custom_entries[profile][resource_name] = []
+  end
+  @custom_entries[profile][resource_name] << value
+end
+
+def custom_call_file_info
+  file_info = {
+      :file => @context.source.file,
+      # We may not know the line number if this is at Top Scope
+      :line => @context.source.line || '<unknown>',
+  }
+
+  # If we don't know the filename, guess....
+  # This is probably because we're running in Puppet 4
+  if @context.is_topscope?
+    # Cast this to a string because it could potentially be a symbol from
+    # the bowels of Puppet, or 'nil', or whatever and is purely
+    # informative.
+    env_manifest = "#{@context.environment.manifest}"
+
+    if env_manifest =~ /\.pp$/
+      file = env_manifest
+    else
+      file = File.join(env_manifest,'site.pp')
+    end
+  else
+    filename = @context.source.name.split('::')
+    filename[-1] = filename[-1] + '.pp'
+
+    file = File.join(
+        '<estimate>',
+        "#{@context.environment.modulepath.first}",
+        filename
+    )
   end
 
-  # This gets a little hairy, we need to persist the compliance map across
-  # the entire compilation so we hitch a ride on the compiler.
-  @context.compiler.instance_variable_set(:@compliance_map_function_data, compliance_map)
+  return file_info
+end
+def cache(key, value)
+  if @hash == nil
+    @hash = {}
+  end
+  @hash[key] = value
+end
+def cached_value(key)
+  if @hash == nil
+    @hash = {}
+  end
+  @hash[key]
+end
+def cache_has_key(key)
+  if @hash == nil
+    @hash = {}
+  end
+  @hash.key?(key)
 end

--- a/lib/puppetx/simp/compliance_mapper.rb
+++ b/lib/puppetx/simp/compliance_mapper.rb
@@ -47,51 +47,46 @@ def enforcement(key, &block)
     throw :no_such_key
   else
     retval = :notfound
-    if cache_has_key(:lock)
-      lock = cached_value(:lock)
+    if cache_has_key("lock")
+      lock = cached_value("lock")
     else
       lock = false
     end
     if (lock == false)
-      cache(:lock, true)
+      cache("lock", true)
       begin
         profile_list = cached_lookup "compliance_markup::enforcement", [], &block
         unless (profile_list == [])
           debug("compliance_markup::enforcement set to #{profile_list}, attempting to enforce")
-          version = cached_lookup "compliance_markup::version", "1.0.0", &block
-          case version
-          when /1.*/
-            v1_compliance_map = {}
-
-            if (cache_has_key(:v1_compliance_map))
-              v1_compliance_map = cached_value(:v1_compliance_map)
-            else
-              debug("loading compliance_map data from compliance_markup::compliance_map")
-              module_scope_compliance_map = cached_lookup "compliance_markup::compliance_map", {}, &block
-              top_scope_compliance_map = cached_lookup "compliance_map", {}, &block
-              v1_compliance_map.merge!(module_scope_compliance_map)
-              v1_compliance_map.merge!(top_scope_compliance_map)
-              cache(:v1_compliance_map, v1_compliance_map)
-              # XXX ToDo: Add a dynamic loader for compliance data, so that modules can embed
-              # their own compliance map information. Dylan has a way to do this in testing
-              # in Abacus
+          profile = profile_list.hash.to_s
+          if (cache_has_key("compliance_map_#{profile}"))
+            profile_map = cached_value("compliance_map_#{profile}")
+          else
+            debug("compliance map for #{profile_list} not found, starting compiler")
+            compile_start_time = Time.now
+            profile_compiler = compiler_class.new(self)
+            profile_compiler.load(&block)
+            profile_map = profile_compiler.list_puppet_params(profile_list).cook do |item|
+              item["value"]
             end
-
-
-            profile = profile_list.hash.to_s
-            v1_compile(profile, profile_list, v1_compliance_map)
-            if (v1_compliance_map.key?(profile))
-              # Handle a knockout prefix
-              unless (v1_compliance_map[profile].key?("--" + key))
-                if (v1_compliance_map[profile].key?(key))
-                  retval = v1_compliance_map[profile][key]
-                end
-              end
+            cache("compliance_map_#{profile}", profile_map)
+            compile_end_time = Time.now
+            debug("compiled compliance_map containing #{profile_map.size} keys in #{compile_end_time - compile_start_time} seconds")
+          end
+          # Handle a knockout prefix
+          unless (profile_map.key?("--" + key))
+            if (profile_map.key?(key))
+              retval = profile_map[key]
             end
           end
+
+          # XXX ToDo: Generate a lookup_options hash, set to 'first', if the user specifies some
+          # option that toggles it on. This would allow un-overridable enforcement at the hiera
+          # layer (though it can still be overridden by resource-style class definitions)
         end
+      rescue Exception => ex
       ensure
-        cache(:lock, false)
+        cache("lock", false)
       end
     end
     if (retval == :notfound)
@@ -101,42 +96,6 @@ def enforcement(key, &block)
   return retval
 end
 
-# Pre-compile the values for each profile list array.
-# We use hash.to_s, then create a hash named that in v1_compliance_map,
-# that is a raw key => value mapping. This simplifies our code as we can assume
-# that if the key exists, then the value is what we use. We also don't have to worry
-# about exponential time issues since this is linearlly done once, not every time for
-# every key.
-
-def v1_compile(profile, profile_list, v1_compliance_map)
-  unless (v1_compliance_map.key?(profile))
-    compile_start_time = Time.now
-    debug("compliance map for #{profile_list} not found, starting compiler")
-    table = {}
-    # Set the keys in reverse order. This means that [ 'disa', 'nist'] would prioritize
-    # disa values over nist. Only bother to store the highest priority value
-    profile_list.reverse.each do |profile_map|
-      if (profile_map != /^v[0-9]+/)
-        if (v1_compliance_map.key?(profile_map))
-          v1_compliance_map[profile_map].each do |key, entry|
-            if (entry.key?("value"))
-              # XXX ToDo: Generate a lookup_options hash, set to 'first', if the user specifies some
-              # option that toggles it on. This would allow un-overridable enforcement at the hiera
-              # layer (though it can still be overridden by resource-style class definitions
-              table[key] = entry["value"]
-            end
-          end
-        end
-      end
-    end
-    v1_compliance_map[profile] = table
-    compile_end_time = Time.now
-    debug("compiled compliance_map containing #{table.size} keys in #{compile_end_time - compile_start_time} seconds")
-    # This is necessary for hiera v5 since the cache
-    # is immutable.
-    cache(:v1_compliance_map, v1_compliance_map)
-  end
-end
 
 # These cache functions are assumed to be created by the wrapper
 # object, either the v3 backend or v5 backend.
@@ -149,5 +108,88 @@ def cached_lookup(key, default, &block)
   end
   retval
 end
+
+def compiler_class()
+  Class.new do
+    def initialize(object)
+      @callback = object
+    end
+    def callback
+      @callback
+    end
+
+    def load(&block)
+      @compliance_data = []
+      module_scope_compliance_map = callback.cached_lookup "compliance_markup::compliance_map", {}, &block
+      top_scope_compliance_map = callback.cached_lookup "compliance_map", {}, &block
+      @compliance_data << (module_scope_compliance_map)
+      @compliance_data << (top_scope_compliance_map)
+      location = __FILE__
+      moduleroot = File.dirname(File.dirname(File.dirname(File.dirname(File.dirname(location)))))
+
+      # Dynamically load v1 compliance map data from modules.
+      # Create a set of yaml files (all containing compliance info) in your modules, in
+      # lib/puppetx/compliance/module_name/v1/whatever.yaml
+      # Note: do not attempt to merge or rely on merge behavior for v1
+      Dir.glob(moduleroot + "/*/lib/puppetx/compliance/*/v1/*.yaml") do |filename|
+        begin
+          @compliance_data << YAML.load(File.read(filename))
+        rescue
+        end
+      end
+    end
+
+    def control_list()
+      Class.new do
+        include Enumerable
+        def initialize(hash)
+          @hash = hash
+        end
+        def [](key)
+          @hash[key]
+        end
+        def each(&block)
+          @hash.each(&block)
+        end
+        def cook(&block)
+          nhash = {}
+          @hash.each do |key, value|
+            nvalue = yield value
+            nhash[key] = nvalue
+          end
+          nhash
+        end
+      end
+    end
+    def list_puppet_params(profile_list)
+
+      table = {}
+      # Set the keys in reverse order. This means that [ 'disa', 'nist'] would prioritize
+      # disa values over nist. Only bother to store the highest priority value
+      profile_list.reverse.each do |profile_map|
+        if (profile_map != /^v[0-9]+/)
+          @compliance_data.each do |map|
+            result = v1_parser(profile_map,map)
+            table.merge!(result)
+          end
+        end
+      end
+      control_list.new(table)
+    end
+    def v1_parser(profile, hashmap)
+      table = {}
+      if (hashmap.key?(profile))
+        hashmap[profile].each do |key, entry|
+          if (entry.key?("value"))
+            table[key] = entry
+          end
+        end
+      end
+      table
+    end
+  end
+end
+
+
 
 # vim: set expandtab ts=2 sw=2:

--- a/lib/puppetx/simp/compliance_mapper.rb
+++ b/lib/puppetx/simp/compliance_mapper.rb
@@ -138,7 +138,6 @@ def compiler_class()
         end
       end
     end
-
     def control_list()
       Class.new do
         include Enumerable

--- a/manifests/test.pp
+++ b/manifests/test.pp
@@ -8,8 +8,12 @@
 #
 class compliance_markup::test (
   $testvariable = 'none',
+  $vendoredvariable = 'none',
 ){
-  notify { 'compliance_markup::test':
+  notify { 'compliance_markup::test::testvariable':
     message => "compliance_markup::test::testvariable = ${testvariable}",
+  }
+  notify { 'compliance_markup::test::vendoredvariable':
+    message => "compliance_markup::test::vendoredvariable = ${vendoredvariable}",
   }
 }

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-compliance_markup",
-  "version": "2.3.1",
+  "version": "2.3.2",
   "author": "SIMP Team",
   "summary": "Compliance-mapping annotation for Puppet code",
   "license": "Apache-2.0",

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-compliance_markup",
-  "version": "2.3.2",
+  "version": "2.3.1",
   "author": "SIMP Team",
   "summary": "Compliance-mapping annotation for Puppet code",
   "license": "Apache-2.0",

--- a/spec/acceptance/nodesets/docker.yml
+++ b/spec/acceptance/nodesets/docker.yml
@@ -1,0 +1,39 @@
+HOSTS:
+  el7-compliance-map:
+    roles:
+      - server
+      - primary
+    platform: el-7-x86_64
+    hypervisor: docker
+    image: centos:7
+    docker_cmd: '/usr/sbin/init'
+    docker_preserve_image: true
+    docker_image_commands:
+      # Puppet Deps
+      - 'yum install -y ntpdate rsync openssl openssh-server'
+    yum_repos:
+      epel:
+        mirrorlist: 'https://mirrors.fedoraproject.org/metalink?repo=epel-7&arch=$basearch'
+        gpgkeys:
+          - https://getfedora.org/static/352C64E5.txt
+
+  el6-compliance-map:
+    roles:
+      - secondary
+    platform: el-6-x86_64
+    hypervisor: docker
+    image: centos:6
+    #docker_cmd: '/usr/sbin/init'
+    docker_preserve_image: true
+    docker_image_commands:
+      # Puppet Deps
+      - 'yum install -y ntpdate rsync openssl'
+    yum_repos:
+      epel:
+        mirrorlist: 'https://mirrors.fedoraproject.org/metalink?repo=epel-6&arch=$basearch'
+        gpgkeys:
+          - https://getfedora.org/static/0608B895.txt
+
+CONFIG:
+  log_level: verbose
+  type:      aio

--- a/spec/acceptance/suites/default/00_default_spec.rb
+++ b/spec/acceptance/suites/default/00_default_spec.rb
@@ -43,6 +43,43 @@ EOS
   }
 
   hosts.each do |host|
+    shared_examples 'a valid report' do
+      before(:all) do
+        @compliance_data = {
+          :report => {}
+        }
+      end
+
+      let(:fqdn) { fact_on(host, 'fqdn') }
+
+      tmpdir = Dir.mktmpdir
+      begin
+        Dir.chdir(tmpdir) do
+          it 'should have a report' do
+            if host[:hypervisor] == 'docker'
+              %x(docker cp "#{host.hostname}:/opt/puppetlabs/puppet/cache/simp/compliance_reports/#{fqdn}/compliance_report.json" .)
+            else
+              scp_from(host, "/opt/puppetlabs/puppet/cache/simp/compliance_reports/#{fqdn}/compliance_report.json", '.')
+            end
+
+            expect {
+              @compliance_data[:report] = JSON.load(File.read('compliance_report.json'))
+            }.to_not raise_error
+          end
+        end
+      ensure
+        FileUtils.remove_entry_secure tmpdir
+      end
+
+      it 'should have host metadata' do
+        expect(@compliance_data[:report]['fqdn']).to eq(fqdn)
+      end
+
+      it 'should have a compliance profile report' do
+        expect(@compliance_data[:report]['compliance_profiles']).to_not be_empty
+      end
+    end
+
     context 'default parameters' do
       # Using puppet_apply as a helper
       it 'should work with no errors' do
@@ -53,6 +90,8 @@ EOS
       it 'should be idempotent' do
         apply_manifest_on(host,manifest, :catch_changes => true)
       end
+
+      it_behaves_like 'a valid report'
     end
 
     context 'non-compliant parameters' do
@@ -65,6 +104,8 @@ EOS
       it 'should be idempotent' do
         apply_manifest_on(host,manifest, :catch_changes => true)
       end
+
+      it_behaves_like 'a valid report'
     end
   end
 end

--- a/spec/acceptance/suites/default/00_default_spec.rb
+++ b/spec/acceptance/suites/default/00_default_spec.rb
@@ -52,10 +52,10 @@ EOS
 
       let(:fqdn) { fact_on(host, 'fqdn') }
 
-      tmpdir = Dir.mktmpdir
-      begin
-        Dir.chdir(tmpdir) do
-          it 'should have a report' do
+      it 'should have a report' do
+        tmpdir = Dir.mktmpdir
+        begin
+          Dir.chdir(tmpdir) do
             if host[:hypervisor] == 'docker'
               %x(docker cp "#{host.hostname}:/opt/puppetlabs/puppet/cache/simp/compliance_reports/#{fqdn}/compliance_report.json" .)
             else
@@ -66,9 +66,9 @@ EOS
               @compliance_data[:report] = JSON.load(File.read('compliance_report.json'))
             }.to_not raise_error
           end
+        ensure
+          FileUtils.remove_entry_secure tmpdir
         end
-      ensure
-        FileUtils.remove_entry_secure tmpdir
       end
 
       it 'should have host metadata' do

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -279,13 +279,16 @@ describe 'compliance_markup' do
                 end
 
                 it "should have a valid #{report_format} report" do
+                  file = nil;
                   if report_format == 'yaml'
-                    expect(YAML.load(compliance_file_resource[:content])['version']).to eq(report_version)
+                    file = YAML.load(compliance_file_resource[:content]);
                   elsif report_format == 'json'
-                    expect(JSON.load(compliance_file_resource[:content])['version']).to eq(report_version)
+                    file = JSON.load(compliance_file_resource[:content]);
                   else
                     fail("Invalid report type '#{report_format}' specified")
                   end
+                  version = file['version'];
+                  expect(version).to eq(report_version)
                 end
               end
 
@@ -355,7 +358,6 @@ describe 'compliance_markup' do
                 it 'should have custom_entries for the "other" profile that have identifiers and notes' do
 
                   entry = report['compliance_profiles']['other_profile']['custom_entries']['One_off_inline::one off'].first
-
                   expect(entry['identifiers']).to_not be_empty
                   expect(entry['notes']).to_not be_empty
                 end

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -129,61 +129,115 @@ describe 'compliance_markup' do
             end
           end
         end
-
-        context 'with a fabricated test profile' do
+        [ {
+            :profile_type => 'Array'
+          },
+        {
+            :profile_type => 'String'
+          }
+        ].each do |data|
+          context "with a fabricated test profile #{data[:profile_type]}" do
 
           profile_name = 'test_profile'
-
-          let(:pre_condition) {
-            <<-EOM
-              $compliance_profile = [
-                '#{profile_name}',
-                'other_profile'
-              ]
-
-              class test1 (
-                $arg1_1 = 'foo1_1',
-                $arg1_2 = 'foo1_2'
-              ){
-                notify { 'bar': message => $arg1_1 }
+          case data[:profile_type]
+            when 'Array'
+              let(:pre_condition) {
+                <<-EOM
+                  $compliance_profile = [
+                    '#{profile_name}',
+                    'other_profile'
+                  ]
+    
+                  class test1 (
+                    $arg1_1 = 'foo1_1',
+                    $arg1_2 = 'foo1_2'
+                  ){
+                    notify { 'bar': message => $arg1_1 }
+                  }
+    
+                  class test2 {
+                    class test3 (
+                      $arg3_1 = 'foo3_1'
+                    ) { }
+                  }
+    
+                  define testdef1 (
+                    $defarg1_1 = 'deffoo1_1'
+                  ) {
+                    notify { 'testdef1': message => $defarg1_1}
+                  }
+    
+                  define testdef2 (
+                    $defarg1_2 = 'deffoo1_2',
+                    $defarg2_2 = 'foo'
+                  ) {
+                    notify { 'testdef2': message => $defarg1_2}
+                  }
+    
+                  define one_off_inline {
+                    compliance_map('other_profile', 'ONE_OFF', 'This is awesome')
+    
+                    notify { $name: }
+                  }
+    
+                  include '::test1'
+                  include '::test2::test3'
+    
+                  testdef1 { 'test_definition': }
+                  testdef2 { 'test_definition': defarg1_2 => 'test_bad' }
+                  one_off_inline { 'one off': }
+    
+                  compliance_map('other_profile', 'TOP_LEVEL', 'Top level call')
+                EOM
               }
-
-              class test2 {
-                class test3 (
-                  $arg3_1 = 'foo3_1'
-                ) { }
+            when 'String'
+              let(:pre_condition) {
+                <<-EOM
+                  $compliance_profile = '#{profile_name}'
+    
+                  class test1 (
+                    $arg1_1 = 'foo1_1',
+                    $arg1_2 = 'foo1_2'
+                  ){
+                    notify { 'bar': message => $arg1_1 }
+                  }
+    
+                  class test2 {
+                    class test3 (
+                      $arg3_1 = 'foo3_1'
+                    ) { }
+                  }
+    
+                  define testdef1 (
+                    $defarg1_1 = 'deffoo1_1'
+                  ) {
+                    notify { 'testdef1': message => $defarg1_1}
+                  }
+    
+                  define testdef2 (
+                    $defarg1_2 = 'deffoo1_2',
+                    $defarg2_2 = 'foo'
+                  ) {
+                    notify { 'testdef2': message => $defarg1_2}
+                  }
+    
+                  define one_off_inline {
+                    compliance_map('other_profile', 'ONE_OFF', 'This is awesome')
+    
+                    notify { $name: }
+                  }
+    
+                  include '::test1'
+                  include '::test2::test3'
+    
+                  testdef1 { 'test_definition': }
+                  testdef2 { 'test_definition': defarg1_2 => 'test_bad' }
+                  one_off_inline { 'one off': }
+    
+                  compliance_map('other_profile', 'TOP_LEVEL', 'Top level call')
+                EOM
               }
-
-              define testdef1 (
-                $defarg1_1 = 'deffoo1_1'
-              ) {
-                notify { 'testdef1': message => $defarg1_1}
-              }
-
-              define testdef2 (
-                $defarg1_2 = 'deffoo1_2',
-                $defarg2_2 = 'foo'
-              ) {
-                notify { 'testdef2': message => $defarg1_2}
-              }
-
-              define one_off_inline {
-                compliance_map('other_profile', 'ONE_OFF', 'This is awesome')
-
-                notify { $name: }
-              }
-
-              include '::test1'
-              include '::test2::test3'
-
-              testdef1 { 'test_definition': }
-              testdef2 { 'test_definition': defarg1_2 => 'test_bad' }
-              one_off_inline { 'one off': }
-
-              compliance_map('other_profile', 'TOP_LEVEL', 'Top level call')
-            EOM
-          }
-
+          end
           let(:facts) { facts }
 
           ['yaml','json'].each do |report_format|
@@ -330,37 +384,38 @@ describe 'compliance_markup' do
                 it 'should have a documented_missing_parameters section' do
                   expect( report['compliance_profiles'][profile_name]['documented_missing_parameters'] ).to_not be_empty
                 end
+                if (data[:profile_type] == 'Array')
+                  it 'should note the "other" profile' do
+                    expect( report['compliance_profiles']['other_profile'] ).to_not be_empty
+                  end
 
-                it 'should note the "other" profile' do
-                  expect( report['compliance_profiles']['other_profile'] ).to_not be_empty
-                end
+                  it 'should not include an empty compliant section for the "other" profile' do
+                    expect( report['compliance_profiles']['other_profile']['compliant'] ).to be_nil
+                  end
 
-                it 'should not include an empty compliant section for the "other" profile' do
-                  expect( report['compliance_profiles']['other_profile']['compliant'] ).to be_nil
-                end
+                  it 'should not include an empty non_compliant section for the "other" profile' do
+                    expect( report['compliance_profiles']['other_profile']['non_compliant'] ).to be_nil
+                  end
 
-                it 'should not include an empty non_compliant section for the "other" profile' do
-                  expect( report['compliance_profiles']['other_profile']['non_compliant'] ).to be_nil
-                end
+                  it 'should not include an empty documented_missing_resources section for the "other" profile' do
+                    expect( report['compliance_profiles']['other_profile']['documented_missing_resources'] ).to be_nil
+                  end
 
-                it 'should not include an empty documented_missing_resources section for the "other" profile' do
-                  expect( report['compliance_profiles']['other_profile']['documented_missing_resources'] ).to be_nil
-                end
+                  it 'should not include an empty documented_missing_parameters section for the "other" profile' do
+                    expect( report['compliance_profiles']['other_profile']['documented_missing_parameters'] ).to be_nil
+                  end
 
-                it 'should not include an empty documented_missing_parameters section for the "other" profile' do
-                  expect( report['compliance_profiles']['other_profile']['documented_missing_parameters'] ).to be_nil
-                end
+                  it 'should have a custom_entries section for the "other" profile' do
+                    expect( report['compliance_profiles']['other_profile']['custom_entries'] ).to_not be_empty
+                  end
 
-                it 'should have a custom_entries section for the "other" profile' do
-                  expect( report['compliance_profiles']['other_profile']['custom_entries'] ).to_not be_empty
-                end
+                  it 'should have custom_entries for the "other" profile that have identifiers and notes' do
 
-                it 'should have custom_entries for the "other" profile that have identifiers and notes' do
-
-                  entry = report['compliance_profiles']['other_profile']['custom_entries']['One_off_inline::one off'].first
-                  expect(entry['identifiers']).to_not be_empty
-                  expect(entry['notes']).to_not be_empty
-                end
+                    entry = report['compliance_profiles']['other_profile']['custom_entries']['One_off_inline::one off'].first
+                    expect(entry['identifiers']).to_not be_empty
+                    expect(entry['notes']).to_not be_empty
+                  end
+                  end
               end
 
               context 'when running with the default options' do
@@ -476,6 +531,7 @@ describe 'compliance_markup' do
 =end
             end
           end
+        end
         end
       end
     end

--- a/spec/classes/test_spec.rb
+++ b/spec/classes/test_spec.rb
@@ -20,9 +20,21 @@ describe 'compliance_markup::test' do
                   let(:hieradata){ "#{profile}_spec" }
 
                   it "should return #{profile}" do
-                    is_expected.to(create_notify('compliance_markup::test').with_message("compliance_markup::test::testvariable = #{profile}"))
+                    is_expected.to(create_notify('compliance_markup::test::testvariable').with_message("compliance_markup::test::testvariable = #{profile}"))
                   end
                 end
+              end
+            end
+          end
+          profiles = [ 'disa', 'nist']
+          profiles.each do |profile|
+            order = ([ profile ] + (profiles - [ profile ])).to_s
+            context "when order = #{order} and data file is vendored" do
+              let(:facts) { facts }
+              let(:hieradata){ "#{profile}_spec" }
+
+              it "should return #{profile}" do
+                is_expected.to(create_notify('compliance_markup::test::vendoredvariable').with_message("compliance_markup::test::vendoredvariable = #{profile}"))
               end
             end
           end

--- a/spec/functions/compliance_map_spec.rb
+++ b/spec/functions/compliance_map_spec.rb
@@ -4,28 +4,20 @@ require 'spec_helper'
 describe 'compliance_map' do
   context 'when called improperly' do
     it 'should accept a String or a Hash as the first parameter' do
-      expect {
-        subject.call([['string'],'string'])
-      }.to raise_error(/First parameter must be .* String or Hash/)
+      is_expected.to run.with_params(['string'], 'string').and_raise_error(/First parameter must be .* String or Hash/)
     end
 
     context 'with a String as the first parameter' do
       it 'should only accept a String as the second parameter' do
-        expect {
-          subject.call(['string',['string']])
-        }.to raise_error(/Second parameter must be .* String/)
+        is_expected.to run.with_params('string', ['string']).and_raise_error(/Second parameter must be .* String/)
       end
 
       it 'should only accept a String as the third parameter' do
-        expect {
-          subject.call(['string','string',['string']])
-        }.to raise_error(/Third parameter must be .* String/)
+        is_expected.to run.with_params('string', 'string', ['string']).and_raise_error(/Third parameter must be .* String/)
       end
 
       it 'should require two parameters if any are given' do
-        expect {
-          subject.call(['string'])
-        }.to raise_error(/at least two parameters/)
+        is_expected.to run.with_params('string').and_raise_error(/at least two parameters/)
       end
     end
   end

--- a/tests/data/common.yaml
+++ b/tests/data/common.yaml
@@ -1,7 +1,7 @@
 ---
 compliance_markup::compliance_map:
         disa_stig:
-                test:
+                compliance_markup::test::testvariable:
                         value: "disa_stig"
 compliance_markup::enforcement:  [ 'disa_stig' ]
 test: "hiera"

--- a/tests/hiera.yaml
+++ b/tests/hiera.yaml
@@ -5,7 +5,7 @@ defaults:
         data_hash: yaml_data
 hierarchy:
         - name: "compliance_markup"
-          lookup_key: "compliance_markup::hiera_backend"
+          lookup_key: "compliance_markup::enforcement"
         - name: "common"
           path: "common.yaml"
 

--- a/tests/test.pp
+++ b/tests/test.pp
@@ -1,3 +1,6 @@
+$tvalue = lookup("compliance_markup::test::testvariable", { "default_value" =>  "manifest"})
 
-$value = lookup("test", { "default_value" => "manifest" })
-notify { "${value}": }
+notify { "compliance_markup::test::testvariable = ${tvalue}": }
+$vvalue = lookup("compliance_markup::test::vendoredvariable", { "default_value" =>  "manifest"})
+
+notify { "compliance_markup::test::vendoredvariable = ${vvalue}": }


### PR DESCRIPTION
Replace the compliance mapper's report generator parsing code
with the shared library used by the enforcement backend. This
means that the code to read and parse v1 format compliance maps
is now centralized.

Add vendored (maps-in-modules) support to the compiler for v1
format maps. Note: the operation of this is not well defined, and
intended for use in the v2 format of the compliance maps.

Also expand the shared library to a real object tree, with defined
api endpoints, like load() to load a set of compliance maps, and
list_puppet_params() to generate a puppet parameter hash.

Note: this code was tested using the existing spec tests without
modifications to ensure that the change is a drop-in replacement.
The code coverage of the tests may not be complete to do this.

SIMP-3784 #close