### PR TITLE
(SIMP-4760) Add `audit_session_files` to STIG maps

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -48,8 +48,8 @@
     - bundle exec rake pkg:compare_latest_tag
     - bundle exec rake lint
     - bundle exec rake clean
-    - bundle ruby -r json -e 'Dir.glob("**/*.json").map{|j| puts "Attempting to load #{j}";JSON.load(File.new(j))}'
-    - bundle ruby -r yaml -e 'Dir.glob("**/*.y{,a}ml").map{|y| puts "Attempting to load #{y}";YAML.load(File.new(y))}'
+    - ruby -r json -e 'Dir.glob("**/*.json").map{|j| puts "Attempting to load "+j;JSON.load(File.new(j))}'
+    - ruby -r yaml -e 'Dir.glob("**/*.y{,a}ml").map{|y| puts "Attempting to load "+y;YAML.load(File.new(y))}'
     - bundle exec puppet module build
 
 .spec_tests: &spec_tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,6 @@ before_install:
 jobs:
   allow_failures:
     - env: STRICT_VARIABLES=yes TRUSTED_NODE_DATA=yes PUPPET_VERSION="~> 5.0"
-    # SIMP-4516 has been entered to fix the test that won't run in docker
 
   include:
     - stage: check

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,6 @@ jobs:
   allow_failures:
     - env: STRICT_VARIABLES=yes TRUSTED_NODE_DATA=yes PUPPET_VERSION="~> 5.0"
     # SIMP-4516 has been entered to fix the test that won't run in docker
-    - stage: acceptance
 
   include:
     - stage: check

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,10 +1,15 @@
+* Wed Jun 06 2018 Chris Tessmer <chris.tessmer@onyxpoint.com> - 2.3.5-0
+- Added auditd::config::audit_profiles::simp::audit_session_files and
+  auditd::config::audit_profiles::simp::audit_session_files_tag entries
+  for DISA STIG
+
 * Wed Jun 06 2018 Liz Nemsick <lnemsick.simp@gmail.com> - 2.3.4-0
 - Added auditd::config::audit_profiles::simp::audit_sudoers entries
   for DISA STIG
 - Added auditd::failure_mode entries for DISA STIG
 - Added auditd::config::audit_profiles::simp::audit_selinux_cmds
   entries for DISA STIG.
-- Corrected auditd::enable identifiers in DISA STIG profiles 
+- Corrected auditd::enable identifiers in DISA STIG profiles
 
 * Fri May 18 2018 Jeanne Greulich <jeanne.greulich@onyxpoint.com> - 2.3.4-0
 - Added postfix main.cf settings to el7 DISA STIG.

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,4 @@
-* Wed Jun 06 2018 Chris Tessmer <chris.tessmer@onyxpoint.com> - 2.3.5-0
+* Wed Jun 06 2018 Chris Tessmer <chris.tessmer@onyxpoint.com> - 2.3.4-0
 - Added auditd::config::audit_profiles::simp::audit_session_files and
   auditd::config::audit_profiles::simp::audit_session_files_tag entries
   for DISA STIG

--- a/Gemfile
+++ b/Gemfile
@@ -16,8 +16,8 @@ group :test do
   gem 'puppet-strings'
   gem 'puppet-lint-empty_string-check',   :require => false
   gem 'puppet-lint-trailing_comma-check', :require => false
-  gem 'simp-rspec-puppet-facts', ENV.fetch('SIMP_RSPEC_PUPPET_FACTS_VERSION', '~> 2.0.0')
-  gem 'simp-rake-helpers', ENV.fetch('SIMP_RAKE_HELPERS_VERSION', ['>= 5.2', '< 6.0'])
+  gem 'simp-rspec-puppet-facts', ENV.fetch('SIMP_RSPEC_PUPPET_FACTS_VERSION', '~> 2.0')
+  gem 'simp-rake-helpers', ENV.fetch('SIMP_RAKE_HELPERS_VERSION', '~> 5')
   gem 'semantic_puppet'
 end
 
@@ -31,5 +31,5 @@ end
 group :system_tests do
   gem 'beaker'
   gem 'beaker-rspec'
-  gem 'simp-beaker-helpers', ENV.fetch('SIMP_BEAKER_HELPERS_VERSION', ['>= 1.10', '< 2.0'])
+  gem 'simp-beaker-helpers', ENV.fetch('SIMP_BEAKER_HELPERS_VERSION', ['>= 1.8.4', '< 2.0'])
 end

--- a/Gemfile
+++ b/Gemfile
@@ -17,7 +17,7 @@ group :test do
   gem 'puppet-lint-empty_string-check',   :require => false
   gem 'puppet-lint-trailing_comma-check', :require => false
   gem 'simp-rspec-puppet-facts', ENV.fetch('SIMP_RSPEC_PUPPET_FACTS_VERSION', '~> 2.0')
-  gem 'simp-rake-helpers', ENV.fetch('SIMP_RAKE_HELPERS_VERSION', '~> 5')
+  gem 'simp-rake-helpers', ENV.fetch('SIMP_RAKE_HELPERS_VERSION', ['>= 5.2', '< 6.0'])
   gem 'semantic_puppet'
 end
 
@@ -31,5 +31,5 @@ end
 group :system_tests do
   gem 'beaker'
   gem 'beaker-rspec'
-  gem 'simp-beaker-helpers', ENV.fetch('SIMP_BEAKER_HELPERS_VERSION', ['>= 1.8.4', '< 2.0'])
+  gem 'simp-beaker-helpers', ENV.fetch('SIMP_BEAKER_HELPERS_VERSION', ['>= 1.10', '< 2.0'])
 end

--- a/data/compliance_profiles/CentOS/7/disa_stig.json
+++ b/data/compliance_profiles/CentOS/7/disa_stig.json
@@ -265,10 +265,10 @@
           "SRG-OS-000392-GPOS-00172",
           "SRG-OS-000470-GPOS-00214",
           "SRG-OS-000473-GPOS-00218",
-          "RHEL-07-030610"
+          "RHEL-07-030600"
         ],
         "oval-ids": [
-          "xccdf_org:ssgproject:content_rule_audit_rules_login_events_faillock"
+          "xccdf_org:ssgproject:content_rule_audit_rules_login_events_tallylog"
         ],
         "notes": "The SIMP profile applies a base set of audit rules that adhere to guidance from several sources",
         "value": true
@@ -278,10 +278,10 @@
           "SRG-OS-000392-GPOS-00172",
           "SRG-OS-000470-GPOS-00214",
           "SRG-OS-000473-GPOS-00218",
-          "RHEL-07-030610"
+          "RHEL-07-030600"
         ],
         "oval-ids": [
-          "xccdf_org:ssgproject:content_rule_audit_rules_login_events_faillock"
+          "xccdf_org:ssgproject:content_rule_audit_rules_login_events_tallylog"
         ],
         "notes": "The SIMP profile applies a base set of audit rules that adhere to guidance from several sources",
         "value": "logins"

--- a/data/compliance_profiles/CentOS/7/disa_stig.json
+++ b/data/compliance_profiles/CentOS/7/disa_stig.json
@@ -252,6 +252,32 @@
         ],
         "value": true
       },
+      "auditd::config::audit_profiles::simp::audit_session_files": {
+        "identifiers": [
+          "SRG-OS-000392-GPOS-00172",
+          "SRG-OS-000470-GPOS-00214",
+          "SRG-OS-000473-GPOS-00218",
+          "RHEL-07-030610"
+        ],
+        "oval-ids": [
+          "xccdf_org:ssgproject:content_rule_audit_rules_login_events_faillock"
+        ],
+        "notes": "The SIMP profile applies a base set of audit rules that adhere to guidance from several sources",
+        "value": true
+      },
+      "auditd::config::audit_profiles::simp::audit_session_files_tag": {
+        "identifiers": [
+          "SRG-OS-000392-GPOS-00172",
+          "SRG-OS-000470-GPOS-00214",
+          "SRG-OS-000473-GPOS-00218",
+          "RHEL-07-030610"
+        ],
+        "oval-ids": [
+          "xccdf_org:ssgproject:content_rule_audit_rules_login_events_faillock"
+        ],
+        "notes": "The SIMP profile applies a base set of audit rules that adhere to guidance from several sources",
+        "value": "logins"
+      },
       "auditd::config::audit_profiles::simp::audit_su_root_activity": {
         "identifiers": [
           "SRG-OS-000327-GPOS-00127",

--- a/data/compliance_profiles/RedHat/7/disa_stig.json
+++ b/data/compliance_profiles/RedHat/7/disa_stig.json
@@ -265,10 +265,10 @@
           "SRG-OS-000392-GPOS-00172",
           "SRG-OS-000470-GPOS-00214",
           "SRG-OS-000473-GPOS-00218",
-          "RHEL-07-030610"
+          "RHEL-07-030600"
         ],
         "oval-ids": [
-          "xccdf_org:ssgproject:content_rule_audit_rules_login_events_faillock"
+          "xccdf_org:ssgproject:content_rule_audit_rules_login_events_tallylog"
         ],
         "notes": "The SIMP profile applies a base set of audit rules that adhere to guidance from several sources",
         "value": true
@@ -278,10 +278,10 @@
           "SRG-OS-000392-GPOS-00172",
           "SRG-OS-000470-GPOS-00214",
           "SRG-OS-000473-GPOS-00218",
-          "RHEL-07-030610"
+          "RHEL-07-030600"
         ],
         "oval-ids": [
-          "xccdf_org:ssgproject:content_rule_audit_rules_login_events_faillock"
+          "xccdf_org:ssgproject:content_rule_audit_rules_login_events_tallylog"
         ],
         "notes": "The SIMP profile applies a base set of audit rules that adhere to guidance from several sources",
         "value": "logins"

--- a/data/compliance_profiles/RedHat/7/disa_stig.json
+++ b/data/compliance_profiles/RedHat/7/disa_stig.json
@@ -252,6 +252,32 @@
         ],
         "value": true
       },
+      "auditd::config::audit_profiles::simp::audit_session_files": {
+        "identifiers": [
+          "SRG-OS-000392-GPOS-00172",
+          "SRG-OS-000470-GPOS-00214",
+          "SRG-OS-000473-GPOS-00218",
+          "RHEL-07-030610"
+        ],
+        "oval-ids": [
+          "xccdf_org:ssgproject:content_rule_audit_rules_login_events_faillock"
+        ],
+        "notes": "The SIMP profile applies a base set of audit rules that adhere to guidance from several sources",
+        "value": true
+      },
+      "auditd::config::audit_profiles::simp::audit_session_files_tag": {
+        "identifiers": [
+          "SRG-OS-000392-GPOS-00172",
+          "SRG-OS-000470-GPOS-00214",
+          "SRG-OS-000473-GPOS-00218",
+          "RHEL-07-030610"
+        ],
+        "oval-ids": [
+          "xccdf_org:ssgproject:content_rule_audit_rules_login_events_faillock"
+        ],
+        "notes": "The SIMP profile applies a base set of audit rules that adhere to guidance from several sources",
+        "value": "logins"
+      },
       "auditd::config::audit_profiles::simp::audit_su_root_activity": {
         "identifiers": [
           "SRG-OS-000327-GPOS-00127",

--- a/spec/acceptance/suites/default/00_default_spec.rb
+++ b/spec/acceptance/suites/default/00_default_spec.rb
@@ -56,11 +56,7 @@ EOS
         tmpdir = Dir.mktmpdir
         begin
           Dir.chdir(tmpdir) do
-            if host[:hypervisor] == 'docker'
-              %x(docker cp "#{host.hostname}:/opt/puppetlabs/puppet/cache/simp/compliance_reports/#{fqdn}/compliance_report.json" .)
-            else
-              scp_from(host, "/opt/puppetlabs/puppet/cache/simp/compliance_reports/#{fqdn}/compliance_report.json", '.')
-            end
+            scp_from(host, "/opt/puppetlabs/puppet/cache/simp/compliance_reports/#{fqdn}/compliance_report.json", '.')
 
             expect {
               @compliance_data[:report] = JSON.load(File.read('compliance_report.json'))


### PR DESCRIPTION
This adds `auditd::config::audit_profiles::simp::audit_session_files`
and `auditd::config::audit_profiles::simp::audit_session_files_tag`
to the EL7 STIG mappings.

Note that `auditd::...::simp::audit_session_files` governs audit rules
for four files:

- /var/run/utmp
- /var/log/btmp
- /var/log/wtmp
- /var/log/tallylog

However, the only STIG finding that deals with these files is
[V-72143, version RHEL-07-030600][0], which only recommends checking
`/var/log/tallylog` on RHEL7:

> Verify the operating system generates audit records when
> successful/unsuccessful account access count events occur.
>
> Check the file system rule in "/etc/audit/audit.rules" with the
> following commands:
>
> # grep -i /var/log/tallylog /etc/audit/audit.rules
>
> -w /var/log/tallylog -p wa -k logins
>
> If the command does not return any output, this is a finding.

Note that this also changes the four files' audit filter key (`-k`) from
`sessions` to `logins`.

There is no equivilent requirement in the RHEL6 STIG.

[0]: https://www.stigviewer.com/stig/red_hat_enterprise_linux_7/2017-07-08/finding/V-72143

SIMP-4759 #close
SIMP-4760 #close