### PR TITLE
(SIMP-4840) Fix useradd::useradd::inactive in DISA STIG profiles

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,5 @@
 * Fri Apr 27 2018 Liz Nemsick <lnemsick.simp@gmail.com> - 2.3.4-0
-- Fixed the inappropriate value of useradd::userad::inactive in
+- Fixed the inappropriate value of useradd::useradd::inactive in
   the DISA STIG profiles.  It is now set to 0.
 
 * Fri Mar 30 2018 Trevor Vaughan <tvaughan@onyxpoint.com> - 2.3.4-0

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+* Fri Apr 27 2018 Liz Nemsick <lnemsick.simp@gmail.com> - 2.3.4-0
+- Fixed the inappropriate value of useradd::userad::inactive in
+  the DISA STIG profiles.  It is now set to 0.
+
 * Fri Mar 30 2018 Trevor Vaughan <tvaughan@onyxpoint.com> - 2.3.4-0
 - Fixed issues with the compliance_map logic that were causing false results to
   be added to the 'documented_missing_parameters' and

--- a/data/compliance_profiles/CentOS/7/disa_stig.json
+++ b/data/compliance_profiles/CentOS/7/disa_stig.json
@@ -1963,7 +1963,7 @@
         "oval-ids": [
           "xccdf_org:ssgproject:content_rule_account_disable_post_pw_expiration"
         ],
-        "value": 35
+        "value": 0
       },
       "useradd::etc_profile::session_timeout": {
         "identifiers": [

--- a/data/compliance_profiles/RedHat/7/disa_stig.json
+++ b/data/compliance_profiles/RedHat/7/disa_stig.json
@@ -1963,7 +1963,7 @@
         "oval-ids": [
           "xccdf_org:ssgproject:content_rule_account_disable_post_pw_expiration"
         ],
-        "value": 35
+        "value": 0
       },
       "useradd::etc_profile::session_timeout": {
         "identifiers": [


### PR DESCRIPTION
Value now set to 0.

SIMP-4840 #close
SIMP-4841 #close