### PR TITLE
(SIMP-5490) Fix incorrect parameter types simp::yum::schedule

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,8 @@
+* Fri Oct 19 2018 Liz Nemsick <lnemsick.simp@gmail.com> - 2.4.1-0
+- Fixed the following incorrect parameter types
+  - simp::yum::schedule::minute
+  - simp::yum::schedule::hour
+
 * Thu Sep 20 2018 Dylan Cochran <dylan.cochran@onyxpoint.com> - 2.4.0-0
 - Open-Source SCE version 2.0
   - Add bugfix for environments that are just Strings vs Environment objects.

--- a/data/compliance_profiles/CentOS/7/disa_stig.json
+++ b/data/compliance_profiles/CentOS/7/disa_stig.json
@@ -1783,7 +1783,7 @@
           "CCI-000366"
         ],
         "notes": "The actual hour value can differ, as long as it does not disable the update cron job.",
-        "value": 0
+        "value": "0"
       },
       "simp::yum::schedule::minute": {
         "identifiers": [
@@ -1792,7 +1792,7 @@
           "CCI-000366"
         ],
         "notes": "The actual minute value can differ, as long as it does not disable the update cron job.",
-        "value": 12
+        "value": "12"
       },
       "simp_apache::conf::group": {
         "identifiers": [

--- a/data/compliance_profiles/OracleLinux/7/disa_stig.json
+++ b/data/compliance_profiles/OracleLinux/7/disa_stig.json
@@ -1783,7 +1783,7 @@
           "CCI-000366"
         ],
         "notes": "The actual hour value can differ, as long as it does not disable the update cron job.",
-        "value": 0
+        "value": "0"
       },
       "simp::yum::schedule::minute": {
         "identifiers": [
@@ -1792,7 +1792,7 @@
           "CCI-000366"
         ],
         "notes": "The actual minute value can differ, as long as it does not disable the update cron job.",
-        "value": 12
+        "value": "12"
       },
       "simp_apache::conf::group": {
         "identifiers": [

--- a/data/compliance_profiles/RedHat/7/disa_stig.json
+++ b/data/compliance_profiles/RedHat/7/disa_stig.json
@@ -1783,7 +1783,7 @@
           "CCI-000366"
         ],
         "notes": "The actual hour value can differ, as long as it does not disable the update cron job.",
-        "value": 0
+        "value": "0"
       },
       "simp::yum::schedule::minute": {
         "identifiers": [
@@ -1792,7 +1792,7 @@
           "CCI-000366"
         ],
         "notes": "The actual minute value can differ, as long as it does not disable the update cron job.",
-        "value": 12
+        "value": "12"
       },
       "simp_apache::conf::group": {
         "identifiers": [

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-compliance_markup",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "author": "SIMP Team",
   "summary": "Compliance-mapping annotation for Puppet code",
   "license": "Apache-2.0",


### PR DESCRIPTION
Fixed the following incorrect parameter types that were found
when getting the simp-core tests to work for SIMP 6.3.0:
- simp::\yum::schedule::minute
- simp::\yum::schedule::hour

SIMP-5490 #comment Fix compliance_markup mapping bugs