### PR TITLE
(SIMP-4421) TMOUT setting does not match STIG for EL7

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,113 +1,211 @@
+# The testing matrix considers ruby/puppet versions supported by SIMP and PE:
+#
+# https://puppet.com/docs/pe/2017.3/overview/component_versions_in_recent_pe_releases.html
+# https://puppet.com/misc/puppet-enterprise-lifecycle
+# https://puppet.com/docs/pe/2017.3/overview/getting_support_for_pe.html#standard-releases-and-long-term-support-releases
+# ------------------------------------------------------------------------------
+#  release    pup   ruby      eol
+# PE 2016.4   4.7   2.1.9  2018-10  (LTS)
+# SIMP6.0.0   4.8   2.1.9  TBD
+# PE 2017.2   4.10  2.1.9  2018-02-21
+# PE 2017.3   5.3   2.4.1  2018-07
+# PE 2018.1   ???   ?????  ????-??  (LTS)
 ---
-puppet-syntax: 
-  stage: test
-  tags: 
-    - docker
-  image: ruby:2.1
-  script: 
-    - bundle install
+.cache_bundler: &cache_bundler
+  cache:
+    untracked: true
+    # An attempt at caching between runs (ala Travis CI)
+    key: "${CI_PROJECT_NAMESPACE}__bundler"
+    paths:
+      - '.vendor'
+      - 'vendor'
+
+.setup_env: &setup_env
+  before_script:
+    - '(find .vendor | wc -l) || :'
+    - bundle || gem install bundler --no-rdoc --no-ri
+    - rm -f Gemfile.lock
+    - rm -rf pkg/
+    - bundle install --no-binstubs --jobs $(nproc) --path=.vendor "${FLAGS[@]}"
+
+.setup_env_beaker: &setup_env_beaker
+  before_script:
+    - '(find .vendor | wc -l) || :'
+    - rm -f Gemfile.lock
+    - rm -rf pkg/
+    - bundle install --no-binstubs --jobs $(nproc) --path=.vendor "${FLAGS[@]}"
+
+.validation_checks: &validation_checks
+  script:
     - bundle exec rake syntax
-puppet-lint: 
-  stage: test
-  tags: 
-    - docker
-  image: ruby:2.1
-  script: 
-    - bundle install
+    - bundle exec rake check:dot_underscore
+    - bundle exec rake check:test_file
+    - bundle exec rake pkg:check_version
+    - bundle exec rake pkg:compare_latest_tag
     - bundle exec rake lint
-puppet-metadata: 
-  stage: test
-  tags: 
-    - docker
-  image: ruby:2.1
-  script: 
-    - bundle install
-    - bundle exec rake metadata
-unit-test-ruby-2.1:
-  stage: test
-  tags: 
-    - docker
-  image: ruby:2.1
-  script: 
-    - bundle install
-    - bundle exec rake spec
-unit-test-ruby-2.2:
-  stage: test
-  tags: 
-    - docker
-  image: ruby:2.2
-  allow_failure: true
-  script: 
-    - bundle install
-    - bundle exec rake spec
-unit-test-ruby-2.3:
-  stage: test
-  tags: 
-    - docker
-  image: ruby:2.3
-  allow_failure: true
-  script: 
-    - bundle install
+    - bundle exec rake clean
+    - bundle exec puppet module build
+
+.spec_tests: &spec_tests
+  script:
     - bundle exec rake spec
 
-# For PE LTS Support
+stages:
+  - validation
+  - unit
+  - acceptance
+  - deploy
+
+# Puppet 4.7 for PE 2016.4 LTS Support (EOL: 2018-10-21)
 # See: https://puppet.com/misc/puppet-enterprise-lifecycle
-puppet4.7-syntax: 
-  stage: test
-  tags: 
+# --------------------------------------
+pup4.7-validation:
+  stage: validation
+  tags:
     - docker
   image: ruby:2.1
-  script: 
-    - PUPPET_VERSION=4.7 bundle install
-    - PUPPET_VERSION=4.7 bundle exec rake syntax
-unit-test-puppet4.7-ruby-2.1:
-  stage: test
-  tags: 
-    - docker
-  image: ruby:2.1
-  script: 
-    - PUPPET_VERSION=4.7 bundle install
-    - PUPPET_VERSION=4.7 bundle exec rake spec
-unit-test-puppet4.7-ruby-2.2:
-  stage: test
-  tags: 
-    - docker
-  image: ruby:2.2
-  allow_failure: true
-  script: 
-    - PUPPET_VERSION=4.7 bundle install
-    - PUPPET_VERSION=4.7 bundle exec rake spec
-unit-test-puppet4.7-ruby-2.3:
-  stage: test
-  tags: 
-    - docker
-  image: ruby:2.3
-  allow_failure: true
-  script: 
-    - PUPPET_VERSION=4.7.0 bundle install
-    - PUPPET_VERSION=4.7.0 bundle exec rake spec
+  variables:
+    PUPPET_VERSION: '~> 4.7.0'
+  <<: *cache_bundler
+  <<: *setup_env
+  <<: *validation_checks
 
-acceptance-test-4.7: 
-  stage: test
-  tags: 
+pup4.7-unit:
+  stage: unit
+  tags:
+    - docker
+  image: ruby:2.1
+  variables:
+    PUPPET_VERSION: '~> 4.7.0'
+  <<: *cache_bundler
+  <<: *setup_env
+  <<: *spec_tests
+
+
+# Puppet 4.8 for SIMP 6.0 + 6.1 support
+# --------------------------------------
+pup4.8-validation:
+  stage: validation
+  tags:
+    - docker
+  image: ruby:2.1
+  variables:
+    PUPPET_VERSION: '~> 4.8.0'
+  <<: *cache_bundler
+  <<: *setup_env
+  <<: *validation_checks
+
+pup4.8-unit:
+  stage: unit
+  tags:
+    - docker
+  image: ruby:2.1
+  variables:
+    PUPPET_VERSION: '~> 4.8.0'
+  <<: *cache_bundler
+  <<: *setup_env
+  <<: *spec_tests
+
+
+# Puppet 4.10 for PE 2017.2 support (EOL:2018-02-21)
+# See: https://puppet.com/misc/puppet-enterprise-lifecycle
+# --------------------------------------
+pup4.10-validation:
+  stage: validation
+  tags:
+    - docker
+  image: ruby:2.1
+  variables:
+    PUPPET_VERSION: '~> 4.10.0'
+  <<: *cache_bundler
+  <<: *setup_env
+  <<: *validation_checks
+
+pup4.10-unit:
+  stage: unit
+  tags:
+    - docker
+  image: ruby:2.1
+  variables:
+    PUPPET_VERSION: '~> 4.10.0'
+  <<: *cache_bundler
+  <<: *setup_env
+  <<: *spec_tests
+
+
+# Puppet 5.3 for PE 2017.3 support (EOL: 2018-07)
+# See: https://puppet.com/misc/puppet-enterprise-lifecycle
+# --------------------------------------
+pup5.3-validation:
+  stage: validation
+  tags:
+    - docker
+  image: ruby:2.4
+  variables:
+    PUPPET_VERSION: '~> 5.3.0'
+  <<: *cache_bundler
+  <<: *setup_env
+  <<: *validation_checks
+
+pup5.3-unit:
+  stage: unit
+  tags:
+    - docker
+  image: ruby:2.4
+  variables:
+    PUPPET_VERSION: '~> 5.3.0'
+  <<: *cache_bundler
+  <<: *setup_env
+  <<: *spec_tests
+  allow_failure: true
+
+
+# Keep an eye on the latest puppet 5
+# ----------------------------------
+pup5.latest-validation:
+  stage: validation
+  tags:
+    - docker
+  image: ruby:2.4
+  variables:
+    PUPPET_VERSION: '~> 5.0'
+  <<: *cache_bundler
+  <<: *setup_env
+  <<: *validation_checks
+  allow_failure: true
+
+pup5.latest-unit:
+  stage: unit
+  tags:
+    - docker
+  image: ruby:2.4
+  variables:
+    PUPPET_VERSION: '~> 5.0'
+  <<: *cache_bundler
+  <<: *setup_env
+  <<: *spec_tests
+  allow_failure: true
+
+
+
+# Acceptance tests
+# ==============================================================================
+acceptance-default:
+  stage: acceptance
+  tags:
     - beaker
-  script: 
-    - bundle install --no-binstubs --path=vendor
-    - PUPPET_VERSION=4.7.0 bundle update
-    - PUPPET_VERSION=4.7.0 bundle exec rake acceptance
-acceptance-test-4.8: 
-  stage: test
-  tags: 
+  <<: *cache_bundler
+  <<: *setup_env_beaker
+  script:
+    - bundle exec rake beaker:suites[default]
+
+acceptance-fips-default:
+  stage: acceptance
+  tags:
     - beaker
-  script: 
-    - bundle install --no-binstubs --path=vendor
-    - PUPPET_VERSION=4.8.0 bundle update
-    - PUPPET_VERSION=4.8.0 bundle exec rake acceptance
-acceptance-test-4.10.0: 
-  stage: test
-  tags: 
-    - beaker
-  script: 
-    - bundle install --no-binstubs --path=vendor
-    - PUPPET_VERSION=4.10.0 bundle update
-    - PUPPET_VERSION=4.10.0 bundle exec rake acceptance
+  <<: *cache_bundler
+  <<: *setup_env_beaker
+  variables:
+    BEAKER_fips: 'yes'
+  script:
+    - bundle exec rake beaker:suites[default]

--- a/.puppet-lint.rc
+++ b/.puppet-lint.rc
@@ -2,7 +2,6 @@
 --relative
 --no-class_inherits_from_params_class-check
 --no-140chars-check
---no-empty_string-check
 --no-trailing_comma-check
 # This is here because the code can't handle lookups in parameters and we have
 # a LOT of those

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,8 +25,13 @@ before_install:
   - rm -f Gemfile.lock
 
 jobs:
+  allow_failures:
+    - env: STRICT_VARIABLES=yes TRUSTED_NODE_DATA=yes PUPPET_VERSION="~> 5.0"
+    # SIMP-4516 has been entered to fix the test that won't run in docker
+    - stage: acceptance
+
   include:
-    - stage: spec
+    - stage: check
       rvm: 2.4.1
       env: STRICT_VARIABLES=yes TRUSTED_NODE_DATA=yes PUPPET_VERSION="~> 5"
       script:
@@ -34,7 +39,7 @@ jobs:
         - bundle exec rake check:test_file
         - bundle exec rake pkg:check_version
         - bundle exec rake metadata_lint
-        - bundle exec rake compare_latest_tag
+        - bundle exec rake pkg:compare_latest_tag
 
     - stage: spec
       rvm: 2.4.1
@@ -67,7 +72,7 @@ jobs:
         - docker
       script:
         - bundle exec rake beaker:suites[default,docker]
-      env: PUPPET_VERSION"~> 4.8.2"
+      env: PUPPET_VERSION="4.8.2"
 
     # This needs to be last since we have an acceptance test
     - stage: deploy

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,13 @@
-* Wed Dec 13 2017 Nick Markowski <nicholas.markowski@onyxpoint.com> - 2.3.4-0
+* Tue Mar 06 2018 Liz Nemsick <lnemsick.simp@gmail.com> - 2.3.3-0
+- Updated TMOUT setting in /etc/profile.d/simp.sh to match EL7 STIG
+  setting (Reference: RHEL-07-040160)
+- Added missing audispd program to simp_rsyslog::default_logs
+- Added missing ' IPT:' message start to simp_ryslog::default_logs.
+  This is required for iptables violation messages because some
+  versions of rsyslog add a space separating the message
+  timestamp/id and the message.
+
+* Wed Dec 13 2017 Nick Markowski <nicholas.markowski@onyxpoint.com> - 2.3.3-0
 - Further aligned the EL7 disa_stig profile with scap-security-guide 0.1.33-5
   - Added oval-ids to map puppet parameters to openscap tests and SIMP
     remediations.  Note this mapping is NOT complete.

--- a/Gemfile
+++ b/Gemfile
@@ -17,7 +17,7 @@ group :test do
   gem 'puppet-lint-empty_string-check',   :require => false
   gem 'puppet-lint-trailing_comma-check', :require => false
   gem 'simp-rspec-puppet-facts', ENV.fetch('SIMP_RSPEC_PUPPET_FACTS_VERSION', '~> 2.0')
-  gem 'simp-rake-helpers', ENV.fetch('SIMP_RAKE_HELPERS_VERSION', '~> 4.0')
+  gem 'simp-rake-helpers', ENV.fetch('SIMP_RAKE_HELPERS_VERSION', '~> 5')
   gem 'semantic_puppet'
 end
 

--- a/data/compliance_profiles/CentOS/6/nist_800_53_rev4.json
+++ b/data/compliance_profiles/CentOS/6/nist_800_53_rev4.json
@@ -2109,6 +2109,7 @@
             "sudo",
             "sudosh",
             "yum",
+            "audispd",
             "auditd",
             "audit",
             "systemd",
@@ -2122,6 +2123,7 @@
             "*.emerg"
           ],
           "msg_starts": [
+            " IPT:",
             "IPT:"
           ],
           "msg_regex": [

--- a/data/compliance_profiles/CentOS/7/disa_stig.json
+++ b/data/compliance_profiles/CentOS/7/disa_stig.json
@@ -711,6 +711,7 @@
         "identifiers": [
           "RHEL-07-010370",
           "SRG-OS-000329-GPOS-00128",
+          "SRG-OS-000021-GPOS-00005",
           "CCI-002238"
         ],
         "value": 900
@@ -749,17 +750,6 @@
           "xccdf_org:ssgproject:content_rule_accounts_passwords_pam_faillock_unlock_time"
         ],
         "value": "never"
-      },
-      "pam::fail_interval": {
-        "identifiers": [
-          "SRG-OS-000329-GPOS-00128",
-          "SRG-OS-000021-GPOS-00005",
-          "CCI-002238"
-        ],
-        "oval-ids": [
-          "xccdf_org:ssgproject:content_rule_accounts_passwords_pam_faillock_interval"
-        ],
-        "value": 900
       },
       "pam::use_netgroups": {
         "identifiers": [
@@ -1565,6 +1555,7 @@
             "sudo",
             "sudosh",
             "yum",
+            "audispd",
             "auditd",
             "audit",
             "systemd",
@@ -1578,6 +1569,7 @@
             "*.emerg"
           ],
           "msg_starts": [
+            " IPT:",
             "IPT:"
           ],
           "msg_regex": [
@@ -1976,8 +1968,12 @@
       "useradd::etc_profile::session_timeout": {
         "identifiers": [
           "RHEL-07-010070",
+          "RHEL-07-040160",
           "SRG-OS-000029-GPOS-00010",
-          "CCI-000057"
+          "SRG-OS-000163-GPOS-00072",
+          "CCI-000057",
+          "CCI-000361",
+          "CCI-001133"
         ],
         "oval-ids": [
           "xccdf_org:ssgproject:content_rule_accounts_tmout"
@@ -2226,17 +2222,6 @@
           "xccdf_org:ssgproject:content_rule_accounts_umask_etc_login_defs"
         ],
         "value": "077"
-      },
-      "useradd::etc_profile::session_timeout": {
-        "identifiers": [
-          "SRG-OS-000163-GPOS-00072",
-          "CCI-001133",
-          "CCI-000361"
-        ],
-        "oval-ids": [
-          "xccdf_org:ssgproject:content_rule_accounts_tmout"
-        ],
-        "value": 10
       },
       "useradd::shells_default": {
         "identifiers": [

--- a/data/compliance_profiles/CentOS/7/nist_800_53_rev4.json
+++ b/data/compliance_profiles/CentOS/7/nist_800_53_rev4.json
@@ -2109,6 +2109,7 @@
             "sudo",
             "sudosh",
             "yum",
+            "audispd",
             "auditd",
             "audit",
             "systemd",
@@ -2122,6 +2123,7 @@
             "*.emerg"
           ],
           "msg_starts": [
+            " IPT:",
             "IPT:"
           ],
           "msg_regex": [

--- a/data/compliance_profiles/RedHat/6/nist_800_53_rev4.json
+++ b/data/compliance_profiles/RedHat/6/nist_800_53_rev4.json
@@ -2109,6 +2109,7 @@
             "sudo",
             "sudosh",
             "yum",
+            "audispd",
             "auditd",
             "audit",
             "systemd",
@@ -2122,6 +2123,7 @@
             "*.emerg"
           ],
           "msg_starts": [
+            " IPT:",
             "IPT:"
           ],
           "msg_regex": [

--- a/data/compliance_profiles/RedHat/7/disa_stig.json
+++ b/data/compliance_profiles/RedHat/7/disa_stig.json
@@ -24,6 +24,9 @@
           "CCI-001814",
           "CCI-000368"
         ],
+        "oval-ids": [
+          "xccdf_org:ssgproject:content_rule_aide_periodic_cron_checking"
+        ],
         "value": true
       },
       "aide::logrotate::rotate_period": {
@@ -54,6 +57,9 @@
           "CCI-001744",
           "SRG-OS-000363-GPOS-00150"
         ],
+        "oval-ids": [
+          "xccdf_org:ssgproject:content_rule_aide_periodic_cron_checking"
+        ],
         "value": 5
       },
       "aide::hour": {
@@ -61,12 +67,18 @@
           "CCI-001744",
           "SRG-OS-000363-GPOS-00150"
         ],
+        "oval-ids": [
+          "xccdf_org:ssgproject:content_rule_aide_periodic_cron_checking"
+        ],
         "value": 4
       },
       "aide::weekday": {
         "identifiers": [
           "CCI-001744",
           "SRG-OS-000363-GPOS-00150"
+        ],
+        "oval-ids": [
+          "xccdf_org:ssgproject:content_rule_aide_periodic_cron_checking"
         ],
         "value": 0
       },
@@ -78,6 +90,17 @@
           "SRG-OS-000042-GPOS-00020",
           "CCI-002234",
           "CCI-000135"
+        ],
+        "value": true
+      },
+      "auditd::config::audit_profiles::simp::audit_mount": {
+        "identifiers": [
+          "SRG-OS-000042-GPOS-00020",
+          "SRG-OS-000392-GPOS-00172",
+          "CCI-002884"
+        ],
+        "oval-ids": [
+          "xccdf_org:ssgproject:content_rule_audit_rules_media_export"
         ],
         "value": true
       },
@@ -99,6 +122,14 @@
           "RHEL-07-030402",
           "RHEL-07-030403",
           "RHEL-07-030400"
+        ],
+        "oval-ids": [
+          "xccdf_org:ssgproject:content_rule_audit_rules_dac_modification_fremovexattr",
+          "xccdf_org:ssgproject:content_rule_audit_rules_dac_modification_fsetxattr",
+          "xccdf_org:ssgproject:content_rule_audit_rules_dac_modification_lremovexattr",
+          "xccdf_org:ssgproject:content_rule_audit_rules_dac_modification_lsetxattr",
+          "xccdf_org:ssgproject:content_rule_audit_rules_dac_modification_removexattr",
+          "xccdf_org:ssgproject:content_rule_audit_rules_dac_modification_setxattr"
         ],
         "value": true
       },
@@ -122,6 +153,11 @@
           "RHEL-07-030400"
         ],
         "notes": "SIMP disables this by default due to the excessive number of audit records generated. Enable with caution.",
+        "oval-ids": [
+          "xccdf_org:ssgproject:content_rule_audit_rules_dac_modification_chmod",
+          "xccdf_org:ssgproject:content_rule_audit_rules_dac_modification_fchmod",
+          "xccdf_org:ssgproject:content_rule_audit_rules_dac_modification_fchmodat"
+        ],
         "value": true
       },
       "auditd::config::audit_profiles::simp::audit_chown": {
@@ -142,6 +178,12 @@
           "RHEL-07-030402",
           "RHEL-07-030403",
           "RHEL-07-030400"
+        ],
+        "oval-ids": [
+          "xccdf_org:ssgproject:content_rule_audit_rules_dac_modification_chown",
+          "xccdf_org:ssgproject:content_rule_audit_rules_dac_modification_fchown",
+          "xccdf_org:ssgproject:content_rule_audit_rules_dac_modification_fchownat",
+          "xccdf_org:ssgproject:content_rule_audit_rules_dac_modification_lchown"
         ],
         "value": true
       },
@@ -172,6 +214,9 @@
           "SRG-OS-000470-GPOS-00214",
           "SRG-OS-000473-GPOS-00218",
           "RHEL-07-030490"
+        ],
+        "oval-ids": [
+          "xccdf_org:ssgproject:content_rule_audit_rules_login_events_faillock"
         ],
         "value": true
       },
@@ -204,6 +249,19 @@
           "SRG-OS-000458-GPOS-00203",
           "RHEL-07-030420",
           "RHEL-07-030750"
+        ],
+        "oval-ids": [
+          "xccdf_org:ssgproject:content_rule_audit_rules_unsuccessful_file_modification_creat",
+          "xccdf_org:ssgproject:content_rule_audit_rules_unsuccessful_file_modification_open",
+          "xccdf_org:ssgproject:content_rule_audit_rules_unsuccessful_file_modification_openat",
+          "xccdf_org:ssgproject:content_rule_audit_rules_unsuccessful_file_modification_open_by_handle_at",
+          "xccdf_org:ssgproject:content_rule_audit_rules_unsuccessful_file_modification_truncate",
+          "xccdf_org:ssgproject:content_rule_audit_rules_unsuccessful_file_modification_ftruncate",
+          "xccdf_org:ssgproject:content_rule_audit_rules_file_deletion_events_rmdir",
+          "xccdf_org:ssgproject:content_rule_audit_rules_file_deletion_events_unlink",
+          "xccdf_org:ssgproject:content_rule_audit_rules_file_deletion_events_unlinkat",
+          "xccdf_org:ssgproject:content_rule_audit_rules_file_deletion_events_rename",
+          "xccdf_org:ssgproject:content_rule_audit_rules_file_deletion_events_renameat"
         ],
         "value": true
       },
@@ -274,7 +332,7 @@
           "CCI-001855"
         ],
         "notes": "This value can be changed if there is a more ideal notification method for your systems",
-        "value": "SYSLOG"
+        "value": "EMAIL"
       },
       "auditd::syslog": {
         "identifiers": [
@@ -334,6 +392,9 @@
           "SRG-OS-000480-GPOS-00227",
           "CCI-000366"
         ],
+        "oval-ids": [
+          "xccdf_org:ssgproject:content_rule_install_mcafee_antivirus"
+        ],
         "notes": "If ClamAV is not used, alternate malicious code detection software should be implemented",
         "value": true
       },
@@ -343,6 +404,9 @@
           "SRG-OS-000480-GPOS-00227",
           "CCI-000366"
         ],
+        "oval-ids": [
+          "xccdf_org:ssgproject:content_rule_install_mcafee_antivirus"
+        ],
         "notes": "If ClamAV is not used, alternate malicious code detection software should be implemented",
         "value": false
       },
@@ -351,6 +415,9 @@
           "RHEL-07-030810",
           "SRG-OS-000480-GPOS-00227",
           "CCI-000366"
+        ],
+        "oval-ids": [
+          "xccdf_org:ssgproject:content_rule_install_mcafee_antivirus"
         ],
         "notes": "If ClamAV is not used, alternate malicious code detection software should be implemented",
         "value": true
@@ -377,6 +444,9 @@
           "CCI-000366"
         ],
         "notes": "If the SIMP default rules are modified, the running rules should be viewed to ensure they allow a minimal set inbound flows",
+        "oval-ids": [
+          "xccdf_org:ssgproject:content_rule_set_firewalld_default_zone"
+        ],
         "value": true
       },
       "iptables::ignore": {
@@ -420,6 +490,9 @@
           "SRG-OS-000023-GPOS-00006",
           "SRG-OS-000024-GPOS-00007",
           "CCI-000048"
+        ],
+        "oval-ids": [
+          "xccdf_org:ssgproject:content_rule_banner_etc_issue"
         ],
         "value": "us_dod"
       },
@@ -542,6 +615,9 @@
           "SRG-OS-000072-GPOS-00040",
           "CCI-000195"
         ],
+        "oval-ids": [
+          "xccdf_org:ssgproject:content_rule_accounts_password_pam_difok"
+        ],
         "value": 8
       },
       "pam::cracklib_lcredit": {
@@ -580,6 +656,9 @@
           "SRG-OS-000072-GPOS-00040",
           "CCI-000195"
         ],
+        "oval-ids": [
+          "xccdf_org:ssgproject:content_rule_accounts_password_pam_minclass"
+        ],
         "value": 4
       },
       "pam::cracklib_minlen": {
@@ -604,6 +683,9 @@
           "SRG-OS-000480-GPOS-00225",
           "CCI-000366"
         ],
+        "oval-ids": [
+          "xccdf_org:ssgproject:content_rule_accounts_password_pam_retry"
+        ],
         "value": 3
       },
       "pam::cracklib_ucredit": {
@@ -620,12 +702,16 @@
           "SRG-OS-000329-GPOS-00128",
           "CCI-002238"
         ],
+        "oval-ids": [
+          "xccdf_org:ssgproject:content_rule_accounts_passwords_pam_faillock_deny"
+        ],
         "value": 3
       },
       "pam::fail_interval": {
         "identifiers": [
           "RHEL-07-010370",
           "SRG-OS-000329-GPOS-00128",
+          "SRG-OS-000021-GPOS-00005",
           "CCI-002238"
         ],
         "value": 900
@@ -660,7 +746,10 @@
           "SRG-OS-000329-GPOS-00128",
           "CCI-002238"
         ],
-        "value": 900
+        "oval-ids": [
+          "xccdf_org:ssgproject:content_rule_accounts_passwords_pam_faillock_unlock_time"
+        ],
+        "value": "never"
       },
       "pam::use_netgroups": {
         "identifiers": [
@@ -758,6 +847,9 @@
           "SRG-OS-000341-GPOS-00132",
           "CCI-001849"
         ],
+        "oval-ids": [
+          "xccdf_org:ssgproject:content_rule_rsyslog_cron_logging"
+        ],
         "value": true
       },
       "rsyslog::config::main_msg_queue_save_on_shutdown": {
@@ -827,6 +919,20 @@
           "RHEL-07-020220",
           "SRG-OS-000480-GPOS-00227",
           "CCI-000366"
+        ],
+        "oval-ids": [
+          "xccdf_org:ssgproject:content_rule_disable_ctrlaltdel_reboot"
+        ],
+        "value": false
+      },
+      "simp::ctrl_alt_del::log": {
+        "identifiers": [
+          "RHEL-07-020220",
+          "SRG-OS-000480-GPOS-00227",
+          "CCI-000366"
+        ],
+        "oval-ids": [
+          "xccdf_org:ssgproject:content_rule_disable_ctrlaltdel_reboot"
         ],
         "value": false
       },
@@ -977,6 +1083,9 @@
           "SRG-OS-000001-GPOS-00001",
           "CCI-000015",
           "CCI-002038"
+        ],
+        "oval-ids": [
+          "xccdf_org:ssgproject:content_rule_sudo_remove_nopasswd"
         ],
         "value": true
       },
@@ -1438,11 +1547,15 @@
           "CCI-000172"
         ],
         "notes": "If the default security relevant logs are changed, they should be justified, especially if fewer than the SIMP default are configured",
+        "oval-ids": [
+          "xccdf_org:ssgproject:content_rule_rsyslog_cron_logging"
+        ],
         "value": {
           "programs": [
             "sudo",
             "sudosh",
             "yum",
+            "audispd",
             "auditd",
             "audit",
             "systemd",
@@ -1456,6 +1569,7 @@
             "*.emerg"
           ],
           "msg_starts": [
+            " IPT:",
             "IPT:"
           ],
           "msg_regex": [
@@ -1556,13 +1670,19 @@
           "SRG-OS-000024-GPOS-00007",
           "CCI-000048"
         ],
-        "value": "/etc/issue.net"
+        "oval-ids": [
+          "xccdf_org:ssgproject:content_rule_sshd_enable_warning_banner"
+        ],
+        "value": "/etc/issue"
       },
       "ssh::server::conf::enable_fallback_ciphers": {
         "identifiers": [
           "RHEL-07-040600",
           "SRG-OS-000033-GPOS-00014",
           "CCI-000068"
+        ],
+        "oval-ids": [
+          "xccdf_org:ssgproject:content_rule_sshd_use_approved_ciphers"
         ],
         "value": true
       },
@@ -1639,6 +1759,19 @@
           "CCI-002235"
         ],
         "notes": "For EL7, this should be 'sandbox'. This will be fixed in a later revision of the map.",
+        "oval-ids": [
+          "xccdf_org:ssgproject:content_rule_sshd_use_priv_separation"
+        ],
+        "value": true
+      },
+      "ssh::server::conf::printlastlog": {
+        "identifiers": [
+          "CCI-000366",
+          "SRG-OS-000480-GPOS-00227"
+        ],
+        "oval-ids": [
+          "xccdf_org:ssgproject:content_rule_sshd_print_last_log"
+        ],
         "value": true
       },
       "ssh::server::conf::x11forwarding": {
@@ -1647,7 +1780,10 @@
           "SRG-OS-000480-GPOS-00227",
           "CCI-000366"
         ],
-        "value": false
+        "oval-ids": [
+          "xccdf_org:ssgproject:content_rule_sshd_enable_x11_forwarding"
+        ],
+        "value": true
       },
       "sssd::app_pki_dir": {
         "identifiers": [
@@ -1690,6 +1826,9 @@
           "SRG-OS-000250-GPOS-00093",
           "CCI-001453"
         ],
+        "oval-id": [
+          "xccdf_org:ssgproject:content_rule_ldap_client_start_tls"
+        ],
         "value": true
       },
       "sssd::provider::ldap::ldap_tls_cipher_suite": {
@@ -1697,6 +1836,9 @@
           "RHEL-07-040180",
           "SRG-OS-000250-GPOS-00093",
           "CCI-001453"
+        ],
+        "oval-id": [
+          "xccdf_org:ssgproject:content_rule_ldap_client_start_tls"
         ],
         "value": [
           "HIGH",
@@ -1813,13 +1955,30 @@
         ],
         "value": true
       },
+      "useradd::useradd::inactive": {
+        "identifiers": [
+          "SRG-OS-000118-GPOS-00060",
+          "CCI-000795"
+        ],
+        "oval-ids": [
+          "xccdf_org:ssgproject:content_rule_account_disable_post_pw_expiration"
+        ],
+        "value": 35
+      },
       "useradd::etc_profile::session_timeout": {
         "identifiers": [
           "RHEL-07-010070",
+          "RHEL-07-040160",
           "SRG-OS-000029-GPOS-00010",
-          "CCI-000057"
+          "SRG-OS-000163-GPOS-00072",
+          "CCI-000057",
+          "CCI-000361",
+          "CCI-001133"
         ],
-        "value": 15
+        "oval-ids": [
+          "xccdf_org:ssgproject:content_rule_accounts_tmout"
+        ],
+        "value": 10
       },
       "useradd::etc_profile::umask": {
         "identifiers": [
@@ -1887,6 +2046,9 @@
           "RHEL-07-020630",
           "SRG-OS-000480-GPOS-00227",
           "CCI-000366"
+        ],
+        "oval-ids": [
+          "xccdf_org:ssgproject:content_rule_accounts_have_homedir_login_defs"
         ],
         "value": true
       },
@@ -2022,7 +2184,10 @@
           "SRG-OS-000076-GPOS-00044",
           "CCI-000199"
         ],
-        "value": 180
+        "oval-ids": [
+          "xccdf_org:ssgproject:content_rule_accounts_maximum_age_login_defs"
+        ],
+        "value": 60
       },
       "useradd::login_defs::pass_min_days": {
         "identifiers": [
@@ -2053,7 +2218,10 @@
           "CCI-001813",
           "CCI-001814"
         ],
-        "value": "0077"
+        "oval-ids": [
+          "xccdf_org:ssgproject:content_rule_accounts_umask_etc_login_defs"
+        ],
+        "value": "077"
       },
       "useradd::shells_default": {
         "identifiers": [
@@ -2235,6 +2403,9 @@
         "identifiers": [
           "SI-3(a)"
         ],
+        "oval-ids": [
+          "xccdf_org:ssgproject:content_rule_install_mcafee_antivirus"
+        ],
         "value": true
       },
       "simp_options::fips": {
@@ -2249,6 +2420,9 @@
       "simp_options::firewall": {
         "identifiers": [
           "AC-4"
+        ],
+        "oval-ids": [
+          "xccdf_org:ssgproject:content_rule_service_firewalld_enabled"
         ],
         "value": true
       },
@@ -2350,10 +2524,16 @@
           "CCI-002617",
           "SRG-OS-0000437-GPOS-00194"
         ],
+        "oval-ids": [
+          "xccdf_org:ssgproject:content_rule_clean_components_post_updating",
+          "xccdf_org:ssgproject:content_rule_ensure_gpgcheck_repo_metadata",
+          "xccdf_org:ssgproject:content_rule_ensure_gpgcheck_never_disabled"
+        ],
         "value": {
           "localpkg_gpgcheck": true,
           "gpgcheck": true,
-          "clean_requirements_on_remove": true
+          "clean_requirements_on_remove": true,
+          "repo_gpgcheck": true
         }
       }
     }

--- a/data/compliance_profiles/RedHat/7/nist_800_53_rev4.json
+++ b/data/compliance_profiles/RedHat/7/nist_800_53_rev4.json
@@ -2109,6 +2109,7 @@
             "sudo",
             "sudosh",
             "yum",
+            "audispd",
             "auditd",
             "audit",
             "systemd",
@@ -2122,6 +2123,7 @@
             "*.emerg"
           ],
           "msg_starts": [
+            " IPT:",
             "IPT:"
           ],
           "msg_regex": [

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-compliance_markup",
-  "version": "2.3.4",
+  "version": "2.3.3",
   "author": "SIMP Team",
   "summary": "Compliance-mapping annotation for Puppet code",
   "license": "Apache-2.0",


### PR DESCRIPTION
- Consolidated duplicate entries for useradd::etc_profile::session_timeout
  and pam::fail_interval on CentOS7 disa_stig.json
- Copied over more current CentOS7 disa_stig.json to RedHat7.
  This fixed the TMOUT setting problem.
- Added missing audispd program to simp_rsyslog::default_logs
- Added missing ' IPT:' message start to simp_ryslog::default_logs.
  This is required for iptables violation messages because some
  versions of rsyslog add a space separating the message
  timestamp/id and the message.
- Fixed unnecessary version bump for an unreleased change.

SIMP-4421 #close