### PR TITLE
(SIMP-4952) Add map data for recent auditd changes

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,16 +1,24 @@
+* Mon Jun 11 2018 Nick Miller <nick.miller@onyxpoint.com> - 2.3.4-0
+- DISA STIG changes:
+  - Added auditd::config::audit_profiles::simp::audit_crontab_cmd
+  - Added auditd::config::audit_profiles::simp::audit_pam_timestamp_check_cmd
+  - Added auditd::config::audit_profiles::simp::audit_passwd_cmds
+  - Added auditd::config::audit_profiles::simp::audit_postfix_cmds
+  - Added auditd::config::audit_profiles::simp::audit_priv_cmds
+  - Added auditd::config::audit_profiles::simp::audit_ssh_keysign_cmd
+
 * Wed Jun 06 2018 Chris Tessmer <chris.tessmer@onyxpoint.com> - 2.3.4-0
-- Added auditd::config::audit_profiles::simp::audit_session_files and
-  auditd::config::audit_profiles::simp::audit_session_files_tag entries
-  for DISA STIG
+- DISA STIG changes:
+  - Added auditd::config::audit_profiles::simp::audit_session_files
+  - Added auditd::config::audit_profiles::simp::audit_session_files_tag
 
 * Wed Jun 06 2018 Liz Nemsick <lnemsick.simp@gmail.com> - 2.3.4-0
-- Added auditd::action_mail_acct entries for DISA STIG
-- Added auditd::config::audit_profiles::simp::audit_sudoers entries
-  for DISA STIG
-- Added auditd::config::audit_profiles::simp::audit_selinux_cmds
-  entries for DISA STIG.
-- Added auditd::failure_mode entries for DISA STIG
-- Corrected auditd::enable identifiers in DISA STIG profiles 
+- DISA STIG changes:
+  - Added auditd::action_mail_acct entries
+  - Added auditd::config::audit_profiles::simp::audit_sudoers
+  - Added auditd::config::audit_profiles::simp::audit_selinux_cmds
+  - Added auditd::failure_mode
+  - Corrected auditd::enable identifiers
 
 * Fri May 18 2018 Jeanne Greulich <jeanne.greulich@onyxpoint.com> - 2.3.4-0
 - Added postfix main.cf settings to el7 DISA STIG.

--- a/data/compliance_profiles/CentOS/7/disa_stig.json
+++ b/data/compliance_profiles/CentOS/7/disa_stig.json
@@ -215,6 +215,16 @@
         ],
         "value": true
       },
+      "auditd::config::audit_profiles::simp::audit_crontab_cmd": {
+        "identifiers": [
+          "AU-2",
+          "SRG-OS-000042-GPOS-00020",
+          "SRG-OS-000392-GPOS-00172",
+          "SRG-OS-000471-GPOS-00215",
+          "CCI-000135"
+        ],
+        "value": true
+      },
       "auditd::config::audit_profiles::simp::audit_kernel_modules": {
         "identifiers": [
           "SRG-OS-000471-GPOS-00216",
@@ -245,6 +255,45 @@
         ],
         "oval-ids": [
           "xccdf_org:ssgproject:content_rule_audit_rules_login_events_faillock"
+        ],
+        "value": true
+      },
+      "auditd::config::audit_profiles::simp::audit_pam_timestamp_check_cmd": {
+        "identifiers": [
+          "AU-2",
+          "SRG-OS-000471-GPOS-00215",
+          "CCI-000172"
+        ],
+        "value": true
+      },
+      "auditd::config::audit_profiles::simp::audit_passwd_cmds": {
+        "identifiers": [
+          "AU-2",
+          "SRG-OS-000042-GPOS-00020",
+          "SRG-OS-000392-GPOS-00172",
+          "SRG-OS-000471-GPOS-00215",
+          "CCI-000135"
+        ],
+        "value": true
+      },
+      "auditd::config::audit_profiles::simp::audit_postfix_cmds": {
+        "identifiers": [
+          "AU-2",
+          "SRG-OS-000042-GPOS-00020",
+          "SRG-OS-000392-GPOS-00172",
+          "CCI-000135"
+        ],
+        "value": true
+      },
+      "auditd::config::audit_profiles::simp::audit_priv_cmds": {
+        "identifiers": [
+          "AU-2",
+          "SRG-OS-000037-GPOS-00015",
+          "SRG-OS-000042-GPOS-00020",
+          "SRG-OS-000392-GPOS-00172",
+          "SRG-OS-000462-GPOS-00206",
+          "SRG-OS-000471-GPOS-00215",
+          "CCI-000130"
         ],
         "value": true
       },
@@ -285,6 +334,16 @@
         ],
         "notes": "The SIMP profile applies a base set of audit rules that adhere to guidance from several sources",
         "value": "logins"
+      },
+      "auditd::config::audit_profiles::simp::audit_ssh_keysign_cmd": {
+        "identifiers": [
+          "AU-2",
+          "SRG-OS-000042-GPOS-00020",
+          "SRG-OS-000392-GPOS-00172",
+          "SRG-OS-000471-GPOS-00215",
+          "CCI-000135"
+        ],
+        "value": true
       },
       "auditd::config::audit_profiles::simp::audit_su_root_activity": {
         "identifiers": [

--- a/data/compliance_profiles/RedHat/7/disa_stig.json
+++ b/data/compliance_profiles/RedHat/7/disa_stig.json
@@ -215,6 +215,16 @@
         ],
         "value": true
       },
+      "auditd::config::audit_profiles::simp::audit_crontab_cmd": {
+        "identifiers": [
+          "AU-2",
+          "SRG-OS-000042-GPOS-00020",
+          "SRG-OS-000392-GPOS-00172",
+          "SRG-OS-000471-GPOS-00215",
+          "CCI-000135"
+        ],
+        "value": true
+      },
       "auditd::config::audit_profiles::simp::audit_kernel_modules": {
         "identifiers": [
           "SRG-OS-000471-GPOS-00216",
@@ -245,6 +255,45 @@
         ],
         "oval-ids": [
           "xccdf_org:ssgproject:content_rule_audit_rules_login_events_faillock"
+        ],
+        "value": true
+      },
+      "auditd::config::audit_profiles::simp::audit_pam_timestamp_check_cmd": {
+        "identifiers": [
+          "AU-2",
+          "SRG-OS-000471-GPOS-00215",
+          "CCI-000172"
+        ],
+        "value": true
+      },
+      "auditd::config::audit_profiles::simp::audit_passwd_cmds": {
+        "identifiers": [
+          "AU-2",
+          "SRG-OS-000042-GPOS-00020",
+          "SRG-OS-000392-GPOS-00172",
+          "SRG-OS-000471-GPOS-00215",
+          "CCI-000135"
+        ],
+        "value": true
+      },
+      "auditd::config::audit_profiles::simp::audit_postfix_cmds": {
+        "identifiers": [
+          "AU-2",
+          "SRG-OS-000042-GPOS-00020",
+          "SRG-OS-000392-GPOS-00172",
+          "CCI-000135"
+        ],
+        "value": true
+      },
+      "auditd::config::audit_profiles::simp::audit_priv_cmds": {
+        "identifiers": [
+          "AU-2",
+          "SRG-OS-000037-GPOS-00015",
+          "SRG-OS-000042-GPOS-00020",
+          "SRG-OS-000392-GPOS-00172",
+          "SRG-OS-000462-GPOS-00206",
+          "SRG-OS-000471-GPOS-00215",
+          "CCI-000130"
         ],
         "value": true
       },
@@ -285,6 +334,16 @@
         ],
         "notes": "The SIMP profile applies a base set of audit rules that adhere to guidance from several sources",
         "value": "logins"
+      },
+      "auditd::config::audit_profiles::simp::audit_ssh_keysign_cmd": {
+        "identifiers": [
+          "AU-2",
+          "SRG-OS-000042-GPOS-00020",
+          "SRG-OS-000392-GPOS-00172",
+          "SRG-OS-000471-GPOS-00215",
+          "CCI-000135"
+        ],
+        "value": true
       },
       "auditd::config::audit_profiles::simp::audit_su_root_activity": {
         "identifiers": [


### PR DESCRIPTION
Add data to the DIS STIG items:
- Added auditd::config::audit_profiles::simp::audit_crontab_cmd
- Added auditd::config::audit_profiles::simp::audit_pam_timestamp_check_cmd
- Added auditd::config::audit_profiles::simp::audit_passwd_cmds
- Added auditd::config::audit_profiles::simp::audit_postfix_cmds
- Added auditd::config::audit_profiles::simp::audit_priv_cmds
- Added auditd::config::audit_profiles::simp::audit_ssh_keysign_cmd

SIMP-4952 #close