### PR TITLE
(SIMP-3840) Fix discrepencies between nist and disa compliance profiles

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+* Mon Oct 03 2017 Dylan Cochran <dylan.cochran@onyxpoint.com> - 2.3.2-0
+- Fix discrepencies between nist and disa compliance profiles
+
 * Fri Sep 22 2017 Dylan Cochran <dylan.cochran@onyxpoint.com> - 2.3.1-0
 - Refactor report generator to use a shared file format parser/compiler.
 - Add vendored 'profiles-in-modules' support

--- a/data/compliance_profiles/CentOS/6/nist_800_53_rev4.json
+++ b/data/compliance_profiles/CentOS/6/nist_800_53_rev4.json
@@ -637,7 +637,7 @@
         "identifiers": [
           "IA-5(1)(a)"
         ],
-        "value": 4
+        "value": 8
       },
       "pam::cracklib_enforce_for_root": {
         "identifiers": [
@@ -661,7 +661,7 @@
         "identifiers": [
           "IA-5(1)(a)"
         ],
-        "value": 0
+        "value": 4
       },
       "pam::cracklib_maxrepeat": {
         "identifiers": [
@@ -679,7 +679,7 @@
         "identifiers": [
           "IA-5(1)(a)"
         ],
-        "value": 3
+        "value": 4
       },
       "pam::cracklib_minlen": {
         "identifiers": [
@@ -715,7 +715,7 @@
         "identifiers": [
           "IA-1"
         ],
-        "value": 5
+        "value": 3
       },
       "pam::deny_if_unknown": {
         "identifiers": [
@@ -1312,7 +1312,7 @@
           "AC-10"
         ],
         "notes": "Setting this number higher than 10 should be justified",
-        "value": 11
+        "value": 10
       },
       "simp:root_user::manage_group": {
         "identifiers": [
@@ -1841,7 +1841,7 @@
         "identifiers": [
           "AC-7(a)"
         ],
-        "value": 5
+        "value": 3
       },
       "simp_openldap::server::conf::default_ldif::ppolicy_pwd_min_age": {
         "identifiers": [
@@ -1853,7 +1853,7 @@
         "identifiers": [
           "IA-5(1)(a)"
         ],
-        "value": 14
+        "value": 15
       },
       "simp_openldap::server::conf::default_ldif::ppolicy_pwd_must_change": {
         "identifiers": [
@@ -2775,7 +2775,7 @@
           "IA-5(c)",
           "IA-5(1)(d)"
         ],
-        "value": 14
+        "value": 15
       },
       "useradd::login_defs::pass_warn_age": {
         "identifiers": [
@@ -2836,7 +2836,7 @@
           "AC-2(4)",
           "AC-6"
         ],
-        "value": "0007"
+        "value": "0077"
       },
       "useradd::manage_etc_profile": {
         "identifiers": [

--- a/data/compliance_profiles/CentOS/7/disa_stig.json
+++ b/data/compliance_profiles/CentOS/7/disa_stig.json
@@ -258,7 +258,7 @@
           "CCI-000764",
           "CCI-000770"
         ],
-        "value": "yes"
+        "value": true
       },
       "autofs::ldap_auth::authtype": {
         "identifiers": [
@@ -275,7 +275,7 @@
           "SRG-OS-000250-GPOS-00093",
           "CCI-001453"
         ],
-        "value": "yes"
+        "value": true
       },
       "autofs::ldap_auth::usetls": {
         "identifiers": [
@@ -283,7 +283,7 @@
           "SRG-OS-000250-GPOS-00093",
           "CCI-001453"
         ],
-        "value": "yes"
+        "value": true
       },
       "autofs::ldap_auth_conf_file": {
         "identifiers": [
@@ -525,7 +525,7 @@
           "SRG-OS-000072-GPOS-00040",
           "CCI-000195"
         ],
-        "value": 2
+        "value": 4
       },
       "pam::cracklib_maxrepeat": {
         "identifiers": [

--- a/data/compliance_profiles/CentOS/7/nist_800_53_rev4.json
+++ b/data/compliance_profiles/CentOS/7/nist_800_53_rev4.json
@@ -637,7 +637,7 @@
         "identifiers": [
           "IA-5(1)(a)"
         ],
-        "value": 4
+        "value": 8
       },
       "pam::cracklib_enforce_for_root": {
         "identifiers": [
@@ -661,7 +661,7 @@
         "identifiers": [
           "IA-5(1)(a)"
         ],
-        "value": 0
+        "value": 4
       },
       "pam::cracklib_maxrepeat": {
         "identifiers": [
@@ -679,7 +679,7 @@
         "identifiers": [
           "IA-5(1)(a)"
         ],
-        "value": 3
+        "value": 4
       },
       "pam::cracklib_minlen": {
         "identifiers": [
@@ -715,7 +715,7 @@
         "identifiers": [
           "IA-1"
         ],
-        "value": 5
+        "value": 3
       },
       "pam::deny_if_unknown": {
         "identifiers": [
@@ -1312,7 +1312,7 @@
           "AC-10"
         ],
         "notes": "Setting this number higher than 10 should be justified",
-        "value": 11
+        "value": 10
       },
       "simp:root_user::manage_group": {
         "identifiers": [
@@ -1841,7 +1841,7 @@
         "identifiers": [
           "AC-7(a)"
         ],
-        "value": 5
+        "value": 3
       },
       "simp_openldap::server::conf::default_ldif::ppolicy_pwd_min_age": {
         "identifiers": [
@@ -1853,7 +1853,7 @@
         "identifiers": [
           "IA-5(1)(a)"
         ],
-        "value": 14
+        "value": 15
       },
       "simp_openldap::server::conf::default_ldif::ppolicy_pwd_must_change": {
         "identifiers": [
@@ -2775,7 +2775,7 @@
           "IA-5(c)",
           "IA-5(1)(d)"
         ],
-        "value": 14
+        "value": 15
       },
       "useradd::login_defs::pass_warn_age": {
         "identifiers": [
@@ -2836,7 +2836,7 @@
           "AC-2(4)",
           "AC-6"
         ],
-        "value": "0007"
+        "value": "0077"
       },
       "useradd::manage_etc_profile": {
         "identifiers": [

--- a/data/compliance_profiles/RedHat/6/nist_800_53_rev4.json
+++ b/data/compliance_profiles/RedHat/6/nist_800_53_rev4.json
@@ -637,7 +637,7 @@
         "identifiers": [
           "IA-5(1)(a)"
         ],
-        "value": 4
+        "value": 8
       },
       "pam::cracklib_enforce_for_root": {
         "identifiers": [
@@ -661,7 +661,7 @@
         "identifiers": [
           "IA-5(1)(a)"
         ],
-        "value": 0
+        "value": 4
       },
       "pam::cracklib_maxrepeat": {
         "identifiers": [
@@ -679,7 +679,7 @@
         "identifiers": [
           "IA-5(1)(a)"
         ],
-        "value": 3
+        "value": 4
       },
       "pam::cracklib_minlen": {
         "identifiers": [
@@ -715,7 +715,7 @@
         "identifiers": [
           "IA-1"
         ],
-        "value": 5
+        "value": 3
       },
       "pam::deny_if_unknown": {
         "identifiers": [
@@ -1312,7 +1312,7 @@
           "AC-10"
         ],
         "notes": "Setting this number higher than 10 should be justified",
-        "value": 11
+        "value": 10
       },
       "simp:root_user::manage_group": {
         "identifiers": [
@@ -1841,7 +1841,7 @@
         "identifiers": [
           "AC-7(a)"
         ],
-        "value": 5
+        "value": 3
       },
       "simp_openldap::server::conf::default_ldif::ppolicy_pwd_min_age": {
         "identifiers": [
@@ -1853,7 +1853,7 @@
         "identifiers": [
           "IA-5(1)(a)"
         ],
-        "value": 14
+        "value": 15
       },
       "simp_openldap::server::conf::default_ldif::ppolicy_pwd_must_change": {
         "identifiers": [
@@ -2775,7 +2775,7 @@
           "IA-5(c)",
           "IA-5(1)(d)"
         ],
-        "value": 14
+        "value": 15
       },
       "useradd::login_defs::pass_warn_age": {
         "identifiers": [
@@ -2836,7 +2836,7 @@
           "AC-2(4)",
           "AC-6"
         ],
-        "value": "0007"
+        "value": "0077"
       },
       "useradd::manage_etc_profile": {
         "identifiers": [

--- a/data/compliance_profiles/RedHat/7/disa_stig.json
+++ b/data/compliance_profiles/RedHat/7/disa_stig.json
@@ -258,7 +258,7 @@
           "CCI-000764",
           "CCI-000770"
         ],
-        "value": "yes"
+        "value": true
       },
       "autofs::ldap_auth::authtype": {
         "identifiers": [
@@ -275,7 +275,7 @@
           "SRG-OS-000250-GPOS-00093",
           "CCI-001453"
         ],
-        "value": "yes"
+        "value": true
       },
       "autofs::ldap_auth::usetls": {
         "identifiers": [
@@ -283,7 +283,7 @@
           "SRG-OS-000250-GPOS-00093",
           "CCI-001453"
         ],
-        "value": "yes"
+        "value": true
       },
       "autofs::ldap_auth_conf_file": {
         "identifiers": [
@@ -525,7 +525,7 @@
           "SRG-OS-000072-GPOS-00040",
           "CCI-000195"
         ],
-        "value": 2
+        "value": 4
       },
       "pam::cracklib_maxrepeat": {
         "identifiers": [

--- a/data/compliance_profiles/RedHat/7/nist_800_53_rev4.json
+++ b/data/compliance_profiles/RedHat/7/nist_800_53_rev4.json
@@ -637,7 +637,7 @@
         "identifiers": [
           "IA-5(1)(a)"
         ],
-        "value": 4
+        "value": 8
       },
       "pam::cracklib_enforce_for_root": {
         "identifiers": [
@@ -661,7 +661,7 @@
         "identifiers": [
           "IA-5(1)(a)"
         ],
-        "value": 0
+        "value": 4
       },
       "pam::cracklib_maxrepeat": {
         "identifiers": [
@@ -679,7 +679,7 @@
         "identifiers": [
           "IA-5(1)(a)"
         ],
-        "value": 3
+        "value": 4
       },
       "pam::cracklib_minlen": {
         "identifiers": [
@@ -715,7 +715,7 @@
         "identifiers": [
           "IA-1"
         ],
-        "value": 5
+        "value": 3
       },
       "pam::deny_if_unknown": {
         "identifiers": [
@@ -1312,7 +1312,7 @@
           "AC-10"
         ],
         "notes": "Setting this number higher than 10 should be justified",
-        "value": 11
+        "value": 10
       },
       "simp:root_user::manage_group": {
         "identifiers": [
@@ -1841,7 +1841,7 @@
         "identifiers": [
           "AC-7(a)"
         ],
-        "value": 5
+        "value": 3
       },
       "simp_openldap::server::conf::default_ldif::ppolicy_pwd_min_age": {
         "identifiers": [
@@ -1853,7 +1853,7 @@
         "identifiers": [
           "IA-5(1)(a)"
         ],
-        "value": 14
+        "value": 15
       },
       "simp_openldap::server::conf::default_ldif::ppolicy_pwd_must_change": {
         "identifiers": [
@@ -2775,7 +2775,7 @@
           "IA-5(c)",
           "IA-5(1)(d)"
         ],
-        "value": 14
+        "value": 15
       },
       "useradd::login_defs::pass_warn_age": {
         "identifiers": [
@@ -2836,7 +2836,7 @@
           "AC-2(4)",
           "AC-6"
         ],
-        "value": "0007"
+        "value": "0077"
       },
       "useradd::manage_etc_profile": {
         "identifiers": [

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-compliance_markup",
-  "version": "2.3.1",
+  "version": "2.3.2",
   "author": "SIMP Team",
   "summary": "Compliance-mapping annotation for Puppet code",
   "license": "Apache-2.0",


### PR DESCRIPTION
The DISA and NIST compliance profiles had conflicting values for
puppet parameters. After re-reviewing we found that all the values
should be the same on both NIST and DISA profiles.

This updates the data to match

SIMP-3840 #close