### PR TITLE
(SIMP-4330) Add gemspec for the simp-compliance-engine in the compliance_markup module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,5 @@ vendor/
 junit/
 log/
 doc/
+.gem_date
+.gem_version

--- a/simp-compliance-engine.gemspec
+++ b/simp-compliance-engine.gemspec
@@ -1,0 +1,40 @@
+# vim: set expandtab ts=2 sw=2:
+$LOAD_PATH.unshift File.expand_path('../lib', __FILE__)
+
+module Simp
+  class Helpers
+    def self.get_param(param, command)
+      file = "#{File.dirname(__FILE__)}/.gem_#{param}"
+      if (File.exists?(file))
+        info = File.read(file)
+      else
+        info = `#{command}`
+        File.open(file, "w") do |f|
+          f.write(info)
+        end
+      end
+      puts info
+      info
+    end
+  end
+end
+
+Gem::Specification.new do |s|
+  s.name = 'simp-compliance-engine'
+  ver = Simp::Helpers.get_param("version", "git describe --always --dirty")
+  date = Simp::Helpers.get_param("date", "git show -s --date=format:%Y-%m-%d --format=%cd HEAD")
+  s.date = date
+  s.version = ver
+  s.summary = 'SIMP Metadata Library'
+  s.description = 'A library for accessing the SIMP metadata format for the simp project'
+  s.authors = [
+    "SIMP Project"
+  ]
+  s.executables      = `git ls-files -- exe/*`.split("\n").map{ |f| File.basename(f) }
+  s.bindir           = 'exe'
+  s.email = 'simp@simp-project.org'
+  s.license = 'Apache-2.0'
+  s.homepage = 'https://github.com/simp/pupmod-simp-compliance_markup'
+  s.files = Dir['Rakefile', '{bin,lib,spec}/**/*', 'README*','*.gemspec','*.md','CONTRIBUTORS','Gemfile','LICENSE','NOTICE.TXT', '.gem_version', '.gem_date']
+
+end


### PR DESCRIPTION
Add a gemspec for building a standalone gem for the compliance engine. This allows for
hiera v3 support as well as some downstream consumers in the enterprise edition.

SIMP-4330 #close