### PR TITLE
(SIMP-4725) Update simp::systctl values in compliance maps

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,9 @@
+* Wed May 16 2018 Liz Nemsick <lnemsick.simp@gmail.com> - 2.3.4-0
+- Added simp::sysctl entries to the DISA STIG profiles for
+  net.ipv4.conf.default.accept_source_route,
+  net.ipv4.conf.default.send_redirects, and
+  net.ipv6.conf.all.accept_source_route.
+
 * Fri May 04 2018 Jeanne Greulich <jeanne.greulich@onyxpoint.com> - 2.3.4-0
 - Added and updated ssh::server::conf entries for DISA STIG
  

--- a/data/compliance_profiles/CentOS/7/disa_stig.json
+++ b/data/compliance_profiles/CentOS/7/disa_stig.json
@@ -1162,6 +1162,22 @@
         ],
         "value": 0
       },
+      "simp::sysctl::net__ipv4__conf__default__accept_source_route": {
+        "identifiers": [
+          "RHEL-07-040620",
+          "SRG-OS-000480-GPOS-00227",
+          "CCI-000366"
+        ],
+        "value": 0
+      },
+      "simp::sysctl::net__ipv4__conf__default__send_redirects": {
+        "identifiers": [
+          "RHEL-07-040650",
+          "SRG-OS-000480-GPOS-00227",
+          "CCI-000366"
+        ],
+        "value": 0
+      },
       "simp::sysctl::net__ipv4__icmp_echo_ignore_broadcasts": {
         "identifiers": [
           "RHEL-07-040870",
@@ -1177,6 +1193,14 @@
           "CCI-000366"
         ],
         "value": 1
+      },
+      "simp::sysctl::net__ipv6__conf__all__accept_source_route": {
+        "identifiers": [
+          "RHEL-07-040830",
+          "SRG-OS-000480-GPOS-00227",
+          "CCI-000366"
+        ],
+        "value": 0
       },
       "simp::yum::enable_auto_updates": {
         "identifiers": [

--- a/data/compliance_profiles/RedHat/7/disa_stig.json
+++ b/data/compliance_profiles/RedHat/7/disa_stig.json
@@ -1162,6 +1162,22 @@
         ],
         "value": 0
       },
+      "simp::sysctl::net__ipv4__conf__default__accept_source_route": {
+        "identifiers": [
+          "RHEL-07-040620",
+          "SRG-OS-000480-GPOS-00227",
+          "CCI-000366"
+        ],
+        "value": 0
+      },
+      "simp::sysctl::net__ipv4__conf__default__send_redirects": {
+        "identifiers": [
+          "RHEL-07-040650",
+          "SRG-OS-000480-GPOS-00227",
+          "CCI-000366"
+        ],
+        "value": 0
+      },
       "simp::sysctl::net__ipv4__icmp_echo_ignore_broadcasts": {
         "identifiers": [
           "RHEL-07-040870",
@@ -1177,6 +1193,14 @@
           "CCI-000366"
         ],
         "value": 1
+      },
+      "simp::sysctl::net__ipv6__conf__all__accept_source_route": {
+        "identifiers": [
+          "RHEL-07-040830",
+          "SRG-OS-000480-GPOS-00227",
+          "CCI-000366"
+        ],
+        "value": 0
       },
       "simp::yum::enable_auto_updates": {
         "identifiers": [


### PR DESCRIPTION
Added simp::sysctl entries to the DISA STIG profiles for
net.ipv4.conf.default.accept_source_route,
net.ipv4.conf.default.send_redirects, and
net.ipv6.conf.all.accept_source_route.

SIMP-4725 #close