### PR TITLE
(SIMP-4697) Enable svckill in STIG and NIST

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+* Mon Apr 30 2018 Trevor Vaughan <tvaughan@onyxpoint.com> - 2.3.4-0
+- Added 'svckill::mode' to be 'enforcing' in STIG and 800-53 modes
+
 * Fri Apr 27 2018 Liz Nemsick <lnemsick.simp@gmail.com> - 2.3.4-0
 - Fixed the inappropriate value of useradd::useradd::inactive in
   the DISA STIG profiles.  It is now set to 0.

--- a/data/compliance_profiles/CentOS/7/disa_stig.json
+++ b/data/compliance_profiles/CentOS/7/disa_stig.json
@@ -2536,6 +2536,12 @@
         ],
         "notes": "This will probably change in the future to a class inclusion method that is more clear"
       },
+      "svckill::mode": {
+        "identifiers": [
+          "CCI-000381"
+        ],
+        "value": "enforcing"
+      },
       "yum::config_options": {
         "identifiers": [
           "CCI-002617",

--- a/data/compliance_profiles/CentOS/7/nist_800_53_rev4.json
+++ b/data/compliance_profiles/CentOS/7/nist_800_53_rev4.json
@@ -2472,6 +2472,12 @@
         ],
         "value": true
       },
+      "svckill::mode": {
+        "identifiers": [
+          "CM-7"
+        ],
+        "value": "enforcing"
+      },
       "tpm::ima::enable": {
         "identifiers": [
           "AC-25",

--- a/data/compliance_profiles/RedHat/7/disa_stig.json
+++ b/data/compliance_profiles/RedHat/7/disa_stig.json
@@ -2536,6 +2536,12 @@
         ],
         "notes": "This will probably change in the future to a class inclusion method that is more clear"
       },
+      "svckill::mode": {
+        "identifiers": [
+          "CCI-000381"
+        ],
+        "value": "enforcing"
+      },
       "yum::config_options": {
         "identifiers": [
           "CCI-002617",

--- a/data/compliance_profiles/RedHat/7/nist_800_53_rev4.json
+++ b/data/compliance_profiles/RedHat/7/nist_800_53_rev4.json
@@ -2472,6 +2472,12 @@
         ],
         "value": true
       },
+      "svckill::mode": {
+        "identifiers": [
+          "CM-7"
+        ],
+        "value": "enforcing"
+      },
       "tpm::ima::enable": {
         "identifiers": [
           "AC-25",


### PR DESCRIPTION
The DISA STIG and the NIST 800-53 require that no unnecessary services
be running on systems. `svckill` is our mechanism for enforcing this and
has been enabled in the compliance profiles.

SIMP-4717 #close