### PR TITLE
(SIMP-4769) Set auditd failure mode to 2 for STIG

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -197,6 +197,7 @@ acceptance-default:
   <<: *cache_bundler
   <<: *setup_env_beaker
   script:
+    - bundle exec rake spec_clean
     - bundle exec rake beaker:suites[default]
 
 acceptance-fips-default:
@@ -208,4 +209,5 @@ acceptance-fips-default:
   variables:
     BEAKER_fips: 'yes'
   script:
+    - bundle exec rake spec_clean
     - bundle exec rake beaker:suites[default]

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,10 @@
+* Wed Jun 06 2018 Liz Nemsick <lnemsick.simp@gmail.com> - 2.3.4-0
+- Added auditd::failure_mode entries for DISA STIG
+- Corrected auditd::enable identifiers in DISA STIG profiles 
+
 * Fri May 18 2018 Jeanne Greulich <jeanne.greulich@onyxpoint.com> - 2.3.4-0
 - Added postfix main.cf settings to el7 DISA STIG.
- 
+
 * Wed May 16 2018 Liz Nemsick <lnemsick.simp@gmail.com> - 2.3.4-0
 - Added aide::aliases entries for DISA STIG
 - Replaced OBE simp::yum::enable_auto_updates entries with

--- a/data/compliance_profiles/CentOS/7/disa_stig.json
+++ b/data/compliance_profiles/CentOS/7/disa_stig.json
@@ -306,14 +306,24 @@
       },
       "auditd::enable": {
         "identifiers": [
-          "RHEL-07-030010",
+          "RHEL-07-030000",
           "SRG-OS-000038-GPOS-00016",
           "SRG-OS-000039-GPOS-00017",
           "SRG-OS-000042-GPOS-00021",
-          "CCI-000131",
+          "SRG-OS-000254-GPOS-00095",
+          "SRG-OS-000255-GPOS-00096",
           "CCI-000126"
         ],
         "value": true
+      },
+      "auditd::failure_mode": {
+        "identifiers": [
+          "RHEL-07-030010",
+          "SRG-OS-000046-GPOS-00022",
+          "SRG-OS-000047-GPOS-00023",
+          "CCI: CCI-000139"
+        ],
+        "value": 2
       },
       "auditd::package_name": {
         "identifiers": [

--- a/data/compliance_profiles/RedHat/7/disa_stig.json
+++ b/data/compliance_profiles/RedHat/7/disa_stig.json
@@ -306,14 +306,24 @@
       },
       "auditd::enable": {
         "identifiers": [
-          "RHEL-07-030010",
+          "RHEL-07-030000",
           "SRG-OS-000038-GPOS-00016",
           "SRG-OS-000039-GPOS-00017",
           "SRG-OS-000042-GPOS-00021",
-          "CCI-000131",
+          "SRG-OS-000254-GPOS-00095",
+          "SRG-OS-000255-GPOS-00096",
           "CCI-000126"
         ],
         "value": true
+      },
+      "auditd::failure_mode": {
+        "identifiers": [
+          "RHEL-07-030010",
+          "SRG-OS-000046-GPOS-00022",
+          "SRG-OS-000047-GPOS-00023",
+          "CCI: CCI-000139"
+        ],
+        "value": 2
       },
       "auditd::package_name": {
         "identifiers": [


### PR DESCRIPTION
DISA STIG profile updates:
- Added auditd::failure_mode entries
- Corrected auditd::enable identifiers

SIMP-4769 #close