### PR TITLE
WIP: (SIMP-5526) Add NIST 800.53 Sub-controls to NIST 800.53 master control list

### DIFF
--- a/simp/compliance_profiles/nist_800_53_rev4/control-families.yaml
+++ b/simp/compliance_profiles/nist_800_53_rev4/control-families.yaml
@@ -1,6 +1,6 @@
 ---
 version: 2.0.0
-control-families:
+control_families:
   AC:
     standard: nist_800_53:rev4
     title: Access Control

--- a/simp/compliance_profiles/nist_800_53_rev4/controls.yaml
+++ b/simp/compliance_profiles/nist_800_53_rev4/controls.yaml
@@ -6,20 +6,41 @@ controls:
       name: nist_800_53:rev4
       template:
         confidentiality:
-          - HIGH
-          - MODERATE
-          - LOW
+        - HIGH
+        - MODERATE
+        - LOW
         integrity:
-          - HIGH
-          - MODERATE
-          - LOW
+        - HIGH
+        - MODERATE
+        - LOW
         availability:
-          - HIGH
-          - MODERATE
-          - LOW
+        - HIGH
+        - MODERATE
+        - LOW
     family: AC
     title: Access Control Policy And Procedures
-    description: "The organization develops, disseminates, and reviews/updates [Assignment: organizationdefined\nfrequency]:\na. A formal, documented access control policy that addresses purpose, scope, roles,\nresponsibilities, management commitment, coordination among organizational entities, and\ncompliance; and\nb. Formal, documented procedures to facilitate the implementation of the access control policy\nand associated access controls.\n\nSupplemental Guidance: This control addresses the establishment of policy and procedures for the\neffective implementation of selected security controls and control enhancements in the AC family.\nPolicy and procedures reflect applicable federal laws, Executive Orders, directives, regulations,\npolicies, standards, and guidance. Security program policies and procedures at the organization\nlevel may make the need for system-specific policies and procedures unnecessary. The policy can\nbe included as part of the general information security policy for organizations. The procedures\ncan be established for the security program in general and for particular information systems, if\nneeded. The organizational risk management strategy is a key factor in establishing policy and\nprocedures. Related control: PM-9.\n\nControl Enhancements: None.\n\nReferences: NIST Special Publications 800-12, 800-100.\n"
+    description: |
+      The organization develops, disseminates, and reviews/updates [Assignment: organizationdefined
+      frequency]:
+      a. A formal, documented access control policy that addresses purpose, scope, roles,
+      responsibilities, management commitment, coordination among organizational entities, and
+      compliance; and
+      b. Formal, documented procedures to facilitate the implementation of the access control policy
+      and associated access controls.
+
+      Supplemental Guidance: This control addresses the establishment of policy and procedures for the
+      effective implementation of selected security controls and control enhancements in the AC family.
+      Policy and procedures reflect applicable federal laws, Executive Orders, directives, regulations,
+      policies, standards, and guidance. Security program policies and procedures at the organization
+      level may make the need for system-specific policies and procedures unnecessary. The policy can
+      be included as part of the general information security policy for organizations. The procedures
+      can be established for the security program in general and for particular information systems, if
+      needed. The organizational risk management strategy is a key factor in establishing policy and
+      procedures. Related control: PM-9.
+
+      Control Enhancements: None.
+
+      References: NIST Special Publications 800-12, 800-100.
     notes: Implementation specific. Though listed in the Technical class, policy and
       procedural controls are established at the organizational level which drives
       technical implementation. SIMP can technically implement this control.
@@ -28,17 +49,17 @@ controls:
       name: nist_800_53:rev4
       template:
         confidentiality:
-          - HIGH
-          - MODERATE
-          - LOW
+        - HIGH
+        - MODERATE
+        - LOW
         integrity:
-          - HIGH
-          - MODERATE
-          - LOW
+        - HIGH
+        - MODERATE
+        - LOW
         availability:
-          - HIGH
-          - MODERATE
-          - LOW
+        - HIGH
+        - MODERATE
+        - LOW
     family: AC
     title: Account Management
     description: ''
@@ -48,17 +69,17 @@ controls:
       name: nist_800_53:rev4
       template:
         confidentiality:
-          - HIGH
-          - MODERATE
-          - LOW
+        - HIGH
+        - MODERATE
+        - LOW
         integrity:
-          - HIGH
-          - MODERATE
-          - LOW
+        - HIGH
+        - MODERATE
+        - LOW
         availability:
-          - HIGH
-          - MODERATE
-          - LOW
+        - HIGH
+        - MODERATE
+        - LOW
     family: AC
     title: Access Enforcement
     description: ''
@@ -68,15 +89,15 @@ controls:
       name: nist_800_53:rev4
       template:
         confidentiality:
-          - HIGH
-          - MODERATE
+        - HIGH
+        - MODERATE
         integrity:
-          - HIGH
-          - MODERATE
+        - HIGH
+        - MODERATE
         availability:
-          - HIGH
-          - MODERATE
-    specification:
+        - HIGH
+        - MODERATE
+    specification: 
     family: AC
     title: Information Flow Enforcement
     description: ''
@@ -86,14 +107,14 @@ controls:
       name: nist_800_53:rev4
       template:
         confidentiality:
-          - HIGH
-          - MODERATE
+        - HIGH
+        - MODERATE
         integrity:
-          - HIGH
-          - MODERATE
+        - HIGH
+        - MODERATE
         availability:
-          - HIGH
-          - MODERATE
+        - HIGH
+        - MODERATE
     family: AC
     title: Separation Of Duties
     description: ''
@@ -103,14 +124,14 @@ controls:
       name: nist_800_53:rev4
       template:
         confidentiality:
-          - HIGH
-          - MODERATE
+        - HIGH
+        - MODERATE
         integrity:
-          - HIGH
-          - MODERATE
+        - HIGH
+        - MODERATE
         availability:
-          - HIGH
-          - MODERATE
+        - HIGH
+        - MODERATE
     family: AC
     title: Least Privilege
     description: ''
@@ -118,6 +139,19 @@ controls:
   nist_800_53:rev4:AC-7:
     standard:
       name: nist_800_53:rev4
+      template:
+        confidentiality:
+        - HIGH
+        - MODERATE
+        - LOW
+        integrity:
+        - HIGH
+        - MODERATE
+        - LOW
+        availability:
+        - HIGH
+        - MODERATE
+        - LOW
     family: AC
     title: Unsuccessful Login Attempts
     description: ''
@@ -125,6 +159,19 @@ controls:
   nist_800_53:rev4:AC-8:
     standard:
       name: nist_800_53:rev4
+      template:
+        confidentiality:
+        - HIGH
+        - MODERATE
+        - LOW
+        integrity:
+        - HIGH
+        - MODERATE
+        - LOW
+        availability:
+        - HIGH
+        - MODERATE
+        - LOW
     family: AC
     title: System Use Notification
     description: ''
@@ -141,11 +188,11 @@ controls:
       name: nist_800_53:rev4
       template:
         confidentiality:
-          - HIGH
+        - HIGH
         integrity:
-          - HIGH
+        - HIGH
         availability:
-          - HIGH
+        - HIGH
     family: AC
     title: Concurrent Session Control
     description: ''
@@ -153,6 +200,16 @@ controls:
   nist_800_53:rev4:AC-11:
     standard:
       name: nist_800_53:rev4
+      template:
+        confidentiality:
+        - HIGH
+        - MODERATE
+        integrity:
+        - HIGH
+        - MODERATE
+        availability:
+        - HIGH
+        - MODERATE
     family: AC
     title: Session Lock
     description: ''
@@ -160,6 +217,16 @@ controls:
   nist_800_53:rev4:AC-12:
     standard:
       name: nist_800_53:rev4
+      template:
+        confidentiality:
+        - HIGH
+        - MODERATE
+        integrity:
+        - HIGH
+        - MODERATE
+        availability:
+        - HIGH
+        - MODERATE
     family: AC
     title: Session Termination
     description: ''
@@ -174,6 +241,19 @@ controls:
   nist_800_53:rev4:AC-14:
     standard:
       name: nist_800_53:rev4
+      template:
+        confidentiality:
+        - HIGH
+        - MODERATE
+        - LOW
+        integrity:
+        - HIGH
+        - MODERATE
+        - LOW
+        availability:
+        - HIGH
+        - MODERATE
+        - LOW
     family: AC
     title: Permitted Actions Without Identification Or Authentication
     description: ''
@@ -195,6 +275,19 @@ controls:
   nist_800_53:rev4:AC-17:
     standard:
       name: nist_800_53:rev4
+      template:
+        confidentiality:
+        - HIGH
+        - MODERATE
+        - LOW
+        integrity:
+        - HIGH
+        - MODERATE
+        - LOW
+        availability:
+        - HIGH
+        - MODERATE
+        - LOW
     family: AC
     title: Remote Access
     description: ''
@@ -202,6 +295,19 @@ controls:
   nist_800_53:rev4:AC-18:
     standard:
       name: nist_800_53:rev4
+      template:
+        confidentiality:
+        - HIGH
+        - MODERATE
+        - LOW
+        integrity:
+        - HIGH
+        - MODERATE
+        - LOW
+        availability:
+        - HIGH
+        - MODERATE
+        - LOW
     family: AC
     title: Wireless Access Restrictions
     description: ''
@@ -209,6 +315,19 @@ controls:
   nist_800_53:rev4:AC-19:
     standard:
       name: nist_800_53:rev4
+      template:
+        confidentiality:
+        - HIGH
+        - MODERATE
+        - LOW
+        integrity:
+        - HIGH
+        - MODERATE
+        - LOW
+        availability:
+        - HIGH
+        - MODERATE
+        - LOW
     family: AC
     title: Access Control For Portable And Mobile Devices
     description: ''
@@ -216,7 +335,78 @@ controls:
   nist_800_53:rev4:AC-20:
     standard:
       name: nist_800_53:rev4
+      template:
+        confidentiality:
+        - HIGH
+        - MODERATE
+        - LOW
+        integrity:
+        - HIGH
+        - MODERATE
+        - LOW
+        availability:
+        - HIGH
+        - MODERATE
+        - LOW
     family: AC
+    title: Information Sharing
+    description: ''
+    notes: N/A
+  nist_800_53:rev4:AC-21:
+    standard:
+      name: nist_800_53:rev4
+      template:
+        confidentiality:
+        - HIGH
+        - MODERATE
+        integrity:
+        - HIGH
+        - MODERATE
+        availability:
+        - HIGH
+        - MODERATE
+    family: AC
+    title: Publicly Accessible Content
+    description: ''
+    notes: N/A
+  nist_800_53:rev4:AC-22:
+    standard:
+      name: nist_800_53:rev4
+      template:
+        confidentiality:
+        - HIGH
+        - MODERATE
+        - LOW
+        integrity:
+        - HIGH
+        - MODERATE
+        - LOW
+        availability:
+        - HIGH
+        - MODERATE
+        - LOW
+    family: AC
+    title: Data Mining Protection
+    description: ''
+    notes: N/A
+  nist_800_53:rev4:AC-23:
+    standard:
+      name: nist_800_53:rev4
+    family: AC
+    title: Acccess Control Decisions
+    description: ''
+    notes: N/A
+  nist_800_53:rev4:AC-24:
+    standard:
+      name: nist_800_53:rev4
+    family: AC
+    title: Reference Monitor
+    description: ''
+    notes: N/A
+  nist_800_53:rev4:AC-25:
+    standard:
+      name: nist_800_53:rev4
+    family: AT
     title: Use Of External Information Systems
     description: ''
     notes: Considered a Operational Class control, this control is typically defined
@@ -224,6 +414,19 @@ controls:
   nist_800_53:rev4:AT-1:
     standard:
       name: nist_800_53:rev4
+      template:
+        confidentiality:
+        - HIGH
+        - MODERATE
+        - LOW
+        integrity:
+        - HIGH
+        - MODERATE
+        - LOW
+        availability:
+        - HIGH
+        - MODERATE
+        - LOW
     family: AT
     title: Security Awareness And Training Policy And Procedures
     description: ''
@@ -232,6 +435,19 @@ controls:
   nist_800_53:rev4:AT-2:
     standard:
       name: nist_800_53:rev4
+      template:
+        confidentiality:
+        - HIGH
+        - MODERATE
+        - LOW
+        integrity:
+        - HIGH
+        - MODERATE
+        - LOW
+        availability:
+        - HIGH
+        - MODERATE
+        - LOW
     family: AT
     title: Security Awareness
     description: ''
@@ -240,6 +456,19 @@ controls:
   nist_800_53:rev4:AT-3:
     standard:
       name: nist_800_53:rev4
+      template:
+        confidentiality:
+        - HIGH
+        - MODERATE
+        - LOW
+        integrity:
+        - HIGH
+        - MODERATE
+        - LOW
+        availability:
+        - HIGH
+        - MODERATE
+        - LOW
     family: AT
     title: Security Training
     description: ''
@@ -248,6 +477,19 @@ controls:
   nist_800_53:rev4:AT-4:
     standard:
       name: nist_800_53:rev4
+      template:
+        confidentiality:
+        - HIGH
+        - MODERATE
+        - LOW
+        integrity:
+        - HIGH
+        - MODERATE
+        - LOW
+        availability:
+        - HIGH
+        - MODERATE
+        - LOW
     family: AT
     title: Security Training Records
     description: ''
@@ -256,13 +498,26 @@ controls:
   nist_800_53:rev4:AT-5:
     standard:
       name: nist_800_53:rev4
-    family: AT
+    family: AU
     title: Contacts With Security Groups And Associations
     description: ''
     notes: N/A
   nist_800_53:rev4:AU-1:
     standard:
       name: nist_800_53:rev4
+      template:
+        confidentiality:
+        - HIGH
+        - MODERATE
+        - LOW
+        integrity:
+        - HIGH
+        - MODERATE
+        - LOW
+        availability:
+        - HIGH
+        - MODERATE
+        - LOW
     family: AU
     title: Audit And Accountability Policy And Procedures
     description: ''
@@ -272,6 +527,19 @@ controls:
   nist_800_53:rev4:AU-2:
     standard:
       name: nist_800_53:rev4
+      template:
+        confidentiality:
+        - HIGH
+        - MODERATE
+        - LOW
+        integrity:
+        - HIGH
+        - MODERATE
+        - LOW
+        availability:
+        - HIGH
+        - MODERATE
+        - LOW
     family: AU
     title: Auditable Events
     description: ''
@@ -279,6 +547,19 @@ controls:
   nist_800_53:rev4:AU-3:
     standard:
       name: nist_800_53:rev4
+      template:
+        confidentiality:
+        - HIGH
+        - MODERATE
+        - LOW
+        integrity:
+        - HIGH
+        - MODERATE
+        - LOW
+        availability:
+        - HIGH
+        - MODERATE
+        - LOW
     family: AU
     title: Content Of Audit Records
     description: ''
@@ -286,6 +567,19 @@ controls:
   nist_800_53:rev4:AU-4:
     standard:
       name: nist_800_53:rev4
+      template:
+        confidentiality:
+        - HIGH
+        - MODERATE
+        - LOW
+        integrity:
+        - HIGH
+        - MODERATE
+        - LOW
+        availability:
+        - HIGH
+        - MODERATE
+        - LOW
     family: AU
     title: Audit Storage Capacity
     description: ''
@@ -293,6 +587,19 @@ controls:
   nist_800_53:rev4:AU-5:
     standard:
       name: nist_800_53:rev4
+      template:
+        confidentiality:
+        - HIGH
+        - MODERATE
+        - LOW
+        integrity:
+        - HIGH
+        - MODERATE
+        - LOW
+        availability:
+        - HIGH
+        - MODERATE
+        - LOW
     family: AU
     title: Response To Audit Processing Failures
     description: ''
@@ -302,6 +609,19 @@ controls:
   nist_800_53:rev4:AU-6:
     standard:
       name: nist_800_53:rev4
+      template:
+        confidentiality:
+        - HIGH
+        - MODERATE
+        - LOW
+        integrity:
+        - HIGH
+        - MODERATE
+        - LOW
+        availability:
+        - HIGH
+        - MODERATE
+        - LOW
     family: AU
     title: Audit Monitoring, Analysis, And Reporting
     description: ''
@@ -309,6 +629,16 @@ controls:
   nist_800_53:rev4:AU-7:
     standard:
       name: nist_800_53:rev4
+      template:
+        confidentiality:
+        - HIGH
+        - MODERATE
+        integrity:
+        - HIGH
+        - MODERATE
+        availability:
+        - HIGH
+        - MODERATE
     family: AU
     title: Audit Reduction And Report Generation
     description: ''
@@ -316,6 +646,19 @@ controls:
   nist_800_53:rev4:AU-8:
     standard:
       name: nist_800_53:rev4
+      template:
+        confidentiality:
+        - HIGH
+        - MODERATE
+        - LOW
+        integrity:
+        - HIGH
+        - MODERATE
+        - LOW
+        availability:
+        - HIGH
+        - MODERATE
+        - LOW
     family: AU
     title: Time Stamps
     description: ''
@@ -323,6 +666,19 @@ controls:
   nist_800_53:rev4:AU-9:
     standard:
       name: nist_800_53:rev4
+      template:
+        confidentiality:
+        - HIGH
+        - MODERATE
+        - LOW
+        integrity:
+        - HIGH
+        - MODERATE
+        - LOW
+        availability:
+        - HIGH
+        - MODERATE
+        - LOW
     family: AU
     title: Protection Of Audit Information
     description: ''
@@ -330,6 +686,13 @@ controls:
   nist_800_53:rev4:AU-10:
     standard:
       name: nist_800_53:rev4
+      template:
+        confidentiality:
+        - HIGH
+        integrity:
+        - HIGH
+        availability:
+        - HIGH
     family: AU
     title: Non-Repudiation
     description: ''
@@ -339,6 +702,19 @@ controls:
   nist_800_53:rev4:AU-11:
     standard:
       name: nist_800_53:rev4
+      template:
+        confidentiality:
+        - HIGH
+        - MODERATE
+        - LOW
+        integrity:
+        - HIGH
+        - MODERATE
+        - LOW
+        availability:
+        - HIGH
+        - MODERATE
+        - LOW
     family: AU
     title: Audit Record Retention
     description: ''
@@ -346,6 +722,19 @@ controls:
   nist_800_53:rev4:AU-12:
     standard:
       name: nist_800_53:rev4
+      template:
+        confidentiality:
+        - HIGH
+        - MODERATE
+        - LOW
+        integrity:
+        - HIGH
+        - MODERATE
+        - LOW
+        availability:
+        - HIGH
+        - MODERATE
+        - LOW
     family: AU
     title: AUDIT GENERATION
     description: ''
@@ -361,12 +750,39 @@ controls:
     standard:
       name: nist_800_53:rev4
     family: AU
+    title: Alternate Audit Capability
+    description: ''
+    notes: 'Yes'
+  nist_800_53:rev4:AU-15:
+    standard:
+      name: nist_800_53:rev4
+    family: AU
+    title: Cross-Organizational Auditing
+    description: ''
+    notes: 'Yes'
+  nist_800_53:rev4:AU-16:
+    standard:
+      name: nist_800_53:rev4
+    family: AU
     title: SESSION AUDIT
     description: ''
     notes: 'Yes'
   nist_800_53:rev4:CA-1:
     standard:
       name: nist_800_53:rev4
+      template:
+        confidentiality:
+        - HIGH
+        - MODERATE
+        - LOW
+        integrity:
+        - HIGH
+        - MODERATE
+        - LOW
+        availability:
+        - HIGH
+        - MODERATE
+        - LOW
     family: CA
     title: Certification, Accreditation, And Security Assessment Policies And Procedures
     description: ''
@@ -375,6 +791,19 @@ controls:
   nist_800_53:rev4:CA-2:
     standard:
       name: nist_800_53:rev4
+      template:
+        confidentiality:
+        - HIGH
+        - MODERATE
+        - LOW
+        integrity:
+        - HIGH
+        - MODERATE
+        - LOW
+        availability:
+        - HIGH
+        - MODERATE
+        - LOW
     family: CA
     title: Security Assessments
     description: ''
@@ -383,6 +812,19 @@ controls:
   nist_800_53:rev4:CA-3:
     standard:
       name: nist_800_53:rev4
+      template:
+        confidentiality:
+        - HIGH
+        - MODERATE
+        - LOW
+        integrity:
+        - HIGH
+        - MODERATE
+        - LOW
+        availability:
+        - HIGH
+        - MODERATE
+        - LOW
     family: CA
     title: Information System Connections
     description: ''
@@ -398,6 +840,19 @@ controls:
   nist_800_53:rev4:CA-5:
     standard:
       name: nist_800_53:rev4
+      template:
+        confidentiality:
+        - HIGH
+        - MODERATE
+        - LOW
+        integrity:
+        - HIGH
+        - MODERATE
+        - LOW
+        availability:
+        - HIGH
+        - MODERATE
+        - LOW
     family: CA
     title: Plan Of Action And Milestones
     description: ''
@@ -406,6 +861,19 @@ controls:
   nist_800_53:rev4:CA-6:
     standard:
       name: nist_800_53:rev4
+      template:
+        confidentiality:
+        - HIGH
+        - MODERATE
+        - LOW
+        integrity:
+        - HIGH
+        - MODERATE
+        - LOW
+        availability:
+        - HIGH
+        - MODERATE
+        - LOW
     family: CA
     title: Security Accreditation
     description: ''
@@ -414,14 +882,76 @@ controls:
   nist_800_53:rev4:CA-7:
     standard:
       name: nist_800_53:rev4
+      template:
+        confidentiality:
+        - HIGH
+        - MODERATE
+        - LOW
+        integrity:
+        - HIGH
+        - MODERATE
+        - LOW
+        availability:
+        - HIGH
+        - MODERATE
+        - LOW
     family: CA
     title: Continuous Monitoring
+    description: ''
+    notes: Considered a Operational Class control, this control is typically defined
+      at the organization level.
+  nist_800_53:rev4:CA-8:
+    standard:
+      name: nist_800_53:rev4
+      template:
+        confidentiality:
+        - HIGH
+        integrity:
+        - HIGH
+        availability:
+        - HIGH
+    family: CA
+    title: Penetration Testing
+    description: ''
+    notes: Considered a Operational Class control, this control is typically defined
+      at the organization level.
+  nist_800_53:rev4:CA-9:
+    standard:
+      name: nist_800_53:rev4
+      template:
+        confidentiality:
+        - HIGH
+        - MODERATE
+        - LOW
+        integrity:
+        - HIGH
+        - MODERATE
+        - LOW
+        availability:
+        - HIGH
+        - MODERATE
+        - LOW
+    family: CA
+    title: Internal System Connections
     description: ''
     notes: Considered a Operational Class control, this control is typically defined
       at the organization level.
   nist_800_53:rev4:CM-1:
     standard:
       name: nist_800_53:rev4
+      template:
+        confidentiality:
+        - HIGH
+        - MODERATE
+        - LOW
+        integrity:
+        - HIGH
+        - MODERATE
+        - LOW
+        availability:
+        - HIGH
+        - MODERATE
+        - LOW
     family: CM
     title: Configuration Management Policy And Procedures
     description: ''
@@ -431,6 +961,19 @@ controls:
   nist_800_53:rev4:CM-2:
     standard:
       name: nist_800_53:rev4
+      template:
+        confidentiality:
+        - HIGH
+        - MODERATE
+        - LOW
+        integrity:
+        - HIGH
+        - MODERATE
+        - LOW
+        availability:
+        - HIGH
+        - MODERATE
+        - LOW
     family: CM
     title: Baseline Configuration
     description: ''
@@ -438,6 +981,16 @@ controls:
   nist_800_53:rev4:CM-3:
     standard:
       name: nist_800_53:rev4
+      template:
+        confidentiality:
+        - HIGH
+        - MODERATE
+        integrity:
+        - HIGH
+        - MODERATE
+        availability:
+        - HIGH
+        - MODERATE
     family: CM
     title: Configuration Change Control
     description: ''
@@ -447,13 +1000,36 @@ controls:
   nist_800_53:rev4:CM-4:
     standard:
       name: nist_800_53:rev4
+      template:
+        confidentiality:
+        - HIGH
+        - MODERATE
+        - LOW
+        integrity:
+        - HIGH
+        - MODERATE
+        - LOW
+        availability:
+        - HIGH
+        - MODERATE
+        - LOW
     family: CM
-    title: Monitoring Configuration Changes
+    title: Security Impact Analysis
     description: ''
     notes: 'NO'
   nist_800_53:rev4:CM-5:
     standard:
       name: nist_800_53:rev4
+      template:
+        confidentiality:
+        - HIGH
+        - MODERATE
+        integrity:
+        - HIGH
+        - MODERATE
+        availability:
+        - HIGH
+        - MODERATE
     family: CM
     title: Access Restrictions For Change
     description: ''
@@ -463,6 +1039,19 @@ controls:
   nist_800_53:rev4:CM-6:
     standard:
       name: nist_800_53:rev4
+      template:
+        confidentiality:
+        - HIGH
+        - MODERATE
+        - LOW
+        integrity:
+        - HIGH
+        - MODERATE
+        - LOW
+        availability:
+        - HIGH
+        - MODERATE
+        - LOW
     family: CM
     title: Configuration Settings
     description: ''
@@ -475,6 +1064,19 @@ controls:
   nist_800_53:rev4:CM-7:
     standard:
       name: nist_800_53:rev4
+      template:
+        confidentiality:
+        - HIGH
+        - MODERATE
+        - LOW
+        integrity:
+        - HIGH
+        - MODERATE
+        - LOW
+        availability:
+        - HIGH
+        - MODERATE
+        - LOW
     family: CM
     title: Least Functionality
     description: ''
@@ -482,13 +1084,94 @@ controls:
   nist_800_53:rev4:CM-8:
     standard:
       name: nist_800_53:rev4
+      template:
+        confidentiality:
+        - HIGH
+        - MODERATE
+        - LOW
+        integrity:
+        - HIGH
+        - MODERATE
+        - LOW
+        availability:
+        - HIGH
+        - MODERATE
+        - LOW
     family: CM
     title: Information System Component Inventory
     description: ''
+    notes: 'Yes'
+  nist_800_53:rev4:CM-9:
+    standard:
+      name: nist_800_53:rev4
+      template:
+        confidentiality:
+        - HIGH
+        - MODERATE
+        integrity:
+        - HIGH
+        - MODERATE
+        availability:
+        - HIGH
+        - MODERATE
+    family: CM
+    title: Information Configuration Management Plan
+    description: ''
     notes: 'NO'
+  nist_800_53:rev4:CM-10:
+    standard:
+      name: nist_800_53:rev4
+      template:
+        confidentiality:
+        - HIGH
+        - MODERATE
+        - LOW
+        integrity:
+        - HIGH
+        - MODERATE
+        - LOW
+        availability:
+        - HIGH
+        - MODERATE
+        - LOW
+    family: CM
+    title: Software Usage Restrictions
+    description: ''
+    notes: 'NO'
+  nist_800_53:rev4:CM-11:
+    standard:
+      name: nist_800_53:rev4
+      template:
+        confidentiality:
+        - HIGH
+        - MODERATE
+        - LOW
+        integrity:
+        - HIGH
+        - MODERATE
+        - LOW
+        availability:
+        - HIGH
+        - MODERATE
+        - LOW
+    family: CM
+    title: User-Installed Software
   nist_800_53:rev4:CP-1:
     standard:
       name: nist_800_53:rev4
+      template:
+        confidentiality:
+        - HIGH
+        - MODERATE
+        - LOW
+        integrity:
+        - HIGH
+        - MODERATE
+        - LOW
+        availability:
+        - HIGH
+        - MODERATE
+        - LOW
     family: CP
     title: Contingency Planning Policy And Procedures
     description: ''
@@ -497,6 +1180,19 @@ controls:
   nist_800_53:rev4:CP-2:
     standard:
       name: nist_800_53:rev4
+      template:
+        confidentiality:
+        - HIGH
+        - MODERATE
+        - LOW
+        integrity:
+        - HIGH
+        - MODERATE
+        - LOW
+        availability:
+        - HIGH
+        - MODERATE
+        - LOW
     family: CP
     title: Contingency Plan
     description: ''
@@ -505,6 +1201,19 @@ controls:
   nist_800_53:rev4:CP-3:
     standard:
       name: nist_800_53:rev4
+      template:
+        confidentiality:
+        - HIGH
+        - MODERATE
+        - LOW
+        integrity:
+        - HIGH
+        - MODERATE
+        - LOW
+        availability:
+        - HIGH
+        - MODERATE
+        - LOW
     family: CP
     title: Contingency Training
     description: ''
@@ -513,8 +1222,21 @@ controls:
   nist_800_53:rev4:CP-4:
     standard:
       name: nist_800_53:rev4
+      template:
+        confidentiality:
+        - HIGH
+        - MODERATE
+        - LOW
+        integrity:
+        - HIGH
+        - MODERATE
+        - LOW
+        availability:
+        - HIGH
+        - MODERATE
+        - LOW
     family: CP
-    title: Contingency Plan Testing And Exercises
+    title: Contingency Plan Testing
     description: ''
     notes: Considered a Operational Class control, this control is typically defined
       at the organization level.
@@ -528,6 +1250,16 @@ controls:
   nist_800_53:rev4:CP-6:
     standard:
       name: nist_800_53:rev4
+      template:
+        confidentiality:
+        - HIGH
+        - MODERATE
+        integrity:
+        - HIGH
+        - MODERATE
+        availability:
+        - HIGH
+        - MODERATE
     family: CP
     title: Alternate Storage Site
     description: ''
@@ -536,6 +1268,16 @@ controls:
   nist_800_53:rev4:CP-7:
     standard:
       name: nist_800_53:rev4
+      template:
+        confidentiality:
+        - HIGH
+        - MODERATE
+        integrity:
+        - HIGH
+        - MODERATE
+        availability:
+        - HIGH
+        - MODERATE
     family: CP
     title: Alternate Processing Site
     description: ''
@@ -544,6 +1286,16 @@ controls:
   nist_800_53:rev4:CP-8:
     standard:
       name: nist_800_53:rev4
+      template:
+        confidentiality:
+        - HIGH
+        - MODERATE
+        integrity:
+        - HIGH
+        - MODERATE
+        availability:
+        - HIGH
+        - MODERATE
     family: CP
     title: Telecommunications Services
     description: ''
@@ -552,6 +1304,19 @@ controls:
   nist_800_53:rev4:CP-9:
     standard:
       name: nist_800_53:rev4
+      template:
+        confidentiality:
+        - HIGH
+        - MODERATE
+        - LOW
+        integrity:
+        - HIGH
+        - MODERATE
+        - LOW
+        availability:
+        - HIGH
+        - MODERATE
+        - LOW
     family: CP
     title: Information System Backup
     description: ''
@@ -560,14 +1325,61 @@ controls:
   nist_800_53:rev4:CP-10:
     standard:
       name: nist_800_53:rev4
+      template:
+        confidentiality:
+        - HIGH
+        - MODERATE
+        - LOW
+        integrity:
+        - HIGH
+        - MODERATE
+        - LOW
+        availability:
+        - HIGH
+        - MODERATE
+        - LOW
     family: CP
     title: Information System Recovery And Reconstitution
     description: ''
     notes: Considered a Operational Class control, this control is typically defined
       at the organization level.
+  nist_800_53:rev4:CP-11:
+    standard:
+      name: nist_800_53:rev4
+    family: CP
+    title: Alternate Communications Protocols
+    description: ''
+    notes: N/A
+  nist_800_53:rev4:CP-12:
+    standard:
+      name: nist_800_53:rev4
+    family: CP
+    title: Safe Mode
+    description: ''
+    notes: N/A
+  nist_800_53:rev4:CP-13:
+    standard:
+      name: nist_800_53:rev4
+    family: CP
+    title: Alternative Security Mechanisms
+    description: ''
+    notes: N/A
   nist_800_53:rev4:IA-1:
     standard:
       name: nist_800_53:rev4
+      template:
+        confidentiality:
+        - HIGH
+        - MODERATE
+        - LOW
+        integrity:
+        - HIGH
+        - MODERATE
+        - LOW
+        availability:
+        - HIGH
+        - MODERATE
+        - LOW
     family: IA
     title: Identification And Authentication Policy And Procedures
     description: ''
@@ -577,6 +1389,19 @@ controls:
   nist_800_53:rev4:IA-2:
     standard:
       name: nist_800_53:rev4
+      template:
+        confidentiality:
+        - HIGH
+        - MODERATE
+        - LOW
+        integrity:
+        - HIGH
+        - MODERATE
+        - LOW
+        availability:
+        - HIGH
+        - MODERATE
+        - LOW
     family: IA
     title: Identification And Authentication (Organizational Users)
     description: ''
@@ -584,6 +1409,16 @@ controls:
   nist_800_53:rev4:IA-3:
     standard:
       name: nist_800_53:rev4
+      template:
+        confidentiality:
+        - HIGH
+        - MODERATE
+        integrity:
+        - HIGH
+        - MODERATE
+        availability:
+        - HIGH
+        - MODERATE
     family: IA
     title: Device Identification And Authentication
     description: ''
@@ -591,6 +1426,19 @@ controls:
   nist_800_53:rev4:IA-4:
     standard:
       name: nist_800_53:rev4
+      template:
+        confidentiality:
+        - HIGH
+        - MODERATE
+        - LOW
+        integrity:
+        - HIGH
+        - MODERATE
+        - LOW
+        availability:
+        - HIGH
+        - MODERATE
+        - LOW
     family: IA
     title: Identifier Management
     description: ''
@@ -598,6 +1446,19 @@ controls:
   nist_800_53:rev4:IA-5:
     standard:
       name: nist_800_53:rev4
+      template:
+        confidentiality:
+        - HIGH
+        - MODERATE
+        - LOW
+        integrity:
+        - HIGH
+        - MODERATE
+        - LOW
+        availability:
+        - HIGH
+        - MODERATE
+        - LOW
     family: IA
     title: Authenticator Management
     description: ''
@@ -605,6 +1466,19 @@ controls:
   nist_800_53:rev4:IA-6:
     standard:
       name: nist_800_53:rev4
+      template:
+        confidentiality:
+        - HIGH
+        - MODERATE
+        - LOW
+        integrity:
+        - HIGH
+        - MODERATE
+        - LOW
+        availability:
+        - HIGH
+        - MODERATE
+        - LOW
     family: IA
     title: Authenticator Feedback
     description: ''
@@ -612,6 +1486,19 @@ controls:
   nist_800_53:rev4:IA-7:
     standard:
       name: nist_800_53:rev4
+      template:
+        confidentiality:
+        - HIGH
+        - MODERATE
+        - LOW
+        integrity:
+        - HIGH
+        - MODERATE
+        - LOW
+        availability:
+        - HIGH
+        - MODERATE
+        - LOW
     family: IA
     title: Cryptographic Module Authentication
     description: ''
@@ -619,6 +1506,19 @@ controls:
   nist_800_53:rev4:IA-8:
     standard:
       name: nist_800_53:rev4
+      template:
+        confidentiality:
+        - HIGH
+        - MODERATE
+        - LOW
+        integrity:
+        - HIGH
+        - MODERATE
+        - LOW
+        availability:
+        - HIGH
+        - MODERATE
+        - LOW
     family: IA
     title: Identification And Authentication (Non-Organizational Users)
     description: ''
@@ -653,6 +1553,19 @@ controls:
   nist_800_53:rev4:IR-1:
     standard:
       name: nist_800_53:rev4
+      template:
+        confidentiality:
+        - HIGH
+        - MODERATE
+        - LOW
+        integrity:
+        - HIGH
+        - MODERATE
+        - LOW
+        availability:
+        - HIGH
+        - MODERATE
+        - LOW
     family: IR
     title: Incident Response Policy And Procedures
     description: ''
@@ -661,6 +1574,19 @@ controls:
   nist_800_53:rev4:IR-2:
     standard:
       name: nist_800_53:rev4
+      template:
+        confidentiality:
+        - HIGH
+        - MODERATE
+        - LOW
+        integrity:
+        - HIGH
+        - MODERATE
+        - LOW
+        availability:
+        - HIGH
+        - MODERATE
+        - LOW
     family: IR
     title: Incident Response Training
     description: ''
@@ -669,6 +1595,16 @@ controls:
   nist_800_53:rev4:IR-3:
     standard:
       name: nist_800_53:rev4
+      template:
+        confidentiality:
+        - HIGH
+        - MODERATE
+        integrity:
+        - HIGH
+        - MODERATE
+        availability:
+        - HIGH
+        - MODERATE
     family: IR
     title: Incident Response Testing And Exercises
     description: ''
@@ -677,6 +1613,19 @@ controls:
   nist_800_53:rev4:IR-4:
     standard:
       name: nist_800_53:rev4
+      template:
+        confidentiality:
+        - HIGH
+        - MODERATE
+        - LOW
+        integrity:
+        - HIGH
+        - MODERATE
+        - LOW
+        availability:
+        - HIGH
+        - MODERATE
+        - LOW
     family: IR
     title: Incident Handling
     description: ''
@@ -685,6 +1634,19 @@ controls:
   nist_800_53:rev4:IR-5:
     standard:
       name: nist_800_53:rev4
+      template:
+        confidentiality:
+        - HIGH
+        - MODERATE
+        - LOW
+        integrity:
+        - HIGH
+        - MODERATE
+        - LOW
+        availability:
+        - HIGH
+        - MODERATE
+        - LOW
     family: IR
     title: Incident Monitoring
     description: ''
@@ -693,6 +1655,19 @@ controls:
   nist_800_53:rev4:IR-6:
     standard:
       name: nist_800_53:rev4
+      template:
+        confidentiality:
+        - HIGH
+        - MODERATE
+        - LOW
+        integrity:
+        - HIGH
+        - MODERATE
+        - LOW
+        availability:
+        - HIGH
+        - MODERATE
+        - LOW
     family: IR
     title: Incident Reporting
     description: ''
@@ -701,6 +1676,19 @@ controls:
   nist_800_53:rev4:IR-7:
     standard:
       name: nist_800_53:rev4
+      template:
+        confidentiality:
+        - HIGH
+        - MODERATE
+        - LOW
+        integrity:
+        - HIGH
+        - MODERATE
+        - LOW
+        availability:
+        - HIGH
+        - MODERATE
+        - LOW
     family: IR
     title: Incident Response Assistance
     description: ''
@@ -709,6 +1697,19 @@ controls:
   nist_800_53:rev4:IR-8:
     standard:
       name: nist_800_53:rev4
+      template:
+        confidentiality:
+        - HIGH
+        - MODERATE
+        - LOW
+        integrity:
+        - HIGH
+        - MODERATE
+        - LOW
+        availability:
+        - HIGH
+        - MODERATE
+        - LOW
     family: IR
     title: Incident Response Plan
     description: ''
@@ -733,6 +1734,19 @@ controls:
   nist_800_53:rev4:MA-1:
     standard:
       name: nist_800_53:rev4
+      template:
+        confidentiality:
+        - HIGH
+        - MODERATE
+        - LOW
+        integrity:
+        - HIGH
+        - MODERATE
+        - LOW
+        availability:
+        - HIGH
+        - MODERATE
+        - LOW
     family: MA
     title: System Maintenance Policy And Procedures
     description: ''
@@ -741,6 +1755,19 @@ controls:
   nist_800_53:rev4:MA-2:
     standard:
       name: nist_800_53:rev4
+      template:
+        confidentiality:
+        - HIGH
+        - MODERATE
+        - LOW
+        integrity:
+        - HIGH
+        - MODERATE
+        - LOW
+        availability:
+        - HIGH
+        - MODERATE
+        - LOW
     family: MA
     title: Controlled Maintenance
     description: ''
@@ -749,6 +1776,16 @@ controls:
   nist_800_53:rev4:MA-3:
     standard:
       name: nist_800_53:rev4
+      template:
+        confidentiality:
+        - HIGH
+        - MODERATE
+        integrity:
+        - HIGH
+        - MODERATE
+        availability:
+        - HIGH
+        - MODERATE
     family: MA
     title: Maintenance Tools
     description: ''
@@ -757,6 +1794,19 @@ controls:
   nist_800_53:rev4:MA-4:
     standard:
       name: nist_800_53:rev4
+      template:
+        confidentiality:
+        - HIGH
+        - MODERATE
+        - LOW
+        integrity:
+        - HIGH
+        - MODERATE
+        - LOW
+        availability:
+        - HIGH
+        - MODERATE
+        - LOW
     family: MA
     title: Remote Maintenance
     description: ''
@@ -765,6 +1815,19 @@ controls:
   nist_800_53:rev4:MA-5:
     standard:
       name: nist_800_53:rev4
+      template:
+        confidentiality:
+        - HIGH
+        - MODERATE
+        - LOW
+        integrity:
+        - HIGH
+        - MODERATE
+        - LOW
+        availability:
+        - HIGH
+        - MODERATE
+        - LOW
     family: MA
     title: Maintenance Personnel
     description: ''
@@ -773,6 +1836,16 @@ controls:
   nist_800_53:rev4:MA-6:
     standard:
       name: nist_800_53:rev4
+      template:
+        confidentiality:
+        - HIGH
+        - MODERATE
+        integrity:
+        - HIGH
+        - MODERATE
+        availability:
+        - HIGH
+        - MODERATE
     family: MA
     title: Timely Maintenance
     description: ''
@@ -781,6 +1854,19 @@ controls:
   nist_800_53:rev4:MP-1:
     standard:
       name: nist_800_53:rev4
+      template:
+        confidentiality:
+        - HIGH
+        - MODERATE
+        - LOW
+        integrity:
+        - HIGH
+        - MODERATE
+        - LOW
+        availability:
+        - HIGH
+        - MODERATE
+        - LOW
     family: MP
     title: Media Protection Policy And Procedures
     description: ''
@@ -789,6 +1875,19 @@ controls:
   nist_800_53:rev4:MP-2:
     standard:
       name: nist_800_53:rev4
+      template:
+        confidentiality:
+        - HIGH
+        - MODERATE
+        - LOW
+        integrity:
+        - HIGH
+        - MODERATE
+        - LOW
+        availability:
+        - HIGH
+        - MODERATE
+        - LOW
     family: MP
     title: Media Access
     description: ''
@@ -797,6 +1896,16 @@ controls:
   nist_800_53:rev4:MP-3:
     standard:
       name: nist_800_53:rev4
+      template:
+        confidentiality:
+        - HIGH
+        - MODERATE
+        integrity:
+        - HIGH
+        - MODERATE
+        availability:
+        - HIGH
+        - MODERATE
     family: MP
     title: Media Labeling
     description: ''
@@ -805,6 +1914,16 @@ controls:
   nist_800_53:rev4:MP-4:
     standard:
       name: nist_800_53:rev4
+      template:
+        confidentiality:
+        - HIGH
+        - MODERATE
+        integrity:
+        - HIGH
+        - MODERATE
+        availability:
+        - HIGH
+        - MODERATE
     family: MP
     title: Media Storage
     description: ''
@@ -813,6 +1932,16 @@ controls:
   nist_800_53:rev4:MP-5:
     standard:
       name: nist_800_53:rev4
+      template:
+        confidentiality:
+        - HIGH
+        - MODERATE
+        integrity:
+        - HIGH
+        - MODERATE
+        availability:
+        - HIGH
+        - MODERATE
     family: MP
     title: Media Transport
     description: ''
@@ -821,6 +1950,19 @@ controls:
   nist_800_53:rev4:MP-6:
     standard:
       name: nist_800_53:rev4
+      template:
+        confidentiality:
+        - HIGH
+        - MODERATE
+        - LOW
+        integrity:
+        - HIGH
+        - MODERATE
+        - LOW
+        availability:
+        - HIGH
+        - MODERATE
+        - LOW
     family: MP
     title: Media Sanitization And Disposal
     description: ''
@@ -829,6 +1971,19 @@ controls:
   nist_800_53:rev4:MP-7:
     standard:
       name: nist_800_53:rev4
+      template:
+        confidentiality:
+        - HIGH
+        - MODERATE
+        - LOW
+        integrity:
+        - HIGH
+        - MODERATE
+        - LOW
+        availability:
+        - HIGH
+        - MODERATE
+        - LOW
     family: MP
     title: Media Use
     description: ''
@@ -845,6 +2000,19 @@ controls:
   nist_800_53:rev4:PE-1:
     standard:
       name: nist_800_53:rev4
+      template:
+        confidentiality:
+        - HIGH
+        - MODERATE
+        - LOW
+        integrity:
+        - HIGH
+        - MODERATE
+        - LOW
+        availability:
+        - HIGH
+        - MODERATE
+        - LOW
     family: PE
     title: Physical And Environmental Protection Policy And Procedures
     description: ''
@@ -853,6 +2021,19 @@ controls:
   nist_800_53:rev4:PE-2:
     standard:
       name: nist_800_53:rev4
+      template:
+        confidentiality:
+        - HIGH
+        - MODERATE
+        - LOW
+        integrity:
+        - HIGH
+        - MODERATE
+        - LOW
+        availability:
+        - HIGH
+        - MODERATE
+        - LOW
     family: PE
     title: Physical Access Authorizations
     description: ''
@@ -861,6 +2042,19 @@ controls:
   nist_800_53:rev4:PE-3:
     standard:
       name: nist_800_53:rev4
+      template:
+        confidentiality:
+        - HIGH
+        - MODERATE
+        - LOW
+        integrity:
+        - HIGH
+        - MODERATE
+        - LOW
+        availability:
+        - HIGH
+        - MODERATE
+        - LOW
     family: PE
     title: Physical Access Control
     description: ''
@@ -869,6 +2063,16 @@ controls:
   nist_800_53:rev4:PE-4:
     standard:
       name: nist_800_53:rev4
+      template:
+        confidentiality:
+        - HIGH
+        - MODERATE
+        integrity:
+        - HIGH
+        - MODERATE
+        availability:
+        - HIGH
+        - MODERATE
     family: PE
     title: Access Control For Transmission Medium
     description: ''
@@ -877,6 +2081,16 @@ controls:
   nist_800_53:rev4:PE-5:
     standard:
       name: nist_800_53:rev4
+      template:
+        confidentiality:
+        - HIGH
+        - MODERATE
+        integrity:
+        - HIGH
+        - MODERATE
+        availability:
+        - HIGH
+        - MODERATE
     family: PE
     title: Access Control For Display Medium
     description: ''
@@ -885,6 +2099,19 @@ controls:
   nist_800_53:rev4:PE-6:
     standard:
       name: nist_800_53:rev4
+      template:
+        confidentiality:
+        - HIGH
+        - MODERATE
+        - LOW
+        integrity:
+        - HIGH
+        - MODERATE
+        - LOW
+        availability:
+        - HIGH
+        - MODERATE
+        - LOW
     family: PE
     title: Monitoring Physical Access
     description: ''
@@ -901,6 +2128,19 @@ controls:
   nist_800_53:rev4:PE-8:
     standard:
       name: nist_800_53:rev4
+      template:
+        confidentiality:
+        - HIGH
+        - MODERATE
+        - LOW
+        integrity:
+        - HIGH
+        - MODERATE
+        - LOW
+        availability:
+        - HIGH
+        - MODERATE
+        - LOW
     family: PE
     title: Access Records
     description: ''
@@ -909,6 +2149,16 @@ controls:
   nist_800_53:rev4:PE-9:
     standard:
       name: nist_800_53:rev4
+      template:
+        confidentiality:
+        - HIGH
+        - MODERATE
+        integrity:
+        - HIGH
+        - MODERATE
+        availability:
+        - HIGH
+        - MODERATE
     family: PE
     title: Power Equipment And Power Cabling
     description: ''
@@ -917,6 +2167,16 @@ controls:
   nist_800_53:rev4:PE-10:
     standard:
       name: nist_800_53:rev4
+      template:
+        confidentiality:
+        - HIGH
+        - MODERATE
+        integrity:
+        - HIGH
+        - MODERATE
+        availability:
+        - HIGH
+        - MODERATE
     family: PE
     title: Emergency Shutoff
     description: ''
@@ -925,6 +2185,16 @@ controls:
   nist_800_53:rev4:PE-11:
     standard:
       name: nist_800_53:rev4
+      template:
+        confidentiality:
+        - HIGH
+        - MODERATE
+        integrity:
+        - HIGH
+        - MODERATE
+        availability:
+        - HIGH
+        - MODERATE
     family: PE
     title: Emergency Power
     description: ''
@@ -933,6 +2203,19 @@ controls:
   nist_800_53:rev4:PE-12:
     standard:
       name: nist_800_53:rev4
+      template:
+        confidentiality:
+        - HIGH
+        - MODERATE
+        - LOW
+        integrity:
+        - HIGH
+        - MODERATE
+        - LOW
+        availability:
+        - HIGH
+        - MODERATE
+        - LOW
     family: PE
     title: Emergency Lighting
     description: ''
@@ -941,6 +2224,19 @@ controls:
   nist_800_53:rev4:PE-13:
     standard:
       name: nist_800_53:rev4
+      template:
+        confidentiality:
+        - HIGH
+        - MODERATE
+        - LOW
+        integrity:
+        - HIGH
+        - MODERATE
+        - LOW
+        availability:
+        - HIGH
+        - MODERATE
+        - LOW
     family: PE
     title: Fire Protection
     description: ''
@@ -949,6 +2245,19 @@ controls:
   nist_800_53:rev4:PE-14:
     standard:
       name: nist_800_53:rev4
+      template:
+        confidentiality:
+        - HIGH
+        - MODERATE
+        - LOW
+        integrity:
+        - HIGH
+        - MODERATE
+        - LOW
+        availability:
+        - HIGH
+        - MODERATE
+        - LOW
     family: PE
     title: Temperature And Humidity Controls
     description: ''
@@ -957,6 +2266,19 @@ controls:
   nist_800_53:rev4:PE-15:
     standard:
       name: nist_800_53:rev4
+      template:
+        confidentiality:
+        - HIGH
+        - MODERATE
+        - LOW
+        integrity:
+        - HIGH
+        - MODERATE
+        - LOW
+        availability:
+        - HIGH
+        - MODERATE
+        - LOW
     family: PE
     title: Water Damage Protection
     description: ''
@@ -965,6 +2287,19 @@ controls:
   nist_800_53:rev4:PE-16:
     standard:
       name: nist_800_53:rev4
+      template:
+        confidentiality:
+        - HIGH
+        - MODERATE
+        - LOW
+        integrity:
+        - HIGH
+        - MODERATE
+        - LOW
+        availability:
+        - HIGH
+        - MODERATE
+        - LOW
     family: PE
     title: Delivery And Removal
     description: ''
@@ -973,6 +2308,16 @@ controls:
   nist_800_53:rev4:PE-17:
     standard:
       name: nist_800_53:rev4
+      template:
+        confidentiality:
+        - HIGH
+        - MODERATE
+        integrity:
+        - HIGH
+        - MODERATE
+        availability:
+        - HIGH
+        - MODERATE
     family: PE
     title: Alternate Work Site
     description: ''
@@ -981,6 +2326,13 @@ controls:
   nist_800_53:rev4:PE-18:
     standard:
       name: nist_800_53:rev4
+      template:
+        confidentiality:
+        - HIGH
+        integrity:
+        - HIGH
+        availability:
+        - HIGH
     family: PE
     title: Location Of Information System Components
     description: ''
@@ -994,9 +2346,30 @@ controls:
     description: ''
     notes: Considered a Operational Class control, this control is typically defined
       at the organization level.
+  nist_800_53:rev4:PE-20:
+    standard:
+      name: nist_800_53:rev4
+    family: PE
+    title: Asset Monitoring and Tracking
+    description: ''
+    notes: Considered a Operational Class control, this control is typically defined
+      at the organization level.
   nist_800_53:rev4:PL-1:
     standard:
       name: nist_800_53:rev4
+      template:
+        confidentiality:
+        - HIGH
+        - MODERATE
+        - LOW
+        integrity:
+        - HIGH
+        - MODERATE
+        - LOW
+        availability:
+        - HIGH
+        - MODERATE
+        - LOW
     family: PL
     title: Security Planning Policy And Procedures
     description: ''
@@ -1005,6 +2378,19 @@ controls:
   nist_800_53:rev4:PL-2:
     standard:
       name: nist_800_53:rev4
+      template:
+        confidentiality:
+        - HIGH
+        - MODERATE
+        - LOW
+        integrity:
+        - HIGH
+        - MODERATE
+        - LOW
+        availability:
+        - HIGH
+        - MODERATE
+        - LOW
     family: PL
     title: System Security Plan
     description: ''
@@ -1021,6 +2407,19 @@ controls:
   nist_800_53:rev4:PL-4:
     standard:
       name: nist_800_53:rev4
+      template:
+        confidentiality:
+        - HIGH
+        - MODERATE
+        - LOW
+        integrity:
+        - HIGH
+        - MODERATE
+        - LOW
+        availability:
+        - HIGH
+        - MODERATE
+        - LOW
     family: PL
     title: Rules Of Behavior
     description: ''
@@ -1053,6 +2452,16 @@ controls:
   nist_800_53:rev4:PL-8:
     standard:
       name: nist_800_53:rev4
+      template:
+        confidentiality:
+        - HIGH
+        - MODERATE
+        integrity:
+        - HIGH
+        - MODERATE
+        availability:
+        - HIGH
+        - MODERATE
     family: PL
     title: Information Security Architecture
     description: ''
@@ -1181,6 +2590,19 @@ controls:
   nist_800_53:rev4:PS-1:
     standard:
       name: nist_800_53:rev4
+      template:
+        confidentiality:
+        - HIGH
+        - MODERATE
+        - LOW
+        integrity:
+        - HIGH
+        - MODERATE
+        - LOW
+        availability:
+        - HIGH
+        - MODERATE
+        - LOW
     family: PS
     title: Personnel Security Policy And Procedures
     description: ''
@@ -1189,6 +2611,19 @@ controls:
   nist_800_53:rev4:PS-2:
     standard:
       name: nist_800_53:rev4
+      template:
+        confidentiality:
+        - HIGH
+        - MODERATE
+        - LOW
+        integrity:
+        - HIGH
+        - MODERATE
+        - LOW
+        availability:
+        - HIGH
+        - MODERATE
+        - LOW
     family: PS
     title: Position Categorization
     description: ''
@@ -1197,6 +2632,19 @@ controls:
   nist_800_53:rev4:PS-3:
     standard:
       name: nist_800_53:rev4
+      template:
+        confidentiality:
+        - HIGH
+        - MODERATE
+        - LOW
+        integrity:
+        - HIGH
+        - MODERATE
+        - LOW
+        availability:
+        - HIGH
+        - MODERATE
+        - LOW
     family: PS
     title: Personnel Screening
     description: ''
@@ -1205,6 +2653,19 @@ controls:
   nist_800_53:rev4:PS-4:
     standard:
       name: nist_800_53:rev4
+      template:
+        confidentiality:
+        - HIGH
+        - MODERATE
+        - LOW
+        integrity:
+        - HIGH
+        - MODERATE
+        - LOW
+        availability:
+        - HIGH
+        - MODERATE
+        - LOW
     family: PS
     title: Personnel Termination
     description: ''
@@ -1213,6 +2674,19 @@ controls:
   nist_800_53:rev4:PS-5:
     standard:
       name: nist_800_53:rev4
+      template:
+        confidentiality:
+        - HIGH
+        - MODERATE
+        - LOW
+        integrity:
+        - HIGH
+        - MODERATE
+        - LOW
+        availability:
+        - HIGH
+        - MODERATE
+        - LOW
     family: PS
     title: Personnel Transfer
     description: ''
@@ -1221,6 +2695,19 @@ controls:
   nist_800_53:rev4:PS-6:
     standard:
       name: nist_800_53:rev4
+      template:
+        confidentiality:
+        - HIGH
+        - MODERATE
+        - LOW
+        integrity:
+        - HIGH
+        - MODERATE
+        - LOW
+        availability:
+        - HIGH
+        - MODERATE
+        - LOW
     family: PS
     title: Access Agreements
     description: ''
@@ -1229,6 +2716,19 @@ controls:
   nist_800_53:rev4:PS-7:
     standard:
       name: nist_800_53:rev4
+      template:
+        confidentiality:
+        - HIGH
+        - MODERATE
+        - LOW
+        integrity:
+        - HIGH
+        - MODERATE
+        - LOW
+        availability:
+        - HIGH
+        - MODERATE
+        - LOW
     family: PS
     title: Third-Party Personnel Security
     description: ''
@@ -1237,6 +2737,19 @@ controls:
   nist_800_53:rev4:PS-8:
     standard:
       name: nist_800_53:rev4
+      template:
+        confidentiality:
+        - HIGH
+        - MODERATE
+        - LOW
+        integrity:
+        - HIGH
+        - MODERATE
+        - LOW
+        availability:
+        - HIGH
+        - MODERATE
+        - LOW
     family: PS
     title: Personnel Sanctions
     description: ''
@@ -1245,6 +2758,19 @@ controls:
   nist_800_53:rev4:RA-1:
     standard:
       name: nist_800_53:rev4
+      template:
+        confidentiality:
+        - HIGH
+        - MODERATE
+        - LOW
+        integrity:
+        - HIGH
+        - MODERATE
+        - LOW
+        availability:
+        - HIGH
+        - MODERATE
+        - LOW
     family: RA
     title: Risk Assessment Policy And Procedures
     description: ''
@@ -1253,6 +2779,19 @@ controls:
   nist_800_53:rev4:RA-2:
     standard:
       name: nist_800_53:rev4
+      template:
+        confidentiality:
+        - HIGH
+        - MODERATE
+        - LOW
+        integrity:
+        - HIGH
+        - MODERATE
+        - LOW
+        availability:
+        - HIGH
+        - MODERATE
+        - LOW
     family: RA
     title: Security Categorization
     description: ''
@@ -1261,6 +2800,19 @@ controls:
   nist_800_53:rev4:RA-3:
     standard:
       name: nist_800_53:rev4
+      template:
+        confidentiality:
+        - HIGH
+        - MODERATE
+        - LOW
+        integrity:
+        - HIGH
+        - MODERATE
+        - LOW
+        availability:
+        - HIGH
+        - MODERATE
+        - LOW
     family: RA
     title: Risk Assessment
     description: ''
@@ -1277,6 +2829,19 @@ controls:
   nist_800_53:rev4:RA-5:
     standard:
       name: nist_800_53:rev4
+      template:
+        confidentiality:
+        - HIGH
+        - MODERATE
+        - LOW
+        integrity:
+        - HIGH
+        - MODERATE
+        - LOW
+        availability:
+        - HIGH
+        - MODERATE
+        - LOW
     family: RA
     title: Vulnerability Scanning
     description: ''
@@ -1293,6 +2858,19 @@ controls:
   nist_800_53:rev4:SA-1:
     standard:
       name: nist_800_53:rev4
+      template:
+        confidentiality:
+        - HIGH
+        - MODERATE
+        - LOW
+        integrity:
+        - HIGH
+        - MODERATE
+        - LOW
+        availability:
+        - HIGH
+        - MODERATE
+        - LOW
     family: SA
     title: System And Services Acquisition Policy And Procedures
     description: ''
@@ -1301,6 +2879,19 @@ controls:
   nist_800_53:rev4:SA-2:
     standard:
       name: nist_800_53:rev4
+      template:
+        confidentiality:
+        - HIGH
+        - MODERATE
+        - LOW
+        integrity:
+        - HIGH
+        - MODERATE
+        - LOW
+        availability:
+        - HIGH
+        - MODERATE
+        - LOW
     family: SA
     title: Allocation Of Resources
     description: ''
@@ -1309,6 +2900,19 @@ controls:
   nist_800_53:rev4:SA-3:
     standard:
       name: nist_800_53:rev4
+      template:
+        confidentiality:
+        - HIGH
+        - MODERATE
+        - LOW
+        integrity:
+        - HIGH
+        - MODERATE
+        - LOW
+        availability:
+        - HIGH
+        - MODERATE
+        - LOW
     family: SA
     title: Life Cycle Support
     description: ''
@@ -1317,6 +2921,19 @@ controls:
   nist_800_53:rev4:SA-4:
     standard:
       name: nist_800_53:rev4
+      template:
+        confidentiality:
+        - HIGH
+        - MODERATE
+        - LOW
+        integrity:
+        - HIGH
+        - MODERATE
+        - LOW
+        availability:
+        - HIGH
+        - MODERATE
+        - LOW
     family: SA
     title: Acquisitions
     description: ''
@@ -1325,6 +2942,19 @@ controls:
   nist_800_53:rev4:SA-5:
     standard:
       name: nist_800_53:rev4
+      template:
+        confidentiality:
+        - HIGH
+        - MODERATE
+        - LOW
+        integrity:
+        - HIGH
+        - MODERATE
+        - LOW
+        availability:
+        - HIGH
+        - MODERATE
+        - LOW
     family: SA
     title: Information System Documentation
     description: ''
@@ -1349,6 +2979,16 @@ controls:
   nist_800_53:rev4:SA-8:
     standard:
       name: nist_800_53:rev4
+      template:
+        confidentiality:
+        - HIGH
+        - MODERATE
+        integrity:
+        - HIGH
+        - MODERATE
+        availability:
+        - HIGH
+        - MODERATE
     family: SA
     title: Security Engineering Principles
     description: ''
@@ -1357,6 +2997,19 @@ controls:
   nist_800_53:rev4:SA-9:
     standard:
       name: nist_800_53:rev4
+      template:
+        confidentiality:
+        - HIGH
+        - MODERATE
+        - LOW
+        integrity:
+        - HIGH
+        - MODERATE
+        - LOW
+        availability:
+        - HIGH
+        - MODERATE
+        - LOW
     family: SA
     title: External Information System Services
     description: ''
@@ -1365,6 +3018,16 @@ controls:
   nist_800_53:rev4:SA-10:
     standard:
       name: nist_800_53:rev4
+      template:
+        confidentiality:
+        - HIGH
+        - MODERATE
+        integrity:
+        - HIGH
+        - MODERATE
+        availability:
+        - HIGH
+        - MODERATE
     family: SA
     title: Developer Configuration Management
     description: ''
@@ -1372,6 +3035,16 @@ controls:
   nist_800_53:rev4:SA-11:
     standard:
       name: nist_800_53:rev4
+      template:
+        confidentiality:
+        - HIGH
+        - MODERATE
+        integrity:
+        - HIGH
+        - MODERATE
+        availability:
+        - HIGH
+        - MODERATE
     family: SA
     title: Developer Security Testing
     description: ''
@@ -1379,6 +3052,13 @@ controls:
   nist_800_53:rev4:SA-12:
     standard:
       name: nist_800_53:rev4
+      template:
+        confidentiality:
+        - HIGH
+        integrity:
+        - HIGH
+        availability:
+        - HIGH
     family: SA
     title: Supply Chain Protection
     description: ''
@@ -1403,6 +3083,13 @@ controls:
   nist_800_53:rev4:SA-15:
     standard:
       name: nist_800_53:rev4
+      template:
+        confidentiality:
+        - HIGH
+        integrity:
+        - HIGH
+        availability:
+        - HIGH
     family: SA
     title: Development Process, Standards, and Tools
     description: ''
@@ -1411,6 +3098,13 @@ controls:
   nist_800_53:rev4:SA-16:
     standard:
       name: nist_800_53:rev4
+      template:
+        confidentiality:
+        - HIGH
+        integrity:
+        - HIGH
+        availability:
+        - HIGH
     family: SA
     title: Developer-Provided Training
     description: ''
@@ -1419,6 +3113,13 @@ controls:
   nist_800_53:rev4:SA-17:
     standard:
       name: nist_800_53:rev4
+      template:
+        confidentiality:
+        - HIGH
+        integrity:
+        - HIGH
+        availability:
+        - HIGH
     family: SA
     title: Developer Security Architecture and Design
     description: ''
@@ -1467,6 +3168,19 @@ controls:
   nist_800_53:rev4:SC-1:
     standard:
       name: nist_800_53:rev4
+      template:
+        confidentiality:
+        - HIGH
+        - MODERATE
+        - LOW
+        integrity:
+        - HIGH
+        - MODERATE
+        - LOW
+        availability:
+        - HIGH
+        - MODERATE
+        - LOW
     family: SC
     title: System And Communications Protection Policy And Procedures
     description: ''
@@ -1476,6 +3190,16 @@ controls:
   nist_800_53:rev4:SC-2:
     standard:
       name: nist_800_53:rev4
+      template:
+        confidentiality:
+        - HIGH
+        - MODERATE
+        integrity:
+        - HIGH
+        - MODERATE
+        availability:
+        - HIGH
+        - MODERATE
     family: SC
     title: Application Partitioning
     description: ''
@@ -1494,6 +3218,16 @@ controls:
   nist_800_53:rev4:SC-4:
     standard:
       name: nist_800_53:rev4
+      template:
+        confidentiality:
+        - HIGH
+        - MODERATE
+        integrity:
+        - HIGH
+        - MODERATE
+        availability:
+        - HIGH
+        - MODERATE
     family: SC
     title: Information Remnance
     description: ''
@@ -1503,6 +3237,19 @@ controls:
   nist_800_53:rev4:SC-5:
     standard:
       name: nist_800_53:rev4
+      template:
+        confidentiality:
+        - HIGH
+        - MODERATE
+        - LOW
+        integrity:
+        - HIGH
+        - MODERATE
+        - LOW
+        availability:
+        - HIGH
+        - MODERATE
+        - LOW
     family: SC
     title: Denial Of Service Protection
     description: ''
@@ -1517,6 +3264,19 @@ controls:
   nist_800_53:rev4:SC-7:
     standard:
       name: nist_800_53:rev4
+      template:
+        confidentiality:
+        - HIGH
+        - MODERATE
+        - LOW
+        integrity:
+        - HIGH
+        - MODERATE
+        - LOW
+        availability:
+        - HIGH
+        - MODERATE
+        - LOW
     family: SC
     title: Boundary Protection
     description: ''
@@ -1524,6 +3284,16 @@ controls:
   nist_800_53:rev4:SC-8:
     standard:
       name: nist_800_53:rev4
+      template:
+        confidentiality:
+        - HIGH
+        - MODERATE
+        integrity:
+        - HIGH
+        - MODERATE
+        availability:
+        - HIGH
+        - MODERATE
     family: SC
     title: Transmission Integrity
     description: ''
@@ -1538,6 +3308,16 @@ controls:
   nist_800_53:rev4:SC-10:
     standard:
       name: nist_800_53:rev4
+      template:
+        confidentiality:
+        - HIGH
+        - MODERATE
+        integrity:
+        - HIGH
+        - MODERATE
+        availability:
+        - HIGH
+        - MODERATE
     family: SC
     title: Network Disconnect
     description: ''
@@ -1552,6 +3332,19 @@ controls:
   nist_800_53:rev4:SC-12:
     standard:
       name: nist_800_53:rev4
+      template:
+        confidentiality:
+        - HIGH
+        - MODERATE
+        - LOW
+        integrity:
+        - HIGH
+        - MODERATE
+        - LOW
+        availability:
+        - HIGH
+        - MODERATE
+        - LOW
     family: SC
     title: Cryptographic Key Establishment And Management
     description: ''
@@ -1561,6 +3354,19 @@ controls:
   nist_800_53:rev4:SC-13:
     standard:
       name: nist_800_53:rev4
+      template:
+        confidentiality:
+        - HIGH
+        - MODERATE
+        - LOW
+        integrity:
+        - HIGH
+        - MODERATE
+        - LOW
+        availability:
+        - HIGH
+        - MODERATE
+        - LOW
     family: SC
     title: Use Of Cryptography
     description: ''
@@ -1577,6 +3383,19 @@ controls:
   nist_800_53:rev4:SC-15:
     standard:
       name: nist_800_53:rev4
+      template:
+        confidentiality:
+        - HIGH
+        - MODERATE
+        - LOW
+        integrity:
+        - HIGH
+        - MODERATE
+        - LOW
+        availability:
+        - HIGH
+        - MODERATE
+        - LOW
     family: SC
     title: Collaborative Computing
     description: ''
@@ -1591,6 +3410,16 @@ controls:
   nist_800_53:rev4:SC-17:
     standard:
       name: nist_800_53:rev4
+      template:
+        confidentiality:
+        - HIGH
+        - MODERATE
+        integrity:
+        - HIGH
+        - MODERATE
+        availability:
+        - HIGH
+        - MODERATE
     family: SC
     title: Public Key Infrastructure Certificates
     description: ''
@@ -1598,6 +3427,16 @@ controls:
   nist_800_53:rev4:SC-18:
     standard:
       name: nist_800_53:rev4
+      template:
+        confidentiality:
+        - HIGH
+        - MODERATE
+        integrity:
+        - HIGH
+        - MODERATE
+        availability:
+        - HIGH
+        - MODERATE
     family: SC
     title: Mobile Code
     description: ''
@@ -1607,6 +3446,16 @@ controls:
   nist_800_53:rev4:SC-19:
     standard:
       name: nist_800_53:rev4
+      template:
+        confidentiality:
+        - HIGH
+        - MODERATE
+        integrity:
+        - HIGH
+        - MODERATE
+        availability:
+        - HIGH
+        - MODERATE
     family: SC
     title: Voice Over Internet Protocol
     description: ''
@@ -1614,6 +3463,19 @@ controls:
   nist_800_53:rev4:SC-20:
     standard:
       name: nist_800_53:rev4
+      template:
+        confidentiality:
+        - HIGH
+        - MODERATE
+        - LOW
+        integrity:
+        - HIGH
+        - MODERATE
+        - LOW
+        availability:
+        - HIGH
+        - MODERATE
+        - LOW
     family: SC
     title: Secure Name / Address Resolution Service (Authoritative Source)
     description: ''
@@ -1623,6 +3485,19 @@ controls:
   nist_800_53:rev4:SC-21:
     standard:
       name: nist_800_53:rev4
+      template:
+        confidentiality:
+        - HIGH
+        - MODERATE
+        - LOW
+        integrity:
+        - HIGH
+        - MODERATE
+        - LOW
+        availability:
+        - HIGH
+        - MODERATE
+        - LOW
     family: SC
     title: Secure Name / Address Resolution Service (Recursive Or Caching Resolver)
     description: ''
@@ -1632,6 +3507,19 @@ controls:
   nist_800_53:rev4:SC-22:
     standard:
       name: nist_800_53:rev4
+      template:
+        confidentiality:
+        - HIGH
+        - MODERATE
+        - LOW
+        integrity:
+        - HIGH
+        - MODERATE
+        - LOW
+        availability:
+        - HIGH
+        - MODERATE
+        - LOW
     family: SC
     title: Architecture And Provisioning For Name / Address Resolution Service
     description: ''
@@ -1641,6 +3529,16 @@ controls:
   nist_800_53:rev4:SC-23:
     standard:
       name: nist_800_53:rev4
+      template:
+        confidentiality:
+        - HIGH
+        - MODERATE
+        integrity:
+        - HIGH
+        - MODERATE
+        availability:
+        - HIGH
+        - MODERATE
     family: SC
     title: Session Authenticity
     description: ''
@@ -1648,6 +3546,13 @@ controls:
   nist_800_53:rev4:SC-24:
     standard:
       name: nist_800_53:rev4
+      template:
+        confidentiality:
+        - HIGH
+        integrity:
+        - HIGH
+        availability:
+        - HIGH
     family: SC
     title: Fail in Known State
     description: ''
@@ -1678,6 +3583,16 @@ controls:
   nist_800_53:rev4:SC-28:
     standard:
       name: nist_800_53:rev4
+      template:
+        confidentiality:
+        - HIGH
+        - MODERATE
+        integrity:
+        - HIGH
+        - MODERATE
+        availability:
+        - HIGH
+        - MODERATE
     family: SC
     title: Protection of Information at Rest
     description: ''
@@ -1757,6 +3672,19 @@ controls:
   nist_800_53:rev4:SC-39:
     standard:
       name: nist_800_53:rev4
+      template:
+        confidentiality:
+        - HIGH
+        - MODERATE
+        - LOW
+        integrity:
+        - HIGH
+        - MODERATE
+        - LOW
+        availability:
+        - HIGH
+        - MODERATE
+        - LOW
     family: SC
     title: Process Isolation
     description: ''
@@ -1799,6 +3727,19 @@ controls:
   nist_800_53:rev4:SI-1:
     standard:
       name: nist_800_53:rev4
+      template:
+        confidentiality:
+        - HIGH
+        - MODERATE
+        - LOW
+        integrity:
+        - HIGH
+        - MODERATE
+        - LOW
+        availability:
+        - HIGH
+        - MODERATE
+        - LOW
     family: SI
     title: System And Information Integrity Policy And Procedures
     description: ''
@@ -1807,6 +3748,19 @@ controls:
   nist_800_53:rev4:SI-2:
     standard:
       name: nist_800_53:rev4
+      template:
+        confidentiality:
+        - HIGH
+        - MODERATE
+        - LOW
+        integrity:
+        - HIGH
+        - MODERATE
+        - LOW
+        availability:
+        - HIGH
+        - MODERATE
+        - LOW
     family: SI
     title: Flaw Remediation
     description: ''
@@ -1815,6 +3769,19 @@ controls:
   nist_800_53:rev4:SI-3:
     standard:
       name: nist_800_53:rev4
+      template:
+        confidentiality:
+        - HIGH
+        - MODERATE
+        - LOW
+        integrity:
+        - HIGH
+        - MODERATE
+        - LOW
+        availability:
+        - HIGH
+        - MODERATE
+        - LOW
     family: SI
     title: Malicious Code Protection
     description: ''
@@ -1822,6 +3789,19 @@ controls:
   nist_800_53:rev4:SI-4:
     standard:
       name: nist_800_53:rev4
+      template:
+        confidentiality:
+        - HIGH
+        - MODERATE
+        - LOW
+        integrity:
+        - HIGH
+        - MODERATE
+        - LOW
+        availability:
+        - HIGH
+        - MODERATE
+        - LOW
     family: SI
     title: Information System Monitoring Tools And Techniques
     description: ''
@@ -1832,6 +3812,19 @@ controls:
   nist_800_53:rev4:SI-5:
     standard:
       name: nist_800_53:rev4
+      template:
+        confidentiality:
+        - HIGH
+        - MODERATE
+        - LOW
+        integrity:
+        - HIGH
+        - MODERATE
+        - LOW
+        availability:
+        - HIGH
+        - MODERATE
+        - LOW
     family: SI
     title: Security Alerts And Advisories
     description: ''
@@ -1839,6 +3832,13 @@ controls:
   nist_800_53:rev4:SI-6:
     standard:
       name: nist_800_53:rev4
+      template:
+        confidentiality:
+        - HIGH
+        integrity:
+        - HIGH
+        availability:
+        - HIGH
     family: SI
     title: Security Functionality Verification
     description: ''
@@ -1846,6 +3846,16 @@ controls:
   nist_800_53:rev4:SI-7:
     standard:
       name: nist_800_53:rev4
+      template:
+        confidentiality:
+        - HIGH
+        - MODERATE
+        integrity:
+        - HIGH
+        - MODERATE
+        availability:
+        - HIGH
+        - MODERATE
     family: SI
     title: Software And Information Integrity
     description: ''
@@ -1853,6 +3863,16 @@ controls:
   nist_800_53:rev4:SI-8:
     standard:
       name: nist_800_53:rev4
+      template:
+        confidentiality:
+        - HIGH
+        - MODERATE
+        integrity:
+        - HIGH
+        - MODERATE
+        availability:
+        - HIGH
+        - MODERATE
     family: SI
     title: Spam Protection
     description: ''
@@ -1869,6 +3889,16 @@ controls:
   nist_800_53:rev4:SI-10:
     standard:
       name: nist_800_53:rev4
+      template:
+        confidentiality:
+        - HIGH
+        - MODERATE
+        integrity:
+        - HIGH
+        - MODERATE
+        availability:
+        - HIGH
+        - MODERATE
     family: SI
     title: Information Input Validation
     description: ''
@@ -1876,6 +3906,16 @@ controls:
   nist_800_53:rev4:SI-11:
     standard:
       name: nist_800_53:rev4
+      template:
+        confidentiality:
+        - HIGH
+        - MODERATE
+        integrity:
+        - HIGH
+        - MODERATE
+        availability:
+        - HIGH
+        - MODERATE
     family: SI
     title: Error Handling
     description: ''
@@ -1885,6 +3925,19 @@ controls:
   nist_800_53:rev4:SI-12:
     standard:
       name: nist_800_53:rev4
+      template:
+        confidentiality:
+        - HIGH
+        - MODERATE
+        - LOW
+        integrity:
+        - HIGH
+        - MODERATE
+        - LOW
+        availability:
+        - HIGH
+        - MODERATE
+        - LOW
     family: SI
     title: Information Output Handling And Retention
     description: ''
@@ -1916,6 +3969,16 @@ controls:
   nist_800_53:rev4:SI-16:
     standard:
       name: nist_800_53:rev4
+      template:
+        confidentiality:
+        - HIGH
+        - MODERATE
+        integrity:
+        - HIGH
+        - MODERATE
+        availability:
+        - HIGH
+        - MODERATE
     family: SI
     title: Memory Protection
     description: ''
@@ -1929,3 +3992,10446 @@ controls:
     title: Fail-Safe Procedures
     description: ''
     notes: 'NO'
+  nist_800_53:rev4:AC-1:a:
+    standard:
+      name: nist_800_53:rev4
+    family: AC
+    title: AC-1a.
+    description: 'Develops, documents, and disseminates to [Assignment: organization-defined
+      personnel or roles]:'
+  nist_800_53:rev4:AC-1:a:1:
+    standard:
+      name: nist_800_53:rev4
+    family: AC
+    title: AC-1a.1.
+    description: An access control policy that addresses purpose, scope, roles, responsibilities,
+      management commitment, coordination among organizational entities, and compliance;
+      and
+  nist_800_53:rev4:AC-1:a:2:
+    standard:
+      name: nist_800_53:rev4
+    family: AC
+    title: AC-1a.2.
+    description: Procedures to facilitate the implementation of the access control
+      policy and associated access controls; and
+  nist_800_53:rev4:AC-1:b:
+    standard:
+      name: nist_800_53:rev4
+    family: AC
+    title: AC-1b.
+    description: 'Reviews and updates the current:'
+  nist_800_53:rev4:AC-1:b:1:
+    standard:
+      name: nist_800_53:rev4
+    family: AC
+    title: AC-1b.1.
+    description: 'Access control policy [Assignment: organization-defined frequency];
+      and'
+  nist_800_53:rev4:AC-1:b:2:
+    standard:
+      name: nist_800_53:rev4
+    family: AC
+    title: AC-1b.2.
+    description: 'Access control procedures [Assignment: organization-defined frequency].'
+  nist_800_53:rev4:AC-2:a:
+    standard:
+      name: nist_800_53:rev4
+    family: AC
+    title: AC-2a.
+    description: 'Identifies and selects the following types of information system
+      accounts to support organizational missions/business functions: [Assignment:
+      organization-defined information system account types];'
+  nist_800_53:rev4:AC-2:b:
+    standard:
+      name: nist_800_53:rev4
+    family: AC
+    title: AC-2b.
+    description: Assigns account managers for information system accounts;
+  nist_800_53:rev4:AC-2:c:
+    standard:
+      name: nist_800_53:rev4
+    family: AC
+    title: AC-2c.
+    description: Establishes conditions for group and role membership;
+  nist_800_53:rev4:AC-2:d:
+    standard:
+      name: nist_800_53:rev4
+    family: AC
+    title: AC-2d.
+    description: Specifies authorized users of the information system, group and role
+      membership, and access authorizations (i.e., privileges) and other attributes
+      (as required) for each account;
+  nist_800_53:rev4:AC-2:e:
+    standard:
+      name: nist_800_53:rev4
+    family: AC
+    title: AC-2e.
+    description: 'Requires approvals by [Assignment: organization-defined personnel
+      or roles] for requests to create information system accounts;'
+  nist_800_53:rev4:AC-2:f:
+    standard:
+      name: nist_800_53:rev4
+    family: AC
+    title: AC-2f.
+    description: 'Creates, enables, modifies, disables, and removes information system
+      accounts in accordance with [Assignment: organization-defined procedures or
+      conditions];'
+  nist_800_53:rev4:AC-2:g:
+    standard:
+      name: nist_800_53:rev4
+    family: AC
+    title: AC-2g.
+    description: Monitors the use of information system accounts;
+  nist_800_53:rev4:AC-2:h:
+    standard:
+      name: nist_800_53:rev4
+    family: AC
+    title: AC-2h.
+    description: 'Notifies account managers:'
+  nist_800_53:rev4:AC-2:h:1:
+    standard:
+      name: nist_800_53:rev4
+    family: AC
+    title: AC-2h.1.
+    description: When accounts are no longer required;
+  nist_800_53:rev4:AC-2:h:2:
+    standard:
+      name: nist_800_53:rev4
+    family: AC
+    title: AC-2h.2.
+    description: When users are terminated or transferred; and
+  nist_800_53:rev4:AC-2:h:3:
+    standard:
+      name: nist_800_53:rev4
+    family: AC
+    title: AC-2h.3.
+    description: When individual information system usage or need-to-know changes;
+  nist_800_53:rev4:AC-2:i:
+    standard:
+      name: nist_800_53:rev4
+    family: AC
+    title: AC-2i.
+    description: 'Authorizes access to the information system based on:'
+  nist_800_53:rev4:AC-2:i:1:
+    standard:
+      name: nist_800_53:rev4
+    family: AC
+    title: AC-2i.1.
+    description: A valid access authorization;
+  nist_800_53:rev4:AC-2:i:2:
+    standard:
+      name: nist_800_53:rev4
+    family: AC
+    title: AC-2i.2.
+    description: Intended system usage; and
+  nist_800_53:rev4:AC-2:i:3:
+    standard:
+      name: nist_800_53:rev4
+    family: AC
+    title: AC-2i.3.
+    description: Other attributes as required by the organization or associated missions/business
+      functions;
+  nist_800_53:rev4:AC-2:j:
+    standard:
+      name: nist_800_53:rev4
+    family: AC
+    title: AC-2j.
+    description: 'Reviews accounts for compliance with account management requirements
+      [Assignment: organization-defined frequency]; and'
+  nist_800_53:rev4:AC-2:k:
+    standard:
+      name: nist_800_53:rev4
+    family: AC
+    title: AC-2k.
+    description: Establishes a process for reissuing shared/group account credentials
+      (if deployed) when individuals are removed from the group.
+  nist_800_53:rev4:AC-2:1:
+    standard:
+      name: nist_800_53:rev4
+    family: AC
+    title: AUTOMATED SYSTEM ACCOUNT MANAGEMENT
+    description: The organization employs automated mechanisms to support the management
+      of information system accounts.
+  nist_800_53:rev4:AC-2:2:
+    standard:
+      name: nist_800_53:rev4
+    family: AC
+    title: REMOVAL OF TEMPORARY / EMERGENCY ACCOUNTS
+    description: 'The information system automatically [Selection: removes; disables]
+      temporary and emergency accounts after [Assignment: organization-defined time
+      period for each type of account].'
+  nist_800_53:rev4:AC-2:3:
+    standard:
+      name: nist_800_53:rev4
+    family: AC
+    title: DISABLE INACTIVE ACCOUNTS
+    description: 'The information system automatically disables inactive accounts
+      after [Assignment: organization-defined time period].'
+  nist_800_53:rev4:AC-2:4:
+    standard:
+      name: nist_800_53:rev4
+    family: AC
+    title: AUTOMATED AUDIT ACTIONS
+    description: 'The information system automatically audits account creation, modification,
+      enabling, disabling, and removal actions, and notifies [Assignment: organization-defined
+      personnel or roles].'
+  nist_800_53:rev4:AC-2:5:
+    standard:
+      name: nist_800_53:rev4
+    family: AC
+    title: INACTIVITY LOGOUT
+    description: 'The organization requires that users log out when [Assignment: organization-defined
+      time-period of expected inactivity or description of when to log out].'
+  nist_800_53:rev4:AC-2:6:
+    standard:
+      name: nist_800_53:rev4
+    family: AC
+    title: DYNAMIC PRIVILEGE MANAGEMENT
+    description: 'The information system implements the following dynamic privilege
+      management capabilities: [Assignment: organization-defined list of dynamic privilege
+      management capabilities].'
+  nist_800_53:rev4:AC-2:7:
+    standard:
+      name: nist_800_53:rev4
+    family: AC
+    title: ROLE-BASED SCHEMES
+    description: 'The organization:'
+  nist_800_53:rev4:AC-2:7:a:
+    standard:
+      name: nist_800_53:rev4
+    family: AC
+    title: AC-2 (7)(a)
+    description: Establishes and administers privileged user accounts in accordance
+      with a role-based access scheme that organizes allowed information system access
+      and privileges into roles;
+  nist_800_53:rev4:AC-2:7:b:
+    standard:
+      name: nist_800_53:rev4
+    family: AC
+    title: AC-2 (7)(b)
+    description: Monitors privileged role assignments; and
+  nist_800_53:rev4:AC-2:7:c:
+    standard:
+      name: nist_800_53:rev4
+    family: AC
+    title: AC-2 (7)(c)
+    description: 'Takes [Assignment: organization-defined actions] when privileged
+      role assignments are no longer appropriate.'
+  nist_800_53:rev4:AC-2:8:
+    standard:
+      name: nist_800_53:rev4
+    family: AC
+    title: DYNAMIC ACCOUNT CREATION
+    description: 'The information system creates [Assignment: organization-defined
+      information system accounts] dynamically.'
+  nist_800_53:rev4:AC-2:9:
+    standard:
+      name: nist_800_53:rev4
+    family: AC
+    title: RESTRICTIONS ON USE OF SHARED / GROUP ACCOUNTS
+    description: 'The organization only permits the use of shared/group accounts that
+      meet [Assignment: organization-defined conditions for establishing shared/group
+      accounts].'
+  nist_800_53:rev4:AC-2:10:
+    standard:
+      name: nist_800_53:rev4
+    family: AC
+    title: SHARED / GROUP ACCOUNT CREDENTIAL TERMINATION
+    description: The information system terminates shared/group account credentials
+      when members leave the group.
+  nist_800_53:rev4:AC-2:11:
+    standard:
+      name: nist_800_53:rev4
+    family: AC
+    title: USAGE CONDITIONS
+    description: 'The information system enforces [Assignment: organization-defined
+      circumstances and/or usage conditions] for [Assignment: organization-defined
+      information system accounts].'
+  nist_800_53:rev4:AC-2:12:
+    standard:
+      name: nist_800_53:rev4
+    family: AC
+    title: ACCOUNT MONITORING / ATYPICAL USAGE
+    description: 'The organization:'
+  nist_800_53:rev4:AC-2:12:a:
+    standard:
+      name: nist_800_53:rev4
+    family: AC
+    title: AC-2 (12)(a)
+    description: 'Monitors information system accounts for [Assignment: organization-defined
+      atypical usage]; and'
+  nist_800_53:rev4:AC-2:12:b:
+    standard:
+      name: nist_800_53:rev4
+    family: AC
+    title: AC-2 (12)(b)
+    description: 'Reports atypical usage of information system accounts to [Assignment:
+      organization-defined personnel or roles].'
+  nist_800_53:rev4:AC-2:13:
+    standard:
+      name: nist_800_53:rev4
+    family: AC
+    title: DISABLE ACCOUNTS FOR HIGH-RISK INDIVIDUALS
+    description: 'The organization disables accounts of users posing a significant
+      risk within [Assignment: organization-defined time period] of discovery of the
+      risk.'
+  nist_800_53:rev4:AC-3:1:
+    standard:
+      name: nist_800_53:rev4
+    family: AC
+    title: RESTRICTED ACCESS TO PRIVILEGED FUNCTIONS
+    description: "[Withdrawn: Incorporated into AC-6]."
+  nist_800_53:rev4:AC-3:2:
+    standard:
+      name: nist_800_53:rev4
+    family: AC
+    title: DUAL AUTHORIZATION
+    description: 'The information system enforces dual authorization for [Assignment:
+      organization-defined privileged commands and/or other organization-defined actions].'
+  nist_800_53:rev4:AC-3:3:
+    standard:
+      name: nist_800_53:rev4
+    family: AC
+    title: MANDATORY ACCESS CONTROL
+    description: 'The information system enforces [Assignment: organization-defined
+      mandatory access control policy] over all subjects and objects where the policy:'
+  nist_800_53:rev4:AC-3:3:a:
+    standard:
+      name: nist_800_53:rev4
+    family: AC
+    title: AC-3 (3)(a)
+    description: Is uniformly enforced across all subjects and objects within the
+      boundary of the information system;
+  nist_800_53:rev4:AC-3:3:b:
+    standard:
+      name: nist_800_53:rev4
+    family: AC
+    title: AC-3 (3)(b)
+    description: Specifies that a subject that has been granted access to information
+      is constrained from doing any of the following;
+  nist_800_53:rev4:AC-3:3:b:1:
+    standard:
+      name: nist_800_53:rev4
+    family: AC
+    title: AC-3 (3)(b)(1)
+    description: Passing the information to unauthorized subjects or objects;
+  nist_800_53:rev4:AC-3:3:b:2:
+    standard:
+      name: nist_800_53:rev4
+    family: AC
+    title: AC-3 (3)(b)(2)
+    description: Granting its privileges to other subjects;
+  nist_800_53:rev4:AC-3:3:b:3:
+    standard:
+      name: nist_800_53:rev4
+    family: AC
+    title: AC-3 (3)(b)(3)
+    description: Changing one or more security attributes on subjects, objects, the
+      information system, or information system components;
+  nist_800_53:rev4:AC-3:3:b:4:
+    standard:
+      name: nist_800_53:rev4
+    family: AC
+    title: AC-3 (3)(b)(4)
+    description: Choosing the security attributes and attribute values to be associated
+      with newly created or modified objects; or
+  nist_800_53:rev4:AC-3:3:b:5:
+    standard:
+      name: nist_800_53:rev4
+    family: AC
+    title: AC-3 (3)(b)(5)
+    description: Changing the rules governing access control; and
+  nist_800_53:rev4:AC-3:3:c:
+    standard:
+      name: nist_800_53:rev4
+    family: AC
+    title: AC-3 (3)(c)
+    description: 'Specifies that [Assignment: organization-defined subjects] may explicitly
+      be granted [Assignment: organization-defined privileges (i.e., they are trusted
+      subjects)] such that they are not limited by some or all of the above constraints.'
+  nist_800_53:rev4:AC-3:4:
+    standard:
+      name: nist_800_53:rev4
+    family: AC
+    title: DISCRETIONARY ACCESS CONTROL
+    description: 'The information system enforces [Assignment: organization-defined
+      discretionary access control policy] over defined subjects and objects where
+      the policy specifies that a subject that has been granted access to information
+      can do one or more of the following:'
+  nist_800_53:rev4:AC-3:4:a:
+    standard:
+      name: nist_800_53:rev4
+    family: AC
+    title: AC-3 (4)(a)
+    description: Pass the  information to any other subjects or objects;
+  nist_800_53:rev4:AC-3:4:b:
+    standard:
+      name: nist_800_53:rev4
+    family: AC
+    title: AC-3 (4)(b)
+    description: Grant its privileges to other subjects;
+  nist_800_53:rev4:AC-3:4:c:
+    standard:
+      name: nist_800_53:rev4
+    family: AC
+    title: AC-3 (4)(c)
+    description: Change security attributes on subjects, objects, the information
+      system, or the information system�s components;
+  nist_800_53:rev4:AC-3:4:d:
+    standard:
+      name: nist_800_53:rev4
+    family: AC
+    title: AC-3 (4)(d)
+    description: Choose the security attributes to be associated with newly created
+      or revised objects; or
+  nist_800_53:rev4:AC-3:4:e:
+    standard:
+      name: nist_800_53:rev4
+    family: AC
+    title: AC-3 (4)(e)
+    description: Change the rules governing access control.
+  nist_800_53:rev4:AC-3:5:
+    standard:
+      name: nist_800_53:rev4
+    family: AC
+    title: SECURITY-RELEVANT INFORMATION
+    description: 'The information system prevents access to [Assignment: organization-defined
+      security-relevant information] except during secure, non-operable system states.'
+  nist_800_53:rev4:AC-3:6:
+    standard:
+      name: nist_800_53:rev4
+    family: AC
+    title: PROTECTION OF USER AND SYSTEM INFORMATION
+    description: "[Withdrawn: Incorporated into MP-4 and SC-28]."
+  nist_800_53:rev4:AC-3:7:
+    standard:
+      name: nist_800_53:rev4
+    family: AC
+    title: ROLE-BASED ACCESS CONTROL
+    description: 'The information system enforces a role-based access control policy
+      over defined subjects and objects and controls access based upon [Assignment:
+      organization-defined roles and users authorized to assume such roles].'
+  nist_800_53:rev4:AC-3:8:
+    standard:
+      name: nist_800_53:rev4
+    family: AC
+    title: REVOCATION OF ACCESS AUTHORIZATIONS
+    description: 'The information system enforces the revocation of access authorizations
+      resulting from changes to the security attributes of subjects and objects based
+      on [Assignment: organization-defined rules governing the timing of revocations
+      of access authorizations].'
+  nist_800_53:rev4:AC-3:9:
+    standard:
+      name: nist_800_53:rev4
+    family: AC
+    title: CONTROLLED RELEASE
+    description: 'The information system does not release information outside of the
+      established system boundary unless:'
+  nist_800_53:rev4:AC-3:9:a:
+    standard:
+      name: nist_800_53:rev4
+    family: AC
+    title: AC-3 (9)(a)
+    description: 'The receiving [Assignment: organization-defined information system
+      or system component] provides [Assignment: organization-defined security safeguards];
+      and'
+  nist_800_53:rev4:AC-3:9:b:
+    standard:
+      name: nist_800_53:rev4
+    family: AC
+    title: AC-3 (9)(b)
+    description: "[Assignment: organization-defined security safeguards] are used
+      to validate the appropriateness of the information designated for release."
+  nist_800_53:rev4:AC-3:10:
+    standard:
+      name: nist_800_53:rev4
+    family: AC
+    title: AUDITED OVERRIDE OF ACCESS CONTROL MECHANISMS
+    description: 'The organization employs an audited override of automated access
+      control mechanisms under [Assignment: organization-defined conditions].'
+  nist_800_53:rev4:AC-4:1:
+    standard:
+      name: nist_800_53:rev4
+    family: AC
+    title: OBJECT SECURITY ATTRIBUTES
+    description: 'The information system uses [Assignment: organization-defined security
+      attributes] associated with [Assignment: organization-defined information, source,
+      and destination objects] to enforce [Assignment: organization-defined information
+      flow control policies] as a basis for flow control decisions.'
+  nist_800_53:rev4:AC-4:2:
+    standard:
+      name: nist_800_53:rev4
+    family: AC
+    title: PROCESSING DOMAINS
+    description: 'The information system uses protected processing domains to enforce
+      [Assignment: organization-defined information flow control policies] as a basis
+      for flow control decisions.'
+  nist_800_53:rev4:AC-4:3:
+    standard:
+      name: nist_800_53:rev4
+    family: AC
+    title: DYNAMIC INFORMATION FLOW CONTROL
+    description: 'The information system enforces dynamic information flow control
+      based on [Assignment: organization-defined policies].'
+  nist_800_53:rev4:AC-4:4:
+    standard:
+      name: nist_800_53:rev4
+    family: AC
+    title: CONTENT CHECK ENCRYPTED INFORMATION
+    description: 'The information system prevents encrypted information from bypassing
+      content-checking mechanisms by [Selection (one or more): decrypting the information;
+      blocking the flow of the encrypted information; terminating communications sessions
+      attempting to pass encrypted information; [Assignment: organization-defined
+      procedure or method]].'
+  nist_800_53:rev4:AC-4:5:
+    standard:
+      name: nist_800_53:rev4
+    family: AC
+    title: EMBEDDED DATA TYPES
+    description: 'The information system enforces [Assignment: organization-defined
+      limitations] on embedding data types within other data types.'
+  nist_800_53:rev4:AC-4:6:
+    standard:
+      name: nist_800_53:rev4
+    family: AC
+    title: METADATA
+    description: 'The information system enforces information flow control based on
+      [Assignment: organization-defined metadata].'
+  nist_800_53:rev4:AC-4:7:
+    standard:
+      name: nist_800_53:rev4
+    family: AC
+    title: ONE-WAY FLOW MECHANISMS
+    description: 'The information system enforces [Assignment: organization-defined
+      one-way information flows] using hardware mechanisms.'
+  nist_800_53:rev4:AC-4:8:
+    standard:
+      name: nist_800_53:rev4
+    family: AC
+    title: SECURITY POLICY FILTERS
+    description: 'The information system enforces information flow control using [Assignment:
+      organization-defined security policy filters] as a basis for flow control decisions
+      for [Assignment: organization-defined information flows].'
+  nist_800_53:rev4:AC-4:9:
+    standard:
+      name: nist_800_53:rev4
+    family: AC
+    title: HUMAN REVIEWS
+    description: 'The information system enforces the use of human reviews for [Assignment:
+      organization-defined information flows] under the following conditions: [Assignment:
+      organization-defined conditions].'
+  nist_800_53:rev4:AC-4:10:
+    standard:
+      name: nist_800_53:rev4
+    family: AC
+    title: ENABLE / DISABLE SECURITY POLICY FILTERS
+    description: 'The information system provides the capability for privileged administrators
+      to enable/disable [Assignment: organization-defined security policy filters]
+      under the following conditions: [Assignment: organization-defined conditions].'
+  nist_800_53:rev4:AC-4:11:
+    standard:
+      name: nist_800_53:rev4
+    family: AC
+    title: CONFIGURATION OF SECURITY POLICY FILTERS
+    description: 'The information system provides the capability for privileged administrators
+      to configure [Assignment: organization-defined security policy filters] to support
+      different security policies.'
+  nist_800_53:rev4:AC-4:12:
+    standard:
+      name: nist_800_53:rev4
+    family: AC
+    title: DATA TYPE IDENTIFIERS
+    description: 'The information system, when transferring information between different
+      security domains, uses [Assignment: organization-defined data type identifiers]
+      to validate data essential for information flow decisions.'
+  nist_800_53:rev4:AC-4:13:
+    standard:
+      name: nist_800_53:rev4
+    family: AC
+    title: DECOMPOSITION INTO POLICY-RELEVANT SUBCOMPONENTS
+    description: 'The information system, when transferring information between different
+      security domains, decomposes information into [Assignment: organization-defined
+      policy-relevant subcomponents] for submission to policy enforcement mechanisms.'
+  nist_800_53:rev4:AC-4:14:
+    standard:
+      name: nist_800_53:rev4
+    family: AC
+    title: SECURITY POLICY FILTER CONSTRAINTS
+    description: 'The information system, when transferring information between different
+      security domains, implements [Assignment: organization-defined security policy
+      filters] requiring fully enumerated formats that restrict data structure and
+      content.'
+  nist_800_53:rev4:AC-4:15:
+    standard:
+      name: nist_800_53:rev4
+    family: AC
+    title: DETECTION OF UNSANCTIONED INFORMATION
+    description: 'The information system, when transferring information between different
+      security domains, examines the information for the presence of [Assignment:
+      organized-defined unsanctioned information] and prohibits the transfer of such
+      information in accordance with the [Assignment: organization-defined security
+      policy].'
+  nist_800_53:rev4:AC-4:16:
+    standard:
+      name: nist_800_53:rev4
+    family: AC
+    title: INFORMATION TRANSFERS ON INTERCONNECTED SYSTEMS
+    description: "[Withdrawn: Incorporated into AC-4]."
+  nist_800_53:rev4:AC-4:17:
+    standard:
+      name: nist_800_53:rev4
+    family: AC
+    title: DOMAIN AUTHENTICATION
+    description: 'The information system uniquely identifies and authenticates source
+      and destination points by [Selection (one or more): organization, system, application,
+      individual] for information transfer.'
+  nist_800_53:rev4:AC-4:18:
+    standard:
+      name: nist_800_53:rev4
+    family: AC
+    title: SECURITY ATTRIBUTE BINDING
+    description: 'The information system binds security attributes to information
+      using [Assignment: organization-defined binding techniques] to facilitate information
+      flow policy enforcement.'
+  nist_800_53:rev4:AC-4:19:
+    standard:
+      name: nist_800_53:rev4
+    family: AC
+    title: VALIDATION OF METADATA
+    description: The information system, when transferring information between different
+      security domains, applies the same security policy filtering to metadata as
+      it applies to data payloads.
+  nist_800_53:rev4:AC-4:20:
+    standard:
+      name: nist_800_53:rev4
+    family: AC
+    title: APPROVED SOLUTIONS
+    description: 'The organization employs [Assignment: organization-defined solutions
+      in approved configurations] to control the flow of [Assignment: organization-defined
+      information] across security domains.'
+  nist_800_53:rev4:AC-4:21:
+    standard:
+      name: nist_800_53:rev4
+    family: AC
+    title: PHYSICAL / LOGICAL SEPARATION OF INFORMATION FLOWS
+    description: 'The information system separates information flows logically or
+      physically using [Assignment: organization-defined mechanisms and/or techniques]
+      to accomplish [Assignment: organization-defined required separations by types
+      of information].'
+  nist_800_53:rev4:AC-4:22:
+    standard:
+      name: nist_800_53:rev4
+    family: AC
+    title: ACCESS ONLY
+    description: The information system provides access from a single device to computing
+      platforms, applications, or data residing on multiple different security domains,
+      while preventing any information flow between the different security domains.
+  nist_800_53:rev4:AC-5:a:
+    standard:
+      name: nist_800_53:rev4
+    family: AC
+    title: AC-5a.
+    description: 'Separates [Assignment: organization-defined duties of individuals];'
+  nist_800_53:rev4:AC-5:b:
+    standard:
+      name: nist_800_53:rev4
+    family: AC
+    title: AC-5b.
+    description: Documents separation of duties of individuals; and
+  nist_800_53:rev4:AC-5:c:
+    standard:
+      name: nist_800_53:rev4
+    family: AC
+    title: AC-5c.
+    description: Defines information system access authorizations to support separation
+      of duties.
+  nist_800_53:rev4:AC-6:1:
+    standard:
+      name: nist_800_53:rev4
+    family: AC
+    title: AUTHORIZE ACCESS TO SECURITY FUNCTIONS
+    description: 'The organization explicitly authorizes access to [Assignment: organization-defined
+      security functions (deployed in hardware, software, and firmware) and security-relevant
+      information].'
+  nist_800_53:rev4:AC-6:2:
+    standard:
+      name: nist_800_53:rev4
+    family: AC
+    title: NON-PRIVILEGED ACCESS FOR NONSECURITY FUNCTIONS
+    description: 'The organization requires that users of information system accounts,
+      or roles, with access to [Assignment: organization-defined security functions
+      or security-relevant information], use non-privileged accounts or roles, when
+      accessing nonsecurity functions.'
+  nist_800_53:rev4:AC-6:3:
+    standard:
+      name: nist_800_53:rev4
+    family: AC
+    title: NETWORK ACCESS TO PRIVILEGED COMMANDS
+    description: 'The organization authorizes network access to [Assignment: organization-defined
+      privileged commands] only for [Assignment: organization-defined compelling operational
+      needs] and documents the rationale for such access in the security plan for
+      the information system.'
+  nist_800_53:rev4:AC-6:4:
+    standard:
+      name: nist_800_53:rev4
+    family: AC
+    title: SEPARATE PROCESSING DOMAINS
+    description: The information system provides separate processing domains to enable
+      finer-grained allocation of user privileges.
+  nist_800_53:rev4:AC-6:5:
+    standard:
+      name: nist_800_53:rev4
+    family: AC
+    title: PRIVILEGED ACCOUNTS
+    description: 'The organization restricts privileged accounts on the information
+      system to [Assignment: organization-defined personnel or roles].'
+  nist_800_53:rev4:AC-6:6:
+    standard:
+      name: nist_800_53:rev4
+    family: AC
+    title: PRIVILEGED ACCESS BY NON-ORGANIZATIONAL USERS
+    description: The organization prohibits privileged access to the information system
+      by non-organizational users.
+  nist_800_53:rev4:AC-6:7:
+    standard:
+      name: nist_800_53:rev4
+    family: AC
+    title: REVIEW OF USER PRIVILEGES
+    description: 'The organization:'
+  nist_800_53:rev4:AC-6:7:a:
+    standard:
+      name: nist_800_53:rev4
+    family: AC
+    title: AC-6 (7)(a)
+    description: 'Reviews [Assignment: organization-defined frequency] the privileges
+      assigned to [Assignment: organization-defined roles or classes of users] to
+      validate the need for such privileges; and'
+  nist_800_53:rev4:AC-6:7:b:
+    standard:
+      name: nist_800_53:rev4
+    family: AC
+    title: AC-6 (7)(b)
+    description: Reassigns or removes privileges, if necessary, to correctly reflect
+      organizational mission/business needs.
+  nist_800_53:rev4:AC-6:8:
+    standard:
+      name: nist_800_53:rev4
+    family: AC
+    title: PRIVILEGE LEVELS FOR CODE EXECUTION
+    description: 'The information system prevents [Assignment: organization-defined
+      software] from executing at higher privilege levels than users executing the
+      software.'
+  nist_800_53:rev4:AC-6:9:
+    standard:
+      name: nist_800_53:rev4
+    family: AC
+    title: AUDITING USE OF PRIVILEGED FUNCTIONS
+    description: The information system audits the execution of privileged functions.
+  nist_800_53:rev4:AC-6:10:
+    standard:
+      name: nist_800_53:rev4
+    family: AC
+    title: PROHIBIT NON-PRIVILEGED USERS FROM EXECUTING PRIVILEGED FUNCTIONS
+    description: The information system prevents non-privileged users from executing
+      privileged functions to include disabling, circumventing, or altering implemented
+      security safeguards/countermeasures.
+  nist_800_53:rev4:AC-7:a:
+    standard:
+      name: nist_800_53:rev4
+    family: AC
+    title: AC-7a.
+    description: 'Enforces a limit of [Assignment: organization-defined number] consecutive
+      invalid logon attempts by a user during a [Assignment: organization-defined
+      time period]; and'
+  nist_800_53:rev4:AC-7:b:
+    standard:
+      name: nist_800_53:rev4
+    family: AC
+    title: AC-7b.
+    description: 'Automatically [Selection: locks the account/node for an [Assignment:
+      organization-defined time period]; locks the account/node until released by
+      an administrator; delays next logon prompt according to [Assignment: organization-defined
+      delay algorithm]] when the maximum number of unsuccessful attempts is exceeded.'
+  nist_800_53:rev4:AC-7:1:
+    standard:
+      name: nist_800_53:rev4
+    family: AC
+    title: AUTOMATIC ACCOUNT LOCK
+    description: "[Withdrawn: Incorporated into AC-7]."
+  nist_800_53:rev4:AC-7:2:
+    standard:
+      name: nist_800_53:rev4
+    family: AC
+    title: PURGE / WIPE MOBILE DEVICE
+    description: 'The information system purges/wipes information from [Assignment:
+      organization-defined mobile devices] based on [Assignment: organization-defined
+      purging/wiping requirements/techniques] after [Assignment: organization-defined
+      number] consecutive, unsuccessful device logon attempts.'
+  nist_800_53:rev4:AC-8:a:
+    standard:
+      name: nist_800_53:rev4
+    family: AC
+    title: AC-8a.
+    description: 'Displays to users [Assignment: organization-defined system use notification
+      message or banner] before granting access to the system that provides privacy
+      and security notices consistent with applicable federal laws, Executive Orders,
+      directives, policies, regulations, standards, and guidance and states that:'
+  nist_800_53:rev4:AC-8:a:1:
+    standard:
+      name: nist_800_53:rev4
+    family: AC
+    title: AC-8a.1.
+    description: Users are accessing a U.S. Government information system;
+  nist_800_53:rev4:AC-8:a:2:
+    standard:
+      name: nist_800_53:rev4
+    family: AC
+    title: AC-8a.2.
+    description: Information system usage may be monitored, recorded, and subject
+      to audit;
+  nist_800_53:rev4:AC-8:a:3:
+    standard:
+      name: nist_800_53:rev4
+    family: AC
+    title: AC-8a.3.
+    description: Unauthorized use of the information system is prohibited and subject
+      to criminal and civil penalties; and
+  nist_800_53:rev4:AC-8:a:4:
+    standard:
+      name: nist_800_53:rev4
+    family: AC
+    title: AC-8a.4.
+    description: Use of the information system indicates consent to monitoring and
+      recording;
+  nist_800_53:rev4:AC-8:b:
+    standard:
+      name: nist_800_53:rev4
+    family: AC
+    title: AC-8b.
+    description: Retains the notification message or banner on the screen until users
+      acknowledge the usage conditions and take explicit actions to log on to or further
+      access the information system; and
+  nist_800_53:rev4:AC-8:c:
+    standard:
+      name: nist_800_53:rev4
+    family: AC
+    title: AC-8c.
+    description: 'For publicly accessible systems:'
+  nist_800_53:rev4:AC-8:c:1:
+    standard:
+      name: nist_800_53:rev4
+    family: AC
+    title: AC-8c.1.
+    description: 'Displays system use information [Assignment: organization-defined
+      conditions], before granting further access;'
+  nist_800_53:rev4:AC-8:c:2:
+    standard:
+      name: nist_800_53:rev4
+    family: AC
+    title: AC-8c.2.
+    description: Displays references, if any, to monitoring, recording, or auditing
+      that are consistent with privacy accommodations for such systems that generally
+      prohibit those activities; and
+  nist_800_53:rev4:AC-8:c:3:
+    standard:
+      name: nist_800_53:rev4
+    family: AC
+    title: AC-8c.3.
+    description: Includes a description of the authorized uses of the system.
+  nist_800_53:rev4:AC-9:1:
+    standard:
+      name: nist_800_53:rev4
+    family: AC
+    title: UNSUCCESSFUL LOGONS
+    description: The information system notifies the user, upon successful logon/access,
+      of the number of unsuccessful logon/access attempts since the last successful
+      logon/access.
+  nist_800_53:rev4:AC-9:2:
+    standard:
+      name: nist_800_53:rev4
+    family: AC
+    title: SUCCESSFUL / UNSUCCESSFUL LOGONS
+    description: 'The information system notifies the user of the number of [Selection:
+      successful logons/accesses; unsuccessful logon/access attempts; both] during
+      [Assignment: organization-defined time period].'
+  nist_800_53:rev4:AC-9:3:
+    standard:
+      name: nist_800_53:rev4
+    family: AC
+    title: NOTIFICATION OF ACCOUNT CHANGES
+    description: 'The information system notifies the user of changes to [Assignment:
+      organization-defined security-related characteristics/parameters of the user�s
+      account] during [Assignment: organization-defined time period].'
+  nist_800_53:rev4:AC-9:4:
+    standard:
+      name: nist_800_53:rev4
+    family: AC
+    title: ADDITIONAL LOGON INFORMATION
+    description: 'The information system notifies the user, upon successful logon
+      (access), of the following additional information: [Assignment: organization-defined
+      information to be included in addition to the date and time of the last logon
+      (access)].'
+  nist_800_53:rev4:AC-11:a:
+    standard:
+      name: nist_800_53:rev4
+    family: AC
+    title: AC-11a.
+    description: 'Prevents further access to the system by initiating a session lock
+      after [Assignment: organization-defined time period] of inactivity or upon receiving
+      a request from a user; and'
+  nist_800_53:rev4:AC-11:b:
+    standard:
+      name: nist_800_53:rev4
+    family: AC
+    title: AC-11b.
+    description: Retains the session lock until the user reestablishes access using
+      established identification and authentication procedures.
+  nist_800_53:rev4:AC-11:1:
+    standard:
+      name: nist_800_53:rev4
+    family: AC
+    title: PATTERN-HIDING DISPLAYS
+    description: The information system conceals, via the session lock, information
+      previously visible on the display with a publicly viewable image.
+  nist_800_53:rev4:AC-12:1:
+    standard:
+      name: nist_800_53:rev4
+    family: AC
+    title: USER-INITIATED LOGOUTS / MESSAGE DISPLAYS
+    description: 'The information system:'
+  nist_800_53:rev4:AC-12:1:a:
+    standard:
+      name: nist_800_53:rev4
+    family: AC
+    title: AC-12 (1)(a)
+    description: 'Provides a logout capability for user-initiated communications sessions
+      whenever authentication is used to gain access to [Assignment: organization-defined
+      information resources]; and'
+  nist_800_53:rev4:AC-12:1:b:
+    standard:
+      name: nist_800_53:rev4
+    family: AC
+    title: AC-12 (1)(b)
+    description: Displays an explicit logout message to users indicating the reliable
+      termination of authenticated communications sessions.
+  nist_800_53:rev4:AC-14:a:
+    standard:
+      name: nist_800_53:rev4
+    family: AC
+    title: AC-14a.
+    description: 'Identifies [Assignment: organization-defined user actions] that
+      can be performed on the information system without identification or authentication
+      consistent with organizational missions/business functions; and'
+  nist_800_53:rev4:AC-14:b:
+    standard:
+      name: nist_800_53:rev4
+    family: AC
+    title: AC-14b.
+    description: Documents and provides supporting rationale in the security plan
+      for the information system, user actions not requiring identification or authentication.
+  nist_800_53:rev4:AC-14:1:
+    standard:
+      name: nist_800_53:rev4
+    family: AC
+    title: NECESSARY USES
+    description: "[Withdrawn: Incorporated into AC-14]."
+  nist_800_53:rev4:AC-16:a:
+    standard:
+      name: nist_800_53:rev4
+    family: AC
+    title: AC-16a.
+    description: 'Provides the means to associate [Assignment: organization-defined
+      types of security attributes] having [Assignment: organization-defined security
+      attribute values] with information in storage, in process, and/or in transmission;'
+  nist_800_53:rev4:AC-16:b:
+    standard:
+      name: nist_800_53:rev4
+    family: AC
+    title: AC-16b.
+    description: Ensures that the security attribute associations are made and retained
+      with the information;
+  nist_800_53:rev4:AC-16:c:
+    standard:
+      name: nist_800_53:rev4
+    family: AC
+    title: AC-16c.
+    description: 'Establishes the permitted [Assignment: organization-defined security
+      attributes] for [Assignment: organization-defined information systems]; and'
+  nist_800_53:rev4:AC-16:d:
+    standard:
+      name: nist_800_53:rev4
+    family: AC
+    title: AC-16d.
+    description: 'Determines the permitted [Assignment: organization-defined values
+      or ranges] for each of the established security attributes.'
+  nist_800_53:rev4:AC-16:1:
+    standard:
+      name: nist_800_53:rev4
+    family: AC
+    title: DYNAMIC ATTRIBUTE ASSOCIATION
+    description: 'The information system dynamically associates security attributes
+      with [Assignment: organization-defined subjects and objects] in accordance with
+      [Assignment: organization-defined security policies] as information is created
+      and combined.'
+  nist_800_53:rev4:AC-16:2:
+    standard:
+      name: nist_800_53:rev4
+    family: AC
+    title: ATTRIBUTE VALUE CHANGES BY AUTHORIZED INDIVIDUALS
+    description: The information system provides authorized individuals (or processes
+      acting on behalf of individuals) the capability to define or change the value
+      of associated security attributes.
+  nist_800_53:rev4:AC-16:3:
+    standard:
+      name: nist_800_53:rev4
+    family: AC
+    title: MAINTENANCE OF ATTRIBUTE ASSOCIATIONS BY INFORMATION SYSTEM
+    description: 'The information system maintains the association and integrity of
+      [Assignment: organization-defined security attributes] to [Assignment: organization-defined
+      subjects and objects].'
+  nist_800_53:rev4:AC-16:4:
+    standard:
+      name: nist_800_53:rev4
+    family: AC
+    title: ASSOCIATION OF ATTRIBUTES BY AUTHORIZED INDIVIDUALS
+    description: 'The information system supports the association of [Assignment:
+      organization-defined security attributes] with [Assignment: organization-defined
+      subjects and objects] by authorized individuals (or processes acting on behalf
+      of individuals).'
+  nist_800_53:rev4:AC-16:5:
+    standard:
+      name: nist_800_53:rev4
+    family: AC
+    title: ATTRIBUTE DISPLAYS FOR OUTPUT DEVICES
+    description: 'The information system displays security attributes in human-readable
+      form on each object that the system transmits to output devices to identify
+      [Assignment: organization-identified special dissemination, handling, or distribution
+      instructions] using [Assignment: organization-identified human-readable, standard
+      naming conventions].'
+  nist_800_53:rev4:AC-16:6:
+    standard:
+      name: nist_800_53:rev4
+    family: AC
+    title: MAINTENANCE OF ATTRIBUTE ASSOCIATION BY ORGANIZATION
+    description: 'The organization allows personnel to associate, and maintain the
+      association of [Assignment: organization-defined security attributes] with [Assignment:
+      organization-defined subjects and objects] in accordance with [Assignment: organization-defined
+      security policies].'
+  nist_800_53:rev4:AC-16:7:
+    standard:
+      name: nist_800_53:rev4
+    family: AC
+    title: CONSISTENT ATTRIBUTE INTERPRETATION
+    description: The organization provides a consistent interpretation of security
+      attributes transmitted between distributed information system components.
+  nist_800_53:rev4:AC-16:8:
+    standard:
+      name: nist_800_53:rev4
+    family: AC
+    title: ASSOCIATION TECHNIQUES / TECHNOLOGIES
+    description: 'The information system implements [Assignment: organization-defined
+      techniques or technologies] with [Assignment: organization-defined level of
+      assurance] in associating security attributes to information.'
+  nist_800_53:rev4:AC-16:9:
+    standard:
+      name: nist_800_53:rev4
+    family: AC
+    title: ATTRIBUTE REASSIGNMENT
+    description: 'The organization ensures that security attributes associated with
+      information are reassigned only via re-grading mechanisms validated using [Assignment:
+      organization-defined techniques or procedures].'
+  nist_800_53:rev4:AC-16:10:
+    standard:
+      name: nist_800_53:rev4
+    family: AC
+    title: ATTRIBUTE CONFIGURATION BY AUTHORIZED INDIVIDUALS
+    description: The information system provides authorized individuals the capability
+      to define or change the type and value of security attributes available for
+      association with subjects and objects.
+  nist_800_53:rev4:AC-17:a:
+    standard:
+      name: nist_800_53:rev4
+    family: AC
+    title: AC-17a.
+    description: Establishes and documents usage restrictions, configuration/connection
+      requirements, and implementation guidance for each type of remote access allowed;
+      and
+  nist_800_53:rev4:AC-17:b:
+    standard:
+      name: nist_800_53:rev4
+    family: AC
+    title: AC-17b.
+    description: Authorizes remote access to the information system prior to allowing
+      such connections.
+  nist_800_53:rev4:AC-17:1:
+    standard:
+      name: nist_800_53:rev4
+    family: AC
+    title: AUTOMATED MONITORING / CONTROL
+    description: The information system monitors and controls remote access methods.
+  nist_800_53:rev4:AC-17:2:
+    standard:
+      name: nist_800_53:rev4
+    family: AC
+    title: PROTECTION OF CONFIDENTIALITY / INTEGRITY USING ENCRYPTION
+    description: The information system implements cryptographic mechanisms to protect
+      the confidentiality and integrity of remote access sessions.
+  nist_800_53:rev4:AC-17:3:
+    standard:
+      name: nist_800_53:rev4
+    family: AC
+    title: MANAGED ACCESS CONTROL POINTS
+    description: 'The information system routes all remote accesses through [Assignment:
+      organization-defined number] managed network access control points.'
+  nist_800_53:rev4:AC-17:4:
+    standard:
+      name: nist_800_53:rev4
+    family: AC
+    title: PRIVILEGED COMMANDS / ACCESS
+    description: 'The organization:'
+  nist_800_53:rev4:AC-17:4:a:
+    standard:
+      name: nist_800_53:rev4
+    family: AC
+    title: AC-17 (4)(a)
+    description: 'Authorizes the execution of privileged commands and access to security-relevant
+      information via remote access only for [Assignment: organization-defined needs];
+      and'
+  nist_800_53:rev4:AC-17:4:b:
+    standard:
+      name: nist_800_53:rev4
+    family: AC
+    title: AC-17 (4)(b)
+    description: Documents the rationale for such access in the security plan for
+      the information system.
+  nist_800_53:rev4:AC-17:5:
+    standard:
+      name: nist_800_53:rev4
+    family: AC
+    title: MONITORING FOR UNAUTHORIZED CONNECTIONS
+    description: "[Withdrawn: Incorporated into SI-4]."
+  nist_800_53:rev4:AC-17:6:
+    standard:
+      name: nist_800_53:rev4
+    family: AC
+    title: PROTECTION OF INFORMATION
+    description: The organization ensures that users protect information about remote
+      access mechanisms from unauthorized use and disclosure.
+  nist_800_53:rev4:AC-17:7:
+    standard:
+      name: nist_800_53:rev4
+    family: AC
+    title: ADDITIONAL PROTECTION FOR SECURITY FUNCTION ACCESS
+    description: "[Withdrawn: Incorporated into AC-3 (10)]."
+  nist_800_53:rev4:AC-17:8:
+    standard:
+      name: nist_800_53:rev4
+    family: AC
+    title: DISABLE NONSECURE NETWORK PROTOCOLS
+    description: "[Withdrawn: Incorporated into CM-7]."
+  nist_800_53:rev4:AC-17:9:
+    standard:
+      name: nist_800_53:rev4
+    family: AC
+    title: DISCONNECT / DISABLE ACCESS
+    description: 'The organization provides the capability to expeditiously disconnect
+      or disable remote access to the information system within [Assignment: organization-defined
+      time period].'
+  nist_800_53:rev4:AC-18:a:
+    standard:
+      name: nist_800_53:rev4
+    family: AC
+    title: AC-18a.
+    description: Establishes usage restrictions, configuration/connection requirements,
+      and implementation guidance for wireless access; and
+  nist_800_53:rev4:AC-18:b:
+    standard:
+      name: nist_800_53:rev4
+    family: AC
+    title: AC-18b.
+    description: Authorizes wireless access to the information system prior to allowing
+      such connections.
+  nist_800_53:rev4:AC-18:1:
+    standard:
+      name: nist_800_53:rev4
+    family: AC
+    title: AUTHENTICATION AND ENCRYPTION
+    description: 'The information system protects wireless access to the system using
+      authentication of [Selection (one or more): users; devices] and encryption.'
+  nist_800_53:rev4:AC-18:2:
+    standard:
+      name: nist_800_53:rev4
+    family: AC
+    title: MONITORING UNAUTHORIZED CONNECTIONS
+    description: "[Withdrawn: Incorporated into SI-4]."
+  nist_800_53:rev4:AC-18:3:
+    standard:
+      name: nist_800_53:rev4
+    family: AC
+    title: DISABLE WIRELESS NETWORKING
+    description: The organization disables, when not intended for use, wireless networking
+      capabilities internally embedded within information system components prior
+      to issuance and deployment.
+  nist_800_53:rev4:AC-18:4:
+    standard:
+      name: nist_800_53:rev4
+    family: AC
+    title: RESTRICT CONFIGURATIONS BY USERS
+    description: The organization identifies and explicitly authorizes users allowed
+      to independently configure wireless networking capabilities.
+  nist_800_53:rev4:AC-18:5:
+    standard:
+      name: nist_800_53:rev4
+    family: AC
+    title: ANTENNAS / TRANSMISSION POWER LEVELS
+    description: The organization selects radio antennas and calibrates transmission
+      power levels to reduce the probability that usable signals can be received outside
+      of organization-controlled boundaries.
+  nist_800_53:rev4:AC-19:a:
+    standard:
+      name: nist_800_53:rev4
+    family: AC
+    title: AC-19a.
+    description: Establishes usage restrictions, configuration requirements, connection
+      requirements, and implementation guidance for organization-controlled mobile
+      devices; and
+  nist_800_53:rev4:AC-19:b:
+    standard:
+      name: nist_800_53:rev4
+    family: AC
+    title: AC-19b.
+    description: Authorizes the connection of mobile devices to organizational information
+      systems.
+  nist_800_53:rev4:AC-19:1:
+    standard:
+      name: nist_800_53:rev4
+    family: AC
+    title: USE OF  WRITABLE / PORTABLE STORAGE DEVICES
+    description: "[Withdrawn: Incorporated into MP-7]."
+  nist_800_53:rev4:AC-19:2:
+    standard:
+      name: nist_800_53:rev4
+    family: AC
+    title: USE OF PERSONALLY OWNED PORTABLE STORAGE DEVICES
+    description: "[Withdrawn: Incorporated into MP-7]."
+  nist_800_53:rev4:AC-19:3:
+    standard:
+      name: nist_800_53:rev4
+    family: AC
+    title: USE OF PORTABLE STORAGE DEVICES WITH NO IDENTIFIABLE OWNER
+    description: "[Withdrawn: Incorporated into MP-7]."
+  nist_800_53:rev4:AC-19:4:
+    standard:
+      name: nist_800_53:rev4
+    family: AC
+    title: RESTRICTIONS FOR CLASSIFIED INFORMATION
+    description: 'The organization:'
+  nist_800_53:rev4:AC-19:4:a:
+    standard:
+      name: nist_800_53:rev4
+    family: AC
+    title: AC-19 (4)(a)
+    description: Prohibits the use of unclassified mobile devices in facilities containing
+      information systems processing, storing, or transmitting classified information
+      unless specifically permitted by the authorizing official; and
+  nist_800_53:rev4:AC-19:4:b:
+    standard:
+      name: nist_800_53:rev4
+    family: AC
+    title: AC-19 (4)(b)
+    description: 'Enforces the following restrictions on individuals permitted by
+      the authorizing official to use unclassified mobile devices in facilities containing
+      information systems processing, storing, or transmitting classified information:'
+  nist_800_53:rev4:AC-19:4:b:1:
+    standard:
+      name: nist_800_53:rev4
+    family: AC
+    title: AC-19 (4)(b)(1)
+    description: Connection of unclassified mobile devices to classified information
+      systems is prohibited;
+  nist_800_53:rev4:AC-19:4:b:2:
+    standard:
+      name: nist_800_53:rev4
+    family: AC
+    title: AC-19 (4)(b)(2)
+    description: Connection of unclassified mobile devices to unclassified information
+      systems requires approval from the authorizing official;
+  nist_800_53:rev4:AC-19:4:b:3:
+    standard:
+      name: nist_800_53:rev4
+    family: AC
+    title: AC-19 (4)(b)(3)
+    description: Use of internal or external modems or wireless interfaces within
+      the unclassified mobile devices is prohibited; and
+  nist_800_53:rev4:AC-19:4:b:4:
+    standard:
+      name: nist_800_53:rev4
+    family: AC
+    title: AC-19 (4)(b)(4)
+    description: 'Unclassified mobile devices and the information stored on those
+      devices are subject to random reviews and inspections by [Assignment: organization-defined
+      security officials], and if classified information is found, the incident handling
+      policy is followed.'
+  nist_800_53:rev4:AC-19:4:c:
+    standard:
+      name: nist_800_53:rev4
+    family: AC
+    title: AC-19 (4)(c)
+    description: 'Restricts the connection of classified mobile devices to classified
+      information systems in accordance with [Assignment: organization-defined security
+      policies].'
+  nist_800_53:rev4:AC-19:5:
+    standard:
+      name: nist_800_53:rev4
+    family: AC
+    title: FULL DEVICE / CONTAINER-BASED  ENCRYPTION
+    description: 'The organization employs [Selection: full-device encryption; container
+      encryption] to protect the confidentiality and integrity of information on [Assignment:
+      organization-defined mobile devices].'
+  nist_800_53:rev4:AC-20:a:
+    standard:
+      name: nist_800_53:rev4
+    family: AC
+    title: AC-20a.
+    description: Access the information system from external information systems;
+      and
+  nist_800_53:rev4:AC-20:b:
+    standard:
+      name: nist_800_53:rev4
+    family: AC
+    title: AC-20b.
+    description: Process, store, or transmit organization-controlled information using
+      external information systems.
+  nist_800_53:rev4:AC-20:1:
+    standard:
+      name: nist_800_53:rev4
+    family: AC
+    title: LIMITS ON AUTHORIZED USE
+    description: 'The organization permits authorized individuals to use an external
+      information system to access the information system or to process, store, or
+      transmit organization-controlled information only when the organization:'
+  nist_800_53:rev4:AC-20:1:a:
+    standard:
+      name: nist_800_53:rev4
+    family: AC
+    title: AC-20 (1)(a)
+    description: Verifies the implementation of required security controls on the
+      external system as specified in the organization�s information security policy
+      and security plan; or
+  nist_800_53:rev4:AC-20:1:b:
+    standard:
+      name: nist_800_53:rev4
+    family: AC
+    title: AC-20 (1)(b)
+    description: Retains approved information system connection or processing agreements
+      with the organizational entity hosting the external information system.
+  nist_800_53:rev4:AC-20:2:
+    standard:
+      name: nist_800_53:rev4
+    family: AC
+    title: PORTABLE STORAGE DEVICES
+    description: 'The organization [Selection: restricts; prohibits] the use of organization-controlled
+      portable storage devices by authorized individuals on external information systems.'
+  nist_800_53:rev4:AC-20:3:
+    standard:
+      name: nist_800_53:rev4
+    family: AC
+    title: NON-ORGANIZATIONALLY OWNED SYSTEMS / COMPONENTS / DEVICES
+    description: 'The organization [Selection: restricts; prohibits] the use of non-organizationally
+      owned information systems, system components, or devices to process, store,
+      or transmit organizational information.'
+  nist_800_53:rev4:AC-20:4:
+    standard:
+      name: nist_800_53:rev4
+    family: AC
+    title: NETWORK ACCESSIBLE STORAGE DEVICES
+    description: 'The organization prohibits the use of [Assignment: organization-defined
+      network accessible storage devices] in external information systems.'
+  nist_800_53:rev4:AC-21:a:
+    standard:
+      name: nist_800_53:rev4
+    family: AC
+    title: AC-21a.
+    description: 'Facilitates information sharing by enabling authorized users to
+      determine whether access authorizations assigned to the sharing partner match
+      the access restrictions on the information for [Assignment: organization-defined
+      information sharing circumstances where user discretion is required]; and'
+  nist_800_53:rev4:AC-21:b:
+    standard:
+      name: nist_800_53:rev4
+    family: AC
+    title: AC-21b.
+    description: 'Employs [Assignment: organization-defined automated mechanisms or
+      manual processes] to assist users in making information sharing/collaboration
+      decisions.'
+  nist_800_53:rev4:AC-21:1:
+    standard:
+      name: nist_800_53:rev4
+    family: AC
+    title: AUTOMATED DECISION SUPPORT
+    description: The information system enforces information-sharing decisions by
+      authorized users based on access authorizations of sharing partners and access
+      restrictions on information to be shared.
+  nist_800_53:rev4:AC-21:2:
+    standard:
+      name: nist_800_53:rev4
+    family: AC
+    title: INFORMATION SEARCH AND RETRIEVAL
+    description: 'The information system implements information search and retrieval
+      services that enforce [Assignment: organization-defined information sharing
+      restrictions].'
+  nist_800_53:rev4:AC-22:a:
+    standard:
+      name: nist_800_53:rev4
+    family: AC
+    title: AC-22a.
+    description: Designates individuals authorized to post information onto a publicly
+      accessible information system;
+  nist_800_53:rev4:AC-22:b:
+    standard:
+      name: nist_800_53:rev4
+    family: AC
+    title: AC-22b.
+    description: Trains authorized individuals to ensure that publicly accessible
+      information does not contain nonpublic information;
+  nist_800_53:rev4:AC-22:c:
+    standard:
+      name: nist_800_53:rev4
+    family: AC
+    title: AC-22c.
+    description: Reviews the proposed content of information prior to posting onto
+      the publicly accessible information system to ensure that nonpublic information
+      is not included; and
+  nist_800_53:rev4:AC-22:d:
+    standard:
+      name: nist_800_53:rev4
+    family: AC
+    title: AC-22d.
+    description: 'Reviews the content on the publicly accessible information system
+      for nonpublic information [Assignment: organization-defined frequency] and removes
+      such information, if discovered.'
+  nist_800_53:rev4:AC-24:1:
+    standard:
+      name: nist_800_53:rev4
+    family: AC
+    title: TRANSMIT ACCESS AUTHORIZATION INFORMATION
+    description: 'The information system transmits [Assignment: organization-defined
+      access authorization information] using [Assignment: organization-defined security
+      safeguards] to [Assignment: organization-defined information systems] that enforce
+      access control decisions.'
+  nist_800_53:rev4:AC-24:2:
+    standard:
+      name: nist_800_53:rev4
+    family: AC
+    title: NO USER OR PROCESS IDENTITY
+    description: 'The information system enforces access control decisions based on
+      [Assignment: organization-defined security attributes] that do not include the
+      identity of the user or process acting on behalf of the user.'
+  nist_800_53:rev4:AT-1:a:
+    standard:
+      name: nist_800_53:rev4
+    family: AT
+    title: AT-1a.
+    description: 'Develops, documents, and disseminates to [Assignment: organization-defined
+      personnel or roles]:'
+  nist_800_53:rev4:AT-1:a:1:
+    standard:
+      name: nist_800_53:rev4
+    family: AT
+    title: AT-1a.1.
+    description: A security awareness and training policy that addresses purpose,
+      scope, roles, responsibilities, management commitment, coordination among organizational
+      entities, and compliance; and
+  nist_800_53:rev4:AT-1:a:2:
+    standard:
+      name: nist_800_53:rev4
+    family: AT
+    title: AT-1a.2.
+    description: Procedures to facilitate the implementation of the security awareness
+      and training policy and associated security awareness and training controls;
+      and
+  nist_800_53:rev4:AT-1:b:
+    standard:
+      name: nist_800_53:rev4
+    family: AT
+    title: AT-1b.
+    description: 'Reviews and updates the current:'
+  nist_800_53:rev4:AT-1:b:1:
+    standard:
+      name: nist_800_53:rev4
+    family: AT
+    title: AT-1b.1.
+    description: 'Security awareness and training policy [Assignment: organization-defined
+      frequency]; and'
+  nist_800_53:rev4:AT-1:b:2:
+    standard:
+      name: nist_800_53:rev4
+    family: AT
+    title: AT-1b.2.
+    description: 'Security awareness and training procedures [Assignment: organization-defined
+      frequency].'
+  nist_800_53:rev4:AT-2:a:
+    standard:
+      name: nist_800_53:rev4
+    family: AT
+    title: AT-2a.
+    description: As part of initial training for new users;
+  nist_800_53:rev4:AT-2:b:
+    standard:
+      name: nist_800_53:rev4
+    family: AT
+    title: AT-2b.
+    description: When required by information system changes; and
+  nist_800_53:rev4:AT-2:c:
+    standard:
+      name: nist_800_53:rev4
+    family: AT
+    title: AT-2c.
+    description: "[Assignment: organization-defined frequency] thereafter."
+  nist_800_53:rev4:AT-2:1:
+    standard:
+      name: nist_800_53:rev4
+    family: AT
+    title: PRACTICAL EXERCISES
+    description: The organization includes practical exercises in security awareness
+      training that simulate actual cyber attacks.
+  nist_800_53:rev4:AT-2:2:
+    standard:
+      name: nist_800_53:rev4
+    family: AT
+    title: INSIDER THREAT
+    description: The organization includes security awareness training on recognizing
+      and reporting potential indicators of insider threat.
+  nist_800_53:rev4:AT-3:a:
+    standard:
+      name: nist_800_53:rev4
+    family: AT
+    title: AT-3a.
+    description: Before authorizing access to the information system or performing
+      assigned duties;
+  nist_800_53:rev4:AT-3:b:
+    standard:
+      name: nist_800_53:rev4
+    family: AT
+    title: AT-3b.
+    description: When required by information system changes; and
+  nist_800_53:rev4:AT-3:c:
+    standard:
+      name: nist_800_53:rev4
+    family: AT
+    title: AT-3c.
+    description: "[Assignment: organization-defined frequency] thereafter."
+  nist_800_53:rev4:AT-3:1:
+    standard:
+      name: nist_800_53:rev4
+    family: AT
+    title: ENVIRONMENTAL CONTROLS
+    description: 'The organization provides [Assignment: organization-defined personnel
+      or roles] with initial and [Assignment: organization-defined frequency] training
+      in the employment and operation of environmental controls.'
+  nist_800_53:rev4:AT-3:2:
+    standard:
+      name: nist_800_53:rev4
+    family: AT
+    title: PHYSICAL SECURITY CONTROLS
+    description: 'The organization provides [Assignment: organization-defined personnel
+      or roles] with initial and [Assignment: organization-defined frequency] training
+      in the employment and operation of physical security controls.'
+  nist_800_53:rev4:AT-3:3:
+    standard:
+      name: nist_800_53:rev4
+    family: AT
+    title: PRACTICAL EXERCISES
+    description: The organization includes practical exercises in security training
+      that reinforce training objectives.
+  nist_800_53:rev4:AT-3:4:
+    standard:
+      name: nist_800_53:rev4
+    family: AT
+    title: SUSPICIOUS COMMUNICATIONS AND ANOMALOUS SYSTEM BEHAVIOR
+    description: 'The organization provides training to its personnel on [Assignment:
+      organization-defined indicators of malicious code] to recognize suspicious communications
+      and anomalous behavior in organizational information systems.'
+  nist_800_53:rev4:AT-4:a:
+    standard:
+      name: nist_800_53:rev4
+    family: AT
+    title: AT-4a.
+    description: Documents and monitors individual information system security training
+      activities including basic security awareness training and specific information
+      system security training; and
+  nist_800_53:rev4:AT-4:b:
+    standard:
+      name: nist_800_53:rev4
+    family: AT
+    title: AT-4b.
+    description: 'Retains individual training records for [Assignment: organization-defined
+      time period].'
+  nist_800_53:rev4:AU-1:a:
+    standard:
+      name: nist_800_53:rev4
+    family: AU
+    title: AU-1a.
+    description: 'Develops, documents, and disseminates to [Assignment: organization-defined
+      personnel or roles]:'
+  nist_800_53:rev4:AU-1:a:1:
+    standard:
+      name: nist_800_53:rev4
+    family: AU
+    title: AU-1a.1.
+    description: An audit and accountability policy that addresses purpose, scope,
+      roles, responsibilities, management commitment, coordination among organizational
+      entities, and compliance; and
+  nist_800_53:rev4:AU-1:a:2:
+    standard:
+      name: nist_800_53:rev4
+    family: AU
+    title: AU-1a.2.
+    description: Procedures to facilitate the implementation of the audit and accountability
+      policy and associated audit and accountability controls; and
+  nist_800_53:rev4:AU-1:b:
+    standard:
+      name: nist_800_53:rev4
+    family: AU
+    title: AU-1b.
+    description: 'Reviews and updates the current:'
+  nist_800_53:rev4:AU-1:b:1:
+    standard:
+      name: nist_800_53:rev4
+    family: AU
+    title: AU-1b.1.
+    description: 'Audit and accountability policy [Assignment: organization-defined
+      frequency]; and'
+  nist_800_53:rev4:AU-1:b:2:
+    standard:
+      name: nist_800_53:rev4
+    family: AU
+    title: AU-1b.2.
+    description: 'Audit and accountability procedures [Assignment: organization-defined
+      frequency].'
+  nist_800_53:rev4:AU-2:a:
+    standard:
+      name: nist_800_53:rev4
+    family: AU
+    title: AU-2a.
+    description: 'Determines that the information system is capable of auditing the
+      following events: [Assignment: organization-defined auditable events];'
+  nist_800_53:rev4:AU-2:b:
+    standard:
+      name: nist_800_53:rev4
+    family: AU
+    title: AU-2b.
+    description: Coordinates the security audit function with other organizational
+      entities requiring audit-related information to enhance mutual support and to
+      help guide the selection of auditable events;
+  nist_800_53:rev4:AU-2:c:
+    standard:
+      name: nist_800_53:rev4
+    family: AU
+    title: AU-2c.
+    description: Provides a rationale for why the auditable events are deemed to be
+      adequate to support after-the-fact investigations of security incidents; and
+  nist_800_53:rev4:AU-2:d:
+    standard:
+      name: nist_800_53:rev4
+    family: AU
+    title: AU-2d.
+    description: 'Determines that the following events are to be audited within the
+      information system: [Assignment: organization-defined audited events (the subset
+      of the auditable events defined in AU-2 a.) along with the frequency of (or
+      situation requiring) auditing for each identified event].'
+  nist_800_53:rev4:AU-2:1:
+    standard:
+      name: nist_800_53:rev4
+    family: AU
+    title: COMPILATION OF AUDIT RECORDS FROM MULTIPLE SOURCES
+    description: "[Withdrawn: Incorporated into AU-12]."
+  nist_800_53:rev4:AU-2:2:
+    standard:
+      name: nist_800_53:rev4
+    family: AU
+    title: SELECTION OF AUDIT EVENTS BY COMPONENT
+    description: "[Withdrawn: Incorporated into AU-12]."
+  nist_800_53:rev4:AU-2:3:
+    standard:
+      name: nist_800_53:rev4
+    family: AU
+    title: REVIEWS AND UPDATES
+    description: 'The organization reviews and updates the audited events [Assignment:
+      organization-defined frequency].'
+  nist_800_53:rev4:AU-2:4:
+    standard:
+      name: nist_800_53:rev4
+    family: AU
+    title: PRIVILEGED FUNCTIONS
+    description: "[Withdrawn: Incorporated into AC-6 (9)]."
+  nist_800_53:rev4:AU-3:1:
+    standard:
+      name: nist_800_53:rev4
+    family: AU
+    title: ADDITIONAL AUDIT INFORMATION
+    description: 'The information system generates audit records containing the following
+      additional information: [Assignment: organization-defined additional, more detailed
+      information].'
+  nist_800_53:rev4:AU-3:2:
+    standard:
+      name: nist_800_53:rev4
+    family: AU
+    title: CENTRALIZED MANAGEMENT OF PLANNED AUDIT RECORD CONTENT
+    description: 'The information system provides centralized management and configuration
+      of the content to be captured in audit records generated by [Assignment: organization-defined
+      information system components].'
+  nist_800_53:rev4:AU-4:1:
+    standard:
+      name: nist_800_53:rev4
+    family: AU
+    title: TRANSFER TO ALTERNATE STORAGE
+    description: 'The information system off-loads audit records [Assignment: organization-defined
+      frequency] onto a different system or media than the system being audited.'
+  nist_800_53:rev4:AU-5:a:
+    standard:
+      name: nist_800_53:rev4
+    family: AU
+    title: AU-5a.
+    description: 'Alerts [Assignment: organization-defined personnel or roles] in
+      the event of an audit processing failure; and'
+  nist_800_53:rev4:AU-5:b:
+    standard:
+      name: nist_800_53:rev4
+    family: AU
+    title: AU-5b.
+    description: 'Takes the following additional actions: [Assignment: organization-defined
+      actions to be taken (e.g., shut down information system, overwrite oldest audit
+      records, stop generating audit records)].'
+  nist_800_53:rev4:AU-5:1:
+    standard:
+      name: nist_800_53:rev4
+    family: AU
+    title: AUDIT STORAGE CAPACITY
+    description: 'The information system provides a warning to [Assignment: organization-defined
+      personnel, roles, and/or locations] within [Assignment: organization-defined
+      time period] when allocated audit record storage volume reaches [Assignment:
+      organization-defined percentage] of repository maximum audit record storage
+      capacity.'
+  nist_800_53:rev4:AU-5:2:
+    standard:
+      name: nist_800_53:rev4
+    family: AU
+    title: REAL-TIME ALERTS
+    description: 'The information system provides an alert in [Assignment: organization-defined
+      real-time period] to [Assignment: organization-defined personnel, roles, and/or
+      locations] when the following audit failure events occur: [Assignment: organization-defined
+      audit failure events requiring real-time alerts].'
+  nist_800_53:rev4:AU-5:3:
+    standard:
+      name: nist_800_53:rev4
+    family: AU
+    title: CONFIGURABLE TRAFFIC VOLUME THRESHOLDS
+    description: 'The information system enforces configurable network communications
+      traffic volume thresholds reflecting limits on auditing capacity and [Selection:
+      rejects; delays] network traffic above those thresholds.'
+  nist_800_53:rev4:AU-5:4:
+    standard:
+      name: nist_800_53:rev4
+    family: AU
+    title: SHUTDOWN ON FAILURE
+    description: 'The information system invokes a [Selection: full system shutdown;
+      partial system shutdown; degraded operational mode with limited mission/business
+      functionality available] in the event of [Assignment: organization-defined audit
+      failures], unless an alternate audit capability exists.'
+  nist_800_53:rev4:AU-6:a:
+    standard:
+      name: nist_800_53:rev4
+    family: AU
+    title: AU-6a.
+    description: 'Reviews and analyzes information system audit records [Assignment:
+      organization-defined frequency] for indications of [Assignment: organization-defined
+      inappropriate or unusual activity]; and'
+  nist_800_53:rev4:AU-6:b:
+    standard:
+      name: nist_800_53:rev4
+    family: AU
+    title: AU-6b.
+    description: 'Reports findings to [Assignment: organization-defined personnel
+      or roles].'
+  nist_800_53:rev4:AU-6:1:
+    standard:
+      name: nist_800_53:rev4
+    family: AU
+    title: PROCESS INTEGRATION
+    description: The organization employs automated mechanisms to integrate audit
+      review, analysis, and reporting processes to support organizational processes
+      for investigation and response to suspicious activities.
+  nist_800_53:rev4:AU-6:2:
+    standard:
+      name: nist_800_53:rev4
+    family: AU
+    title: AUTOMATED SECURITY ALERTS
+    description: "[Withdrawn: Incorporated into SI-4]."
+  nist_800_53:rev4:AU-6:3:
+    standard:
+      name: nist_800_53:rev4
+    family: AU
+    title: CORRELATE AUDIT REPOSITORIES
+    description: The organization analyzes and correlates audit records across different
+      repositories to gain organization-wide situational awareness.
+  nist_800_53:rev4:AU-6:4:
+    standard:
+      name: nist_800_53:rev4
+    family: AU
+    title: CENTRAL REVIEW AND ANALYSIS
+    description: The information system provides the capability to centrally review
+      and analyze audit records from multiple components within the system.
+  nist_800_53:rev4:AU-6:5:
+    standard:
+      name: nist_800_53:rev4
+    family: AU
+    title: INTEGRATION / SCANNING AND MONITORING CAPABILITIES
+    description: 'The organization integrates analysis of audit records with analysis
+      of [Selection (one or more): vulnerability scanning information; performance
+      data; information system monitoring information; [Assignment: organization-defined
+      data/information collected from other sources]] to further enhance the ability
+      to identify inappropriate or unusual activity.'
+  nist_800_53:rev4:AU-6:6:
+    standard:
+      name: nist_800_53:rev4
+    family: AU
+    title: CORRELATION WITH PHYSICAL MONITORING
+    description: The organization correlates information from audit records with information
+      obtained from monitoring physical access to further enhance the ability to identify
+      suspicious, inappropriate, unusual, or malevolent activity.
+  nist_800_53:rev4:AU-6:7:
+    standard:
+      name: nist_800_53:rev4
+    family: AU
+    title: PERMITTED ACTIONS
+    description: 'The organization specifies the permitted actions for each [Selection
+      (one or more): information system process; role; user] associated with the review,
+      analysis, and reporting of audit information.'
+  nist_800_53:rev4:AU-6:8:
+    standard:
+      name: nist_800_53:rev4
+    family: AU
+    title: FULL TEXT ANALYSIS OF PRIVILEGED COMMANDS
+    description: The organization performs a full text analysis of audited privileged
+      commands in a physically distinct component or subsystem of the information
+      system, or other information system that is dedicated to that analysis.
+  nist_800_53:rev4:AU-6:9:
+    standard:
+      name: nist_800_53:rev4
+    family: AU
+    title: CORRELATION WITH INFORMATION FROM NONTECHNICAL SOURCES
+    description: The organization correlates information from nontechnical sources
+      with audit information to enhance organization-wide situational awareness.
+  nist_800_53:rev4:AU-6:10:
+    standard:
+      name: nist_800_53:rev4
+    family: AU
+    title: AUDIT LEVEL ADJUSTMENT
+    description: The organization adjusts the level of audit review, analysis, and
+      reporting within the information system when there is a change in risk based
+      on law enforcement information, intelligence information, or other credible
+      sources of information.
+  nist_800_53:rev4:AU-7:a:
+    standard:
+      name: nist_800_53:rev4
+    family: AU
+    title: AU-7a.
+    description: Supports on-demand audit review, analysis, and reporting requirements
+      and after-the-fact investigations of security incidents; and
+  nist_800_53:rev4:AU-7:b:
+    standard:
+      name: nist_800_53:rev4
+    family: AU
+    title: AU-7b.
+    description: Does not alter the original content or time ordering of audit records.
+  nist_800_53:rev4:AU-7:1:
+    standard:
+      name: nist_800_53:rev4
+    family: AU
+    title: AUTOMATIC PROCESSING
+    description: 'The information system provides the capability to process audit
+      records for events of interest based on [Assignment: organization-defined audit
+      fields within audit records].'
+  nist_800_53:rev4:AU-7:2:
+    standard:
+      name: nist_800_53:rev4
+    family: AU
+    title: AUTOMATIC SORT AND SEARCH
+    description: 'The information system provides the capability to sort and search
+      audit records for events of interest based on the content of [Assignment: organization-defined
+      audit fields within audit records].'
+  nist_800_53:rev4:AU-8:a:
+    standard:
+      name: nist_800_53:rev4
+    family: AU
+    title: AU-8a.
+    description: Uses internal system clocks to generate time stamps for audit records;
+      and
+  nist_800_53:rev4:AU-8:b:
+    standard:
+      name: nist_800_53:rev4
+    family: AU
+    title: AU-8b.
+    description: 'Records time stamps for audit records that can be mapped to Coordinated
+      Universal Time (UTC) or Greenwich Mean Time (GMT) and meets [Assignment: organization-defined
+      granularity of time measurement].'
+  nist_800_53:rev4:AU-8:1:
+    standard:
+      name: nist_800_53:rev4
+    family: AU
+    title: SYNCHRONIZATION WITH AUTHORITATIVE TIME SOURCE
+    description: 'The information system:'
+  nist_800_53:rev4:AU-8:1:a:
+    standard:
+      name: nist_800_53:rev4
+    family: AU
+    title: AU-8 (1)(a)
+    description: 'Compares the internal information system clocks [Assignment: organization-defined
+      frequency] with [Assignment: organization-defined authoritative time source];
+      and'
+  nist_800_53:rev4:AU-8:1:b:
+    standard:
+      name: nist_800_53:rev4
+    family: AU
+    title: AU-8 (1)(b)
+    description: 'Synchronizes the internal system clocks to the authoritative time
+      source when the time difference is greater than [Assignment: organization-defined
+      time period].'
+  nist_800_53:rev4:AU-8:2:
+    standard:
+      name: nist_800_53:rev4
+    family: AU
+    title: SECONDARY AUTHORITATIVE TIME SOURCE
+    description: The information system identifies a secondary authoritative time
+      source that is located in a different geographic region than the primary authoritative
+      time source.
+  nist_800_53:rev4:AU-9:1:
+    standard:
+      name: nist_800_53:rev4
+    family: AU
+    title: HARDWARE WRITE-ONCE MEDIA
+    description: The information system writes audit trails to hardware-enforced,
+      write-once media.
+  nist_800_53:rev4:AU-9:2:
+    standard:
+      name: nist_800_53:rev4
+    family: AU
+    title: AUDIT BACKUP ON SEPARATE PHYSICAL SYSTEMS / COMPONENTS
+    description: 'The information system backs up audit records [Assignment: organization-defined
+      frequency] onto a physically different system or system component than the system
+      or component being audited.'
+  nist_800_53:rev4:AU-9:3:
+    standard:
+      name: nist_800_53:rev4
+    family: AU
+    title: CRYPTOGRAPHIC PROTECTION
+    description: The information system implements cryptographic mechanisms to protect
+      the integrity of audit information and audit tools.
+  nist_800_53:rev4:AU-9:4:
+    standard:
+      name: nist_800_53:rev4
+    family: AU
+    title: ACCESS BY SUBSET OF PRIVILEGED USERS
+    description: 'The organization authorizes access to management of audit functionality
+      to only [Assignment: organization-defined subset of privileged users].'
+  nist_800_53:rev4:AU-9:5:
+    standard:
+      name: nist_800_53:rev4
+    family: AU
+    title: DUAL AUTHORIZATION
+    description: 'The organization enforces dual authorization for [Selection (one
+      or more): movement; deletion] of [Assignment: organization-defined audit information].'
+  nist_800_53:rev4:AU-9:6:
+    standard:
+      name: nist_800_53:rev4
+    family: AU
+    title: READ ONLY ACCESS
+    description: 'The organization authorizes read-only access to audit information
+      to [Assignment: organization-defined subset of privileged users].'
+  nist_800_53:rev4:AU-10:1:
+    standard:
+      name: nist_800_53:rev4
+    family: AU
+    title: ASSOCIATION OF IDENTITIES
+    description: 'The information system:'
+  nist_800_53:rev4:AU-10:1:a:
+    standard:
+      name: nist_800_53:rev4
+    family: AU
+    title: AU-10 (1)(a)
+    description: 'Binds the identity of the information producer with the information
+      to [Assignment: organization-defined strength of binding]; and'
+  nist_800_53:rev4:AU-10:1:b:
+    standard:
+      name: nist_800_53:rev4
+    family: AU
+    title: AU-10 (1)(b)
+    description: Provides the means for authorized individuals to determine the identity
+      of the producer of the information.
+  nist_800_53:rev4:AU-10:2:
+    standard:
+      name: nist_800_53:rev4
+    family: AU
+    title: VALIDATE BINDING OF INFORMATION PRODUCER IDENTITY
+    description: 'The information system:'
+  nist_800_53:rev4:AU-10:2:a:
+    standard:
+      name: nist_800_53:rev4
+    family: AU
+    title: AU-10 (2)(a)
+    description: 'Validates the binding of the information producer identity to the
+      information at [Assignment: organization-defined frequency]; and'
+  nist_800_53:rev4:AU-10:2:b:
+    standard:
+      name: nist_800_53:rev4
+    family: AU
+    title: AU-10 (2)(b)
+    description: 'Performs [Assignment: organization-defined actions] in the event
+      of a validation error.'
+  nist_800_53:rev4:AU-10:3:
+    standard:
+      name: nist_800_53:rev4
+    family: AU
+    title: CHAIN OF CUSTODY
+    description: The information system maintains reviewer/releaser identity and credentials
+      within the established chain of custody for all information reviewed or released.
+  nist_800_53:rev4:AU-10:4:
+    standard:
+      name: nist_800_53:rev4
+    family: AU
+    title: VALIDATE BINDING OF INFORMATION REVIEWER IDENTITY
+    description: 'The information system:'
+  nist_800_53:rev4:AU-10:4:a:
+    standard:
+      name: nist_800_53:rev4
+    family: AU
+    title: AU-10 (4)(a)
+    description: 'Validates the binding of the information reviewer identity to the
+      information at the transfer or release points prior to release/transfer between
+      [Assignment: organization-defined security domains]; and'
+  nist_800_53:rev4:AU-10:4:b:
+    standard:
+      name: nist_800_53:rev4
+    family: AU
+    title: AU-10 (4)(b)
+    description: 'Performs [Assignment: organization-defined actions] in the event
+      of a validation error.'
+  nist_800_53:rev4:AU-10:5:
+    standard:
+      name: nist_800_53:rev4
+    family: AU
+    title: DIGITAL SIGNATURES
+    description: "[Withdrawn: Incorporated into SI-7]."
+  nist_800_53:rev4:AU-11:1:
+    standard:
+      name: nist_800_53:rev4
+    family: AU
+    title: LONG-TERM RETRIEVAL CAPABILITY
+    description: 'The organization employs [Assignment: organization-defined measures]
+      to ensure that long-term audit records generated by the information system can
+      be retrieved.'
+  nist_800_53:rev4:AU-12:a:
+    standard:
+      name: nist_800_53:rev4
+    family: AU
+    title: AU-12a.
+    description: 'Provides audit record generation capability for the auditable events
+      defined in AU-2 a. at [Assignment: organization-defined information system components];'
+  nist_800_53:rev4:AU-12:b:
+    standard:
+      name: nist_800_53:rev4
+    family: AU
+    title: AU-12b.
+    description: 'Allows [Assignment: organization-defined personnel or roles] to
+      select which auditable events are to be audited by specific components of the
+      information system; and'
+  nist_800_53:rev4:AU-12:c:
+    standard:
+      name: nist_800_53:rev4
+    family: AU
+    title: AU-12c.
+    description: Generates audit records for the events defined in AU-2 d. with the
+      content defined in AU-3.
+  nist_800_53:rev4:AU-12:1:
+    standard:
+      name: nist_800_53:rev4
+    family: AU
+    title: SYSTEM-WIDE / TIME-CORRELATED AUDIT TRAIL
+    description: 'The information system compiles audit records from [Assignment:
+      organization-defined information system components] into a system-wide (logical
+      or physical) audit trail that is time-correlated to within [Assignment: organization-defined
+      level of tolerance for the relationship between time stamps of individual records
+      in the audit trail].'
+  nist_800_53:rev4:AU-12:2:
+    standard:
+      name: nist_800_53:rev4
+    family: AU
+    title: STANDARDIZED FORMATS
+    description: The information system produces a system-wide (logical or physical)
+      audit trail composed of audit records in a standardized format.
+  nist_800_53:rev4:AU-12:3:
+    standard:
+      name: nist_800_53:rev4
+    family: AU
+    title: CHANGES BY AUTHORIZED INDIVIDUALS
+    description: 'The information system provides the capability for [Assignment:
+      organization-defined individuals or roles] to change the auditing to be performed
+      on [Assignment: organization-defined information system components] based on
+      [Assignment: organization-defined selectable event criteria] within [Assignment:
+      organization-defined time thresholds].'
+  nist_800_53:rev4:AU-13:1:
+    standard:
+      name: nist_800_53:rev4
+    family: AU
+    title: USE OF AUTOMATED TOOLS
+    description: The organization employs automated mechanisms to determine if organizational
+      information has been disclosed in an unauthorized manner.
+  nist_800_53:rev4:AU-13:2:
+    standard:
+      name: nist_800_53:rev4
+    family: AU
+    title: REVIEW OF MONITORED SITES
+    description: 'The organization reviews the open source information sites being
+      monitored [Assignment: organization-defined frequency].'
+  nist_800_53:rev4:AU-14:1:
+    standard:
+      name: nist_800_53:rev4
+    family: AU
+    title: SYSTEM START-UP
+    description: The information system initiates session audits at system start-up.
+  nist_800_53:rev4:AU-14:2:
+    standard:
+      name: nist_800_53:rev4
+    family: AU
+    title: CAPTURE/RECORD AND LOG CONTENT
+    description: The information system provides the capability for authorized users
+      to capture/record and log content related to a user session.
+  nist_800_53:rev4:AU-14:3:
+    standard:
+      name: nist_800_53:rev4
+    family: AU
+    title: REMOTE VIEWING / LISTENING
+    description: The information system provides the capability for authorized users
+      to remotely view/hear all content related to an established user session in
+      real time.
+  nist_800_53:rev4:AU-16:1:
+    standard:
+      name: nist_800_53:rev4
+    family: AU
+    title: IDENTITY PRESERVATION
+    description: The organization requires that the identity of individuals be preserved
+      in cross-organizational audit trails.
+  nist_800_53:rev4:AU-16:2:
+    standard:
+      name: nist_800_53:rev4
+    family: AU
+    title: SHARING OF AUDIT INFORMATION
+    description: 'The organization provides cross-organizational audit information
+      to [Assignment: organization-defined organizations] based on [Assignment: organization-defined
+      cross-organizational sharing agreements].'
+  nist_800_53:rev4:CA-1:a:
+    standard:
+      name: nist_800_53:rev4
+    family: CA
+    title: CA-1a.
+    description: 'Develops, documents, and disseminates to [Assignment: organization-defined
+      personnel or roles]:'
+  nist_800_53:rev4:CA-1:a:1:
+    standard:
+      name: nist_800_53:rev4
+    family: CA
+    title: CA-1a.1.
+    description: A security assessment and authorization policy that addresses purpose,
+      scope, roles, responsibilities, management commitment, coordination among organizational
+      entities, and compliance; and
+  nist_800_53:rev4:CA-1:a:2:
+    standard:
+      name: nist_800_53:rev4
+    family: CA
+    title: CA-1a.2.
+    description: Procedures to facilitate the implementation of the security assessment
+      and authorization policy and associated security assessment and authorization
+      controls; and
+  nist_800_53:rev4:CA-1:b:
+    standard:
+      name: nist_800_53:rev4
+    family: CA
+    title: CA-1b.
+    description: 'Reviews and updates the current:'
+  nist_800_53:rev4:CA-1:b:1:
+    standard:
+      name: nist_800_53:rev4
+    family: CA
+    title: CA-1b.1.
+    description: 'Security assessment and authorization policy [Assignment: organization-defined
+      frequency]; and'
+  nist_800_53:rev4:CA-1:b:2:
+    standard:
+      name: nist_800_53:rev4
+    family: CA
+    title: CA-1b.2.
+    description: 'Security assessment and authorization procedures [Assignment: organization-defined
+      frequency].'
+  nist_800_53:rev4:CA-2:a:
+    standard:
+      name: nist_800_53:rev4
+    family: CA
+    title: CA-2a.
+    description: 'Develops a security assessment plan that describes the scope of
+      the assessment including:'
+  nist_800_53:rev4:CA-2:a:1:
+    standard:
+      name: nist_800_53:rev4
+    family: CA
+    title: CA-2a.1.
+    description: Security controls and control enhancements under assessment;
+  nist_800_53:rev4:CA-2:a:2:
+    standard:
+      name: nist_800_53:rev4
+    family: CA
+    title: CA-2a.2.
+    description: Assessment procedures to be used to determine security control effectiveness;
+      and
+  nist_800_53:rev4:CA-2:a:3:
+    standard:
+      name: nist_800_53:rev4
+    family: CA
+    title: CA-2a.3.
+    description: Assessment environment, assessment team, and assessment roles and
+      responsibilities;
+  nist_800_53:rev4:CA-2:b:
+    standard:
+      name: nist_800_53:rev4
+    family: CA
+    title: CA-2b.
+    description: 'Assesses the security controls in the information system and its
+      environment of operation [Assignment: organization-defined frequency] to determine
+      the extent to which the controls are implemented correctly, operating as intended,
+      and producing the desired outcome with respect to meeting established security
+      requirements;'
+  nist_800_53:rev4:CA-2:c:
+    standard:
+      name: nist_800_53:rev4
+    family: CA
+    title: CA-2c.
+    description: Produces a security assessment report that documents the results
+      of the assessment; and
+  nist_800_53:rev4:CA-2:d:
+    standard:
+      name: nist_800_53:rev4
+    family: CA
+    title: CA-2d.
+    description: 'Provides the results of the security control assessment to [Assignment:
+      organization-defined individuals or roles].'
+  nist_800_53:rev4:CA-2:1:
+    standard:
+      name: nist_800_53:rev4
+    family: CA
+    title: INDEPENDENT ASSESSORS
+    description: 'The organization employs assessors or assessment teams with [Assignment:
+      organization-defined level of independence] to conduct security control assessments.'
+  nist_800_53:rev4:CA-2:2:
+    standard:
+      name: nist_800_53:rev4
+    family: CA
+    title: SPECIALIZED ASSESSMENTS
+    description: 'The organization includes as part of security control assessments,
+      [Assignment: organization-defined frequency], [Selection: announced; unannounced],
+      [Selection (one or more): in-depth monitoring; vulnerability scanning; malicious
+      user testing; insider threat assessment; performance/load testing; [Assignment:
+      organization-defined other forms of security assessment]].'
+  nist_800_53:rev4:CA-2:3:
+    standard:
+      name: nist_800_53:rev4
+    family: CA
+    title: EXTERNAL ORGANIZATIONS
+    description: 'The organization accepts the results of an assessment of [Assignment:
+      organization-defined information system] performed by [Assignment: organization-defined
+      external organization] when the assessment meets [Assignment: organization-defined
+      requirements].'
+  nist_800_53:rev4:CA-3:a:
+    standard:
+      name: nist_800_53:rev4
+    family: CA
+    title: CA-3a.
+    description: Authorizes connections from the information system to other information
+      systems through the use of Interconnection Security Agreements;
+  nist_800_53:rev4:CA-3:b:
+    standard:
+      name: nist_800_53:rev4
+    family: CA
+    title: CA-3b.
+    description: Documents, for each interconnection, the interface characteristics,
+      security requirements, and the nature of the information communicated; and
+  nist_800_53:rev4:CA-3:c:
+    standard:
+      name: nist_800_53:rev4
+    family: CA
+    title: CA-3c.
+    description: 'Reviews and updates Interconnection Security Agreements [Assignment:
+      organization-defined frequency].'
+  nist_800_53:rev4:CA-3:1:
+    standard:
+      name: nist_800_53:rev4
+    family: CA
+    title: UNCLASSIFIED NATIONAL SECURITY SYSTEM CONNECTIONS
+    description: 'The organization prohibits the direct connection of an [Assignment:
+      organization-defined unclassified, national security system] to an external
+      network without the use of [Assignment: organization-defined boundary protection
+      device].'
+  nist_800_53:rev4:CA-3:2:
+    standard:
+      name: nist_800_53:rev4
+    family: CA
+    title: CLASSIFIED NATIONAL SECURITY SYSTEM CONNECTIONS
+    description: 'The organization prohibits the direct connection of a classified,
+      national security system to an external network without the use of [Assignment:
+      organization-defined boundary protection device].'
+  nist_800_53:rev4:CA-3:3:
+    standard:
+      name: nist_800_53:rev4
+    family: CA
+    title: UNCLASSIFIED NON-NATIONAL SECURITY SYSTEM CONNECTIONS
+    description: 'The organization prohibits the direct connection of an [Assignment:
+      organization-defined unclassified, non-national security system] to an external
+      network without the use of [Assignment; organization-defined boundary protection
+      device].'
+  nist_800_53:rev4:CA-3:4:
+    standard:
+      name: nist_800_53:rev4
+    family: CA
+    title: CONNECTIONS TO PUBLIC NETWORKS
+    description: 'The organization prohibits the direct connection of an [Assignment:
+      organization-defined information system] to a public network.'
+  nist_800_53:rev4:CA-3:5:
+    standard:
+      name: nist_800_53:rev4
+    family: CA
+    title: RESTRICTIONS ON EXTERNAL SYSTEM CONNECTIONS
+    description: 'The organization employs [Selection: allow-all, deny-by-exception;
+      deny-all, permit-by-exception] policy for allowing [Assignment: organization-defined
+      information systems] to connect to external information systems.'
+  nist_800_53:rev4:CA-5:a:
+    standard:
+      name: nist_800_53:rev4
+    family: CA
+    title: CA-5a.
+    description: Develops a plan of action and milestones for the information system
+      to document the organization�s planned remedial actions to correct weaknesses
+      or deficiencies noted during the assessment of the security controls and to
+      reduce or eliminate known vulnerabilities in the system; and
+  nist_800_53:rev4:CA-5:b:
+    standard:
+      name: nist_800_53:rev4
+    family: CA
+    title: CA-5b.
+    description: 'Updates existing plan of action and milestones [Assignment: organization-defined
+      frequency] based on the findings from security controls assessments, security
+      impact analyses, and continuous monitoring activities.'
+  nist_800_53:rev4:CA-5:1:
+    standard:
+      name: nist_800_53:rev4
+    family: CA
+    title: AUTOMATION SUPPORT FOR ACCURACY / CURRENCY
+    description: The organization employs automated mechanisms to help ensure that
+      the plan of action and milestones for the information system is accurate, up
+      to date, and readily available.
+  nist_800_53:rev4:CA-6:a:
+    standard:
+      name: nist_800_53:rev4
+    family: CA
+    title: CA-6a.
+    description: Assigns a senior-level executive or manager as the authorizing official
+      for the information system;
+  nist_800_53:rev4:CA-6:b:
+    standard:
+      name: nist_800_53:rev4
+    family: CA
+    title: CA-6b.
+    description: Ensures that the authorizing official authorizes the information
+      system for processing before commencing operations; and
+  nist_800_53:rev4:CA-6:c:
+    standard:
+      name: nist_800_53:rev4
+    family: CA
+    title: CA-6c.
+    description: 'Updates the security authorization [Assignment: organization-defined
+      frequency].'
+  nist_800_53:rev4:CA-7:a:
+    standard:
+      name: nist_800_53:rev4
+    family: CA
+    title: CA-7a.
+    description: 'Establishment of [Assignment: organization-defined metrics] to be
+      monitored;'
+  nist_800_53:rev4:CA-7:b:
+    standard:
+      name: nist_800_53:rev4
+    family: CA
+    title: CA-7b.
+    description: 'Establishment of [Assignment: organization-defined frequencies]
+      for monitoring and [Assignment: organization-defined frequencies] for assessments
+      supporting such monitoring;'
+  nist_800_53:rev4:CA-7:c:
+    standard:
+      name: nist_800_53:rev4
+    family: CA
+    title: CA-7c.
+    description: Ongoing security control assessments in accordance with the organizational
+      continuous monitoring strategy;
+  nist_800_53:rev4:CA-7:d:
+    standard:
+      name: nist_800_53:rev4
+    family: CA
+    title: CA-7d.
+    description: Ongoing security status monitoring of organization-defined metrics
+      in accordance with the organizational continuous monitoring strategy;
+  nist_800_53:rev4:CA-7:e:
+    standard:
+      name: nist_800_53:rev4
+    family: CA
+    title: CA-7e.
+    description: Correlation and analysis of security-related information generated
+      by assessments and monitoring;
+  nist_800_53:rev4:CA-7:f:
+    standard:
+      name: nist_800_53:rev4
+    family: CA
+    title: CA-7f.
+    description: Response actions to address results of the analysis of security-related
+      information; and
+  nist_800_53:rev4:CA-7:g:
+    standard:
+      name: nist_800_53:rev4
+    family: CA
+    title: CA-7g.
+    description: 'Reporting the security status of organization and the information
+      system to [Assignment: organization-defined personnel or roles] [Assignment:
+      organization-defined frequency].'
+  nist_800_53:rev4:CA-7:1:
+    standard:
+      name: nist_800_53:rev4
+    family: CA
+    title: INDEPENDENT ASSESSMENT
+    description: 'The organization employs assessors or assessment teams with [Assignment:
+      organization-defined level of independence] to monitor the security controls
+      in the information system on an ongoing basis.'
+  nist_800_53:rev4:CA-7:2:
+    standard:
+      name: nist_800_53:rev4
+    family: CA
+    title: TYPES OF ASSESSMENTS
+    description: "[Withdrawn: Incorporated into CA-2]."
+  nist_800_53:rev4:CA-7:3:
+    standard:
+      name: nist_800_53:rev4
+    family: CA
+    title: TREND ANALYSES
+    description: The organization employs trend analyses to determine if security
+      control implementations, the frequency of continuous monitoring activities,
+      and/or the types of activities used in the continuous monitoring process need
+      to be modified based on empirical data.
+  nist_800_53:rev4:CA-8:1:
+    standard:
+      name: nist_800_53:rev4
+    family: CA
+    title: INDEPENDENT PENETRATION AGENT OR TEAM
+    description: The organization employs an independent penetration agent or penetration
+      team to perform penetration testing on the information system or system components.
+  nist_800_53:rev4:CA-8:2:
+    standard:
+      name: nist_800_53:rev4
+    family: CA
+    title: RED TEAM EXERCISES
+    description: 'The organization employs [Assignment: organization-defined red team
+      exercises] to simulate attempts by adversaries to compromise organizational
+      information systems in accordance with [Assignment: organization-defined rules
+      of engagement].'
+  nist_800_53:rev4:CA-9:a:
+    standard:
+      name: nist_800_53:rev4
+    family: CA
+    title: CA-9a.
+    description: 'Authorizes internal connections of [Assignment: organization-defined
+      information system components or classes of components] to the information system;
+      and'
+  nist_800_53:rev4:CA-9:b:
+    standard:
+      name: nist_800_53:rev4
+    family: CA
+    title: CA-9b.
+    description: Documents, for each internal connection, the interface characteristics,
+      security requirements, and the nature of the information communicated.
+  nist_800_53:rev4:CA-9:1:
+    standard:
+      name: nist_800_53:rev4
+    family: CA
+    title: SECURITY COMPLIANCE CHECKS
+    description: The information system performs security compliance checks on constituent
+      system components prior to the establishment of the internal connection.
+  nist_800_53:rev4:CM-1:a:
+    standard:
+      name: nist_800_53:rev4
+    family: CM
+    title: CM-1a.
+    description: 'Develops, documents, and disseminates to [Assignment: organization-defined
+      personnel or roles]:'
+  nist_800_53:rev4:CM-1:a:1:
+    standard:
+      name: nist_800_53:rev4
+    family: CM
+    title: CM-1a.1.
+    description: A configuration management policy that addresses purpose, scope,
+      roles, responsibilities, management commitment, coordination among organizational
+      entities, and compliance; and
+  nist_800_53:rev4:CM-1:a:2:
+    standard:
+      name: nist_800_53:rev4
+    family: CM
+    title: CM-1a.2.
+    description: Procedures to facilitate the implementation of the configuration
+      management policy and associated configuration management controls; and
+  nist_800_53:rev4:CM-1:b:
+    standard:
+      name: nist_800_53:rev4
+    family: CM
+    title: CM-1b.
+    description: 'Reviews and updates the current:'
+  nist_800_53:rev4:CM-1:b:1:
+    standard:
+      name: nist_800_53:rev4
+    family: CM
+    title: CM-1b.1.
+    description: 'Configuration management policy [Assignment: organization-defined
+      frequency]; and'
+  nist_800_53:rev4:CM-1:b:2:
+    standard:
+      name: nist_800_53:rev4
+    family: CM
+    title: CM-1b.2.
+    description: 'Configuration management procedures [Assignment: organization-defined
+      frequency].'
+  nist_800_53:rev4:CM-2:1:
+    standard:
+      name: nist_800_53:rev4
+    family: CM
+    title: REVIEWS AND UPDATES
+    description: 'The organization reviews and updates the baseline configuration
+      of the information system:'
+  nist_800_53:rev4:CM-2:1:a:
+    standard:
+      name: nist_800_53:rev4
+    family: CM
+    title: CM-2 (1)(a)
+    description: "[Assignment: organization-defined frequency];"
+  nist_800_53:rev4:CM-2:1:b:
+    standard:
+      name: nist_800_53:rev4
+    family: CM
+    title: CM-2 (1)(b)
+    description: When required due to [Assignment organization-defined circumstances];
+      and
+  nist_800_53:rev4:CM-2:1:c:
+    standard:
+      name: nist_800_53:rev4
+    family: CM
+    title: CM-2 (1)(c)
+    description: As an integral part of information system component installations
+      and upgrades.
+  nist_800_53:rev4:CM-2:2:
+    standard:
+      name: nist_800_53:rev4
+    family: CM
+    title: AUTOMATION SUPPORT FOR ACCURACY / CURRENCY
+    description: The organization employs automated mechanisms to maintain an up-to-date,
+      complete, accurate, and readily available baseline configuration of the information
+      system.
+  nist_800_53:rev4:CM-2:3:
+    standard:
+      name: nist_800_53:rev4
+    family: CM
+    title: RETENTION OF PREVIOUS CONFIGURATIONS
+    description: 'The organization retains [Assignment: organization-defined previous
+      versions of baseline configurations of the information system] to support rollback.'
+  nist_800_53:rev4:CM-2:4:
+    standard:
+      name: nist_800_53:rev4
+    family: CM
+    title: UNAUTHORIZED SOFTWARE
+    description: "[Withdrawn: Incorporated into CM-7]."
+  nist_800_53:rev4:CM-2:5:
+    standard:
+      name: nist_800_53:rev4
+    family: CM
+    title: AUTHORIZED SOFTWARE
+    description: "[Withdrawn: Incorporated into CM-7]."
+  nist_800_53:rev4:CM-2:6:
+    standard:
+      name: nist_800_53:rev4
+    family: CM
+    title: DEVELOPMENT AND TEST ENVIRONMENTS
+    description: The organization maintains a baseline configuration for information
+      system development and test environments that is managed separately from the
+      operational baseline configuration.
+  nist_800_53:rev4:CM-2:7:
+    standard:
+      name: nist_800_53:rev4
+    family: CM
+    title: CONFIGURE SYSTEMS, COMPONENTS, OR DEVICES FOR HIGH-RISK AREAS
+    description: 'The organization:'
+  nist_800_53:rev4:CM-2:7:a:
+    standard:
+      name: nist_800_53:rev4
+    family: CM
+    title: CM-2 (7)(a)
+    description: 'Issues [Assignment: organization-defined information systems, system
+      components, or devices] with [Assignment: organization-defined configurations]
+      to individuals traveling to locations that the organization deems to be of significant
+      risk; and'
+  nist_800_53:rev4:CM-2:7:b:
+    standard:
+      name: nist_800_53:rev4
+    family: CM
+    title: CM-2 (7)(b)
+    description: 'Applies [Assignment: organization-defined security safeguards] to
+      the devices when the individuals return.'
+  nist_800_53:rev4:CM-3:a:
+    standard:
+      name: nist_800_53:rev4
+    family: CM
+    title: CM-3a.
+    description: Determines the types of changes to the information system that are
+      configuration-controlled;
+  nist_800_53:rev4:CM-3:b:
+    standard:
+      name: nist_800_53:rev4
+    family: CM
+    title: CM-3b.
+    description: Reviews proposed configuration-controlled changes to the information
+      system and approves or disapproves such changes with explicit consideration
+      for security impact analyses;
+  nist_800_53:rev4:CM-3:c:
+    standard:
+      name: nist_800_53:rev4
+    family: CM
+    title: CM-3c.
+    description: Documents configuration change decisions associated with the information
+      system;
+  nist_800_53:rev4:CM-3:d:
+    standard:
+      name: nist_800_53:rev4
+    family: CM
+    title: CM-3d.
+    description: Implements approved configuration-controlled changes to the information
+      system;
+  nist_800_53:rev4:CM-3:e:
+    standard:
+      name: nist_800_53:rev4
+    family: CM
+    title: CM-3e.
+    description: 'Retains records of configuration-controlled changes to the information
+      system for [Assignment: organization-defined time period];'
+  nist_800_53:rev4:CM-3:f:
+    standard:
+      name: nist_800_53:rev4
+    family: CM
+    title: CM-3f.
+    description: Audits and reviews activities associated with configuration-controlled
+      changes to the information system; and
+  nist_800_53:rev4:CM-3:g:
+    standard:
+      name: nist_800_53:rev4
+    family: CM
+    title: CM-3g.
+    description: 'Coordinates and provides oversight for configuration change control
+      activities through [Assignment: organization-defined configuration change control
+      element (e.g., committee, board)] that convenes [Selection (one or more): [Assignment:
+      organization-defined frequency]; [Assignment: organization-defined configuration
+      change conditions]].'
+  nist_800_53:rev4:CM-3:1:
+    standard:
+      name: nist_800_53:rev4
+    family: CM
+    title: AUTOMATED DOCUMENT / NOTIFICATION / PROHIBITION OF CHANGES
+    description: 'The organization employs automated mechanisms to:'
+  nist_800_53:rev4:CM-3:1:a:
+    standard:
+      name: nist_800_53:rev4
+    family: CM
+    title: CM-3 (1)(a)
+    description: Document proposed changes to the information system;
+  nist_800_53:rev4:CM-3:1:b:
+    standard:
+      name: nist_800_53:rev4
+    family: CM
+    title: CM-3 (1)(b)
+    description: 'Notify [Assignment: organized-defined approval authorities] of proposed
+      changes to the information system and request change approval;'
+  nist_800_53:rev4:CM-3:1:c:
+    standard:
+      name: nist_800_53:rev4
+    family: CM
+    title: CM-3 (1)(c)
+    description: 'Highlight proposed changes to the information system that have not
+      been approved or disapproved by [Assignment: organization-defined time period];'
+  nist_800_53:rev4:CM-3:1:d:
+    standard:
+      name: nist_800_53:rev4
+    family: CM
+    title: CM-3 (1)(d)
+    description: Prohibit changes to the information system until designated approvals
+      are received;
+  nist_800_53:rev4:CM-3:1:e:
+    standard:
+      name: nist_800_53:rev4
+    family: CM
+    title: CM-3 (1)(e)
+    description: Document all changes to the information system; and
+  nist_800_53:rev4:CM-3:1:f:
+    standard:
+      name: nist_800_53:rev4
+    family: CM
+    title: CM-3 (1)(f)
+    description: 'Notify [Assignment: organization-defined personnel] when approved
+      changes to the information system are completed.'
+  nist_800_53:rev4:CM-3:2:
+    standard:
+      name: nist_800_53:rev4
+    family: CM
+    title: TEST / VALIDATE / DOCUMENT CHANGES
+    description: The organization tests, validates, and documents changes to the information
+      system before implementing the changes on the operational system.
+  nist_800_53:rev4:CM-3:3:
+    standard:
+      name: nist_800_53:rev4
+    family: CM
+    title: AUTOMATED CHANGE IMPLEMENTATION
+    description: The organization employs automated mechanisms to implement changes
+      to the current information system baseline and deploys the updated baseline
+      across the installed base.
+  nist_800_53:rev4:CM-3:4:
+    standard:
+      name: nist_800_53:rev4
+    family: CM
+    title: SECURITY REPRESENTATIVE
+    description: 'The organization requires an information security representative
+      to be a member of the [Assignment: organization-defined configuration change
+      control element].'
+  nist_800_53:rev4:CM-3:5:
+    standard:
+      name: nist_800_53:rev4
+    family: CM
+    title: AUTOMATED SECURITY RESPONSE
+    description: 'The information system implements [Assignment: organization-defined
+      security responses] automatically if baseline configurations are changed in
+      an unauthorized manner.'
+  nist_800_53:rev4:CM-3:6:
+    standard:
+      name: nist_800_53:rev4
+    family: CM
+    title: CRYPTOGRAPHY MANAGEMENT
+    description: 'The organization ensures that cryptographic mechanisms used to provide
+      [Assignment: organization-defined security safeguards] are under configuration
+      management.'
+  nist_800_53:rev4:CM-4:1:
+    standard:
+      name: nist_800_53:rev4
+    family: CM
+    title: SEPARATE TEST ENVIRONMENTS
+    description: The organization analyzes changes to the information system in a
+      separate test environment before implementation in an operational environment,
+      looking for security impacts due to flaws, weaknesses, incompatibility, or intentional
+      malice.
+  nist_800_53:rev4:CM-4:2:
+    standard:
+      name: nist_800_53:rev4
+    family: CM
+    title: VERIFICATION OF SECURITY FUNCTIONS
+    description: The organization, after the information system is changed, checks
+      the security functions to verify that the functions are implemented correctly,
+      operating as intended, and producing the desired outcome with regard to meeting
+      the security requirements for the system.
+  nist_800_53:rev4:CM-5:1:
+    standard:
+      name: nist_800_53:rev4
+    family: CM
+    title: AUTOMATED ACCESS ENFORCEMENT / AUDITING
+    description: The information system enforces access restrictions and supports
+      auditing of the enforcement actions.
+  nist_800_53:rev4:CM-5:2:
+    standard:
+      name: nist_800_53:rev4
+    family: CM
+    title: REVIEW SYSTEM CHANGES
+    description: 'The organization reviews information system changes [Assignment:
+      organization-defined frequency] and [Assignment: organization-defined circumstances]
+      to determine whether unauthorized changes have occurred.'
+  nist_800_53:rev4:CM-5:3:
+    standard:
+      name: nist_800_53:rev4
+    family: CM
+    title: SIGNED COMPONENTS
+    description: 'The information system prevents the installation of [Assignment:
+      organization-defined software and firmware components] without verification
+      that the component has been digitally signed using a certificate that is recognized
+      and approved by the organization.'
+  nist_800_53:rev4:CM-5:4:
+    standard:
+      name: nist_800_53:rev4
+    family: CM
+    title: DUAL AUTHORIZATION
+    description: 'The organization enforces dual authorization for implementing changes
+      to [Assignment: organization-defined information system components and system-level
+      information].'
+  nist_800_53:rev4:CM-5:5:
+    standard:
+      name: nist_800_53:rev4
+    family: CM
+    title: LIMIT PRODUCTION / OPERATIONAL PRIVILEGES
+    description: 'The organization:'
+  nist_800_53:rev4:CM-5:5:a:
+    standard:
+      name: nist_800_53:rev4
+    family: CM
+    title: CM-5 (5)(a)
+    description: Limits privileges to change information system components and system-related
+      information within a production or operational environment; and
+  nist_800_53:rev4:CM-5:5:b:
+    standard:
+      name: nist_800_53:rev4
+    family: CM
+    title: CM-5 (5)(b)
+    description: 'Reviews and reevaluates privileges [Assignment: organization-defined
+      frequency].'
+  nist_800_53:rev4:CM-5:6:
+    standard:
+      name: nist_800_53:rev4
+    family: CM
+    title: LIMIT LIBRARY PRIVILEGES
+    description: The organization limits privileges to change software resident within
+      software libraries.
+  nist_800_53:rev4:CM-5:7:
+    standard:
+      name: nist_800_53:rev4
+    family: CM
+    title: AUTOMATIC IMPLEMENTATION OF SECURITY SAFEGUARDS
+    description: "[Withdrawn: Incorporated into SI-7]."
+  nist_800_53:rev4:CM-6:a:
+    standard:
+      name: nist_800_53:rev4
+    family: CM
+    title: CM-6a.
+    description: 'Establishes and documents configuration settings for information
+      technology products employed within the information system using [Assignment:
+      organization-defined security configuration checklists] that reflect the most
+      restrictive mode consistent with operational requirements;'
+  nist_800_53:rev4:CM-6:b:
+    standard:
+      name: nist_800_53:rev4
+    family: CM
+    title: CM-6b.
+    description: Implements the configuration settings;
+  nist_800_53:rev4:CM-6:c:
+    standard:
+      name: nist_800_53:rev4
+    family: CM
+    title: CM-6c.
+    description: 'Identifies, documents, and approves any deviations from established
+      configuration settings for [Assignment: organization-defined information system
+      components] based on [Assignment: organization-defined operational requirements];
+      and'
+  nist_800_53:rev4:CM-6:d:
+    standard:
+      name: nist_800_53:rev4
+    family: CM
+    title: CM-6d.
+    description: Monitors and controls changes to the configuration settings in accordance
+      with organizational policies and procedures.
+  nist_800_53:rev4:CM-6:1:
+    standard:
+      name: nist_800_53:rev4
+    family: CM
+    title: AUTOMATED CENTRAL MANAGEMENT / APPLICATION / VERIFICATION
+    description: 'The organization employs automated mechanisms to centrally manage,
+      apply, and verify configuration settings for [Assignment: organization-defined
+      information system components].'
+  nist_800_53:rev4:CM-6:2:
+    standard:
+      name: nist_800_53:rev4
+    family: CM
+    title: RESPOND TO UNAUTHORIZED CHANGES
+    description: 'The organization employs [Assignment: organization-defined security
+      safeguards] to respond to unauthorized changes to [Assignment: organization-defined
+      configuration settings].'
+  nist_800_53:rev4:CM-6:3:
+    standard:
+      name: nist_800_53:rev4
+    family: CM
+    title: UNAUTHORIZED CHANGE DETECTION
+    description: "[Withdrawn: Incorporated into SI-7]."
+  nist_800_53:rev4:CM-6:4:
+    standard:
+      name: nist_800_53:rev4
+    family: CM
+    title: CONFORMANCE DEMONSTRATION
+    description: "[Withdrawn: Incorporated into CM-4]."
+  nist_800_53:rev4:CM-7:a:
+    standard:
+      name: nist_800_53:rev4
+    family: CM
+    title: CM-7a.
+    description: Configures the information system to provide only essential capabilities;
+      and
+  nist_800_53:rev4:CM-7:b:
+    standard:
+      name: nist_800_53:rev4
+    family: CM
+    title: CM-7b.
+    description: 'Prohibits or restricts the use of the following functions, ports,
+      protocols, and/or services: [Assignment: organization-defined prohibited or
+      restricted functions, ports, protocols, and/or services].'
+  nist_800_53:rev4:CM-7:1:
+    standard:
+      name: nist_800_53:rev4
+    family: CM
+    title: PERIODIC REVIEW
+    description: 'The organization:'
+  nist_800_53:rev4:CM-7:1:a:
+    standard:
+      name: nist_800_53:rev4
+    family: CM
+    title: CM-7 (1)(a)
+    description: 'Reviews the information system [Assignment: organization-defined
+      frequency] to identify unnecessary and/or nonsecure functions, ports, protocols,
+      and services; and'
+  nist_800_53:rev4:CM-7:1:b:
+    standard:
+      name: nist_800_53:rev4
+    family: CM
+    title: CM-7 (1)(b)
+    description: 'Disables [Assignment: organization-defined functions, ports, protocols,
+      and services within the information system deemed to be unnecessary and/or nonsecure].'
+  nist_800_53:rev4:CM-7:2:
+    standard:
+      name: nist_800_53:rev4
+    family: CM
+    title: PREVENT PROGRAM EXECUTION
+    description: 'The information system prevents program execution in accordance
+      with [Selection (one or more): [Assignment: organization-defined policies regarding
+      software program usage and restrictions]; rules authorizing the terms and conditions
+      of software program usage].'
+  nist_800_53:rev4:CM-7:3:
+    standard:
+      name: nist_800_53:rev4
+    family: CM
+    title: REGISTRATION COMPLIANCE
+    description: 'The organization ensures compliance with [Assignment: organization-defined
+      registration requirements for functions, ports, protocols, and services].'
+  nist_800_53:rev4:CM-7:4:
+    standard:
+      name: nist_800_53:rev4
+    family: CM
+    title: UNAUTHORIZED SOFTWARE / BLACKLISTING
+    description: 'The organization:'
+  nist_800_53:rev4:CM-7:4:a:
+    standard:
+      name: nist_800_53:rev4
+    family: CM
+    title: CM-7 (4)(a)
+    description: 'Identifies [Assignment: organization-defined software programs not
+      authorized to execute on the information system];'
+  nist_800_53:rev4:CM-7:4:b:
+    standard:
+      name: nist_800_53:rev4
+    family: CM
+    title: CM-7 (4)(b)
+    description: Employs an allow-all, deny-by-exception policy to prohibit the execution
+      of unauthorized software programs on the information system; and
+  nist_800_53:rev4:CM-7:4:c:
+    standard:
+      name: nist_800_53:rev4
+    family: CM
+    title: CM-7 (4)(c)
+    description: 'Reviews and updates the list of unauthorized software programs [Assignment:
+      organization-defined frequency].'
+  nist_800_53:rev4:CM-7:5:
+    standard:
+      name: nist_800_53:rev4
+    family: CM
+    title: AUTHORIZED SOFTWARE / WHITELISTING
+    description: 'The organization:'
+  nist_800_53:rev4:CM-7:5:a:
+    standard:
+      name: nist_800_53:rev4
+    family: CM
+    title: CM-7 (5)(a)
+    description: 'Identifies [Assignment: organization-defined software programs authorized
+      to execute on the information system];'
+  nist_800_53:rev4:CM-7:5:b:
+    standard:
+      name: nist_800_53:rev4
+    family: CM
+    title: CM-7 (5)(b)
+    description: Employs a deny-all, permit-by-exception policy to allow the execution
+      of authorized software programs on the information system; and
+  nist_800_53:rev4:CM-7:5:c:
+    standard:
+      name: nist_800_53:rev4
+    family: CM
+    title: CM-7 (5)(c)
+    description: 'Reviews and updates the list of authorized software programs [Assignment:
+      organization-defined frequency].'
+  nist_800_53:rev4:CM-8:a:
+    standard:
+      name: nist_800_53:rev4
+    family: CM
+    title: CM-8a.
+    description: 'Develops and documents an inventory of information system components
+      that:'
+  nist_800_53:rev4:CM-8:a:1:
+    standard:
+      name: nist_800_53:rev4
+    family: CM
+    title: CM-8a.1.
+    description: Accurately reflects the current information system;
+  nist_800_53:rev4:CM-8:a:2:
+    standard:
+      name: nist_800_53:rev4
+    family: CM
+    title: CM-8a.2.
+    description: Includes all components within the authorization boundary of the
+      information system;
+  nist_800_53:rev4:CM-8:a:3:
+    standard:
+      name: nist_800_53:rev4
+    family: CM
+    title: CM-8a.3.
+    description: Is at the level of granularity deemed necessary for tracking and
+      reporting; and
+  nist_800_53:rev4:CM-8:a:4:
+    standard:
+      name: nist_800_53:rev4
+    family: CM
+    title: CM-8a.4.
+    description: 'Includes [Assignment: organization-defined information deemed necessary
+      to achieve effective information system component accountability]; and'
+  nist_800_53:rev4:CM-8:b:
+    standard:
+      name: nist_800_53:rev4
+    family: CM
+    title: CM-8b.
+    description: 'Reviews and updates the information system component inventory [Assignment:
+      organization-defined frequency].'
+  nist_800_53:rev4:CM-8:1:
+    standard:
+      name: nist_800_53:rev4
+    family: CM
+    title: UPDATES DURING INSTALLATIONS / REMOVALS
+    description: The organization updates the inventory of information system components
+      as an integral part of component installations, removals, and information system
+      updates.
+  nist_800_53:rev4:CM-8:2:
+    standard:
+      name: nist_800_53:rev4
+    family: CM
+    title: AUTOMATED MAINTENANCE
+    description: The organization employs automated mechanisms to help maintain an
+      up-to-date, complete, accurate, and readily available inventory of information
+      system components.
+  nist_800_53:rev4:CM-8:3:
+    standard:
+      name: nist_800_53:rev4
+    family: CM
+    title: AUTOMATED UNAUTHORIZED COMPONENT DETECTION
+    description: 'The organization:'
+  nist_800_53:rev4:CM-8:3:a:
+    standard:
+      name: nist_800_53:rev4
+    family: CM
+    title: CM-8 (3)(a)
+    description: 'Employs automated mechanisms [Assignment: organization-defined frequency]
+      to detect the presence of unauthorized hardware, software, and firmware components
+      within the information system; and'
+  nist_800_53:rev4:CM-8:3:b:
+    standard:
+      name: nist_800_53:rev4
+    family: CM
+    title: CM-8 (3)(b)
+    description: 'Takes the following actions when unauthorized components are detected:
+      [Selection (one or more): disables network access by such components; isolates
+      the components; notifies [Assignment: organization-defined personnel or roles]].'
+  nist_800_53:rev4:CM-8:4:
+    standard:
+      name: nist_800_53:rev4
+    family: CM
+    title: ACCOUNTABILITY INFORMATION
+    description: 'The organization includes in the information system component inventory
+      information, a means for identifying by [Selection (one or more): name; position;
+      role], individuals responsible/accountable for administering those components.'
+  nist_800_53:rev4:CM-8:5:
+    standard:
+      name: nist_800_53:rev4
+    family: CM
+    title: NO DUPLICATE ACCOUNTING OF COMPONENTS
+    description: The organization verifies that all components within the authorization
+      boundary of the information system are not duplicated in other information system
+      component inventories.
+  nist_800_53:rev4:CM-8:6:
+    standard:
+      name: nist_800_53:rev4
+    family: CM
+    title: ASSESSED CONFIGURATIONS / APPROVED DEVIATIONS
+    description: The organization includes assessed component configurations and any
+      approved deviations to current deployed configurations in the information system
+      component inventory.
+  nist_800_53:rev4:CM-8:7:
+    standard:
+      name: nist_800_53:rev4
+    family: CM
+    title: CENTRALIZED REPOSITORY
+    description: The organization provides a centralized repository for the inventory
+      of information system components.
+  nist_800_53:rev4:CM-8:8:
+    standard:
+      name: nist_800_53:rev4
+    family: CM
+    title: AUTOMATED LOCATION TRACKING
+    description: The organization employs automated mechanisms to support tracking
+      of information system components by geographic location.
+  nist_800_53:rev4:CM-8:9:
+    standard:
+      name: nist_800_53:rev4
+    family: CM
+    title: ASSIGNMENT OF COMPONENTS TO SYSTEMS
+    description: 'The organization:'
+  nist_800_53:rev4:CM-8:9:a:
+    standard:
+      name: nist_800_53:rev4
+    family: CM
+    title: CM-8 (9)(a)
+    description: 'Assigns [Assignment: organization-defined acquired information system
+      components] to an information system; and'
+  nist_800_53:rev4:CM-8:9:b:
+    standard:
+      name: nist_800_53:rev4
+    family: CM
+    title: CM-8 (9)(b)
+    description: Receives an acknowledgement from the information system owner of
+      this assignment.
+  nist_800_53:rev4:CM-9:a:
+    standard:
+      name: nist_800_53:rev4
+    family: CM
+    title: CM-9a.
+    description: Addresses roles, responsibilities, and configuration management processes
+      and procedures;
+  nist_800_53:rev4:CM-9:b:
+    standard:
+      name: nist_800_53:rev4
+    family: CM
+    title: CM-9b.
+    description: Establishes a process for identifying configuration items throughout
+      the system development life cycle and for managing the configuration of the
+      configuration items;
+  nist_800_53:rev4:CM-9:c:
+    standard:
+      name: nist_800_53:rev4
+    family: CM
+    title: CM-9c.
+    description: Defines the configuration items for the information system and places
+      the configuration items under configuration management; and
+  nist_800_53:rev4:CM-9:d:
+    standard:
+      name: nist_800_53:rev4
+    family: CM
+    title: CM-9d.
+    description: Protects the configuration management plan from unauthorized disclosure
+      and modification.
+  nist_800_53:rev4:CM-9:1:
+    standard:
+      name: nist_800_53:rev4
+    family: CM
+    title: ASSIGNMENT OF RESPONSIBILITY
+    description: The organization assigns responsibility for developing the configuration
+      management process to organizational personnel that are not directly involved
+      in information system development.
+  nist_800_53:rev4:CM-10:a:
+    standard:
+      name: nist_800_53:rev4
+    family: CM
+    title: CM-10a.
+    description: Uses software and associated documentation in accordance with contract
+      agreements and copyright laws;
+  nist_800_53:rev4:CM-10:b:
+    standard:
+      name: nist_800_53:rev4
+    family: CM
+    title: CM-10b.
+    description: Tracks the use of software and associated documentation protected
+      by quantity licenses to control copying and distribution; and
+  nist_800_53:rev4:CM-10:c:
+    standard:
+      name: nist_800_53:rev4
+    family: CM
+    title: CM-10c.
+    description: Controls and documents the use of peer-to-peer file sharing technology
+      to ensure that this capability is not used for the unauthorized distribution,
+      display, performance, or reproduction of copyrighted work.
+  nist_800_53:rev4:CM-10:1:
+    standard:
+      name: nist_800_53:rev4
+    family: CM
+    title: OPEN SOURCE SOFTWARE
+    description: 'The organization establishes the following restrictions on the use
+      of open source software: [Assignment: organization-defined restrictions].'
+  nist_800_53:rev4:CM-11:a:
+    standard:
+      name: nist_800_53:rev4
+    family: CM
+    title: CM-11a.
+    description: 'Establishes [Assignment: organization-defined policies] governing
+      the installation of software by users;'
+  nist_800_53:rev4:CM-11:b:
+    standard:
+      name: nist_800_53:rev4
+    family: CM
+    title: CM-11b.
+    description: 'Enforces software installation policies through [Assignment: organization-defined
+      methods]; and'
+  nist_800_53:rev4:CM-11:c:
+    standard:
+      name: nist_800_53:rev4
+    family: CM
+    title: CM-11c.
+    description: 'Monitors policy compliance at [Assignment: organization-defined
+      frequency].'
+  nist_800_53:rev4:CM-11:1:
+    standard:
+      name: nist_800_53:rev4
+    family: CM
+    title: ALERTS FOR UNAUTHORIZED INSTALLATIONS
+    description: 'The information system alerts [Assignment: organization-defined
+      personnel or roles] when the unauthorized installation of software is detected.'
+  nist_800_53:rev4:CM-11:2:
+    standard:
+      name: nist_800_53:rev4
+    family: CM
+    title: PROHIBIT INSTALLATION WITHOUT PRIVILEGED STATUS
+    description: The information system prohibits user installation of software without
+      explicit privileged status.
+  nist_800_53:rev4:CP-1:a:
+    standard:
+      name: nist_800_53:rev4
+    family: CP
+    title: CP-1a.
+    description: 'Develops, documents, and disseminates to [Assignment: organization-defined
+      personnel or roles]:'
+  nist_800_53:rev4:CP-1:a:1:
+    standard:
+      name: nist_800_53:rev4
+    family: CP
+    title: CP-1a.1.
+    description: A contingency planning policy that addresses purpose, scope, roles,
+      responsibilities, management commitment, coordination among organizational entities,
+      and compliance; and
+  nist_800_53:rev4:CP-1:a:2:
+    standard:
+      name: nist_800_53:rev4
+    family: CP
+    title: CP-1a.2.
+    description: Procedures to facilitate the implementation of the contingency planning
+      policy and associated contingency planning controls; and
+  nist_800_53:rev4:CP-1:b:
+    standard:
+      name: nist_800_53:rev4
+    family: CP
+    title: CP-1b.
+    description: 'Reviews and updates the current:'
+  nist_800_53:rev4:CP-1:b:1:
+    standard:
+      name: nist_800_53:rev4
+    family: CP
+    title: CP-1b.1.
+    description: 'Contingency planning policy [Assignment: organization-defined frequency];
+      and'
+  nist_800_53:rev4:CP-1:b:2:
+    standard:
+      name: nist_800_53:rev4
+    family: CP
+    title: CP-1b.2.
+    description: 'Contingency planning procedures [Assignment: organization-defined
+      frequency].'
+  nist_800_53:rev4:CP-2:a:
+    standard:
+      name: nist_800_53:rev4
+    family: CP
+    title: CP-2a.
+    description: 'Develops a contingency plan for the information system that:'
+  nist_800_53:rev4:CP-2:a:1:
+    standard:
+      name: nist_800_53:rev4
+    family: CP
+    title: CP-2a.1.
+    description: Identifies essential missions and business functions and associated
+      contingency requirements;
+  nist_800_53:rev4:CP-2:a:2:
+    standard:
+      name: nist_800_53:rev4
+    family: CP
+    title: CP-2a.2.
+    description: Provides recovery objectives, restoration priorities, and metrics;
+  nist_800_53:rev4:CP-2:a:3:
+    standard:
+      name: nist_800_53:rev4
+    family: CP
+    title: CP-2a.3.
+    description: Addresses contingency roles, responsibilities, assigned individuals
+      with contact information;
+  nist_800_53:rev4:CP-2:a:4:
+    standard:
+      name: nist_800_53:rev4
+    family: CP
+    title: CP-2a.4.
+    description: Addresses maintaining essential missions and business functions despite
+      an information system disruption, compromise, or failure;
+  nist_800_53:rev4:CP-2:a:5:
+    standard:
+      name: nist_800_53:rev4
+    family: CP
+    title: CP-2a.5.
+    description: Addresses eventual, full information system restoration without deterioration
+      of the security safeguards originally planned and implemented; and
+  nist_800_53:rev4:CP-2:a:6:
+    standard:
+      name: nist_800_53:rev4
+    family: CP
+    title: CP-2a.6.
+    description: 'Is reviewed and approved by [Assignment: organization-defined personnel
+      or roles];'
+  nist_800_53:rev4:CP-2:b:
+    standard:
+      name: nist_800_53:rev4
+    family: CP
+    title: CP-2b.
+    description: 'Distributes copies of the contingency plan to [Assignment: organization-defined
+      key contingency personnel (identified by name and/or by role) and organizational
+      elements];'
+  nist_800_53:rev4:CP-2:c:
+    standard:
+      name: nist_800_53:rev4
+    family: CP
+    title: CP-2c.
+    description: Coordinates contingency planning activities with incident handling
+      activities;
+  nist_800_53:rev4:CP-2:d:
+    standard:
+      name: nist_800_53:rev4
+    family: CP
+    title: CP-2d.
+    description: 'Reviews the contingency plan for the information system [Assignment:
+      organization-defined frequency];'
+  nist_800_53:rev4:CP-2:e:
+    standard:
+      name: nist_800_53:rev4
+    family: CP
+    title: CP-2e.
+    description: Updates the contingency plan to address changes to the organization,
+      information system, or environment of operation and problems encountered during
+      contingency plan implementation, execution, or testing;
+  nist_800_53:rev4:CP-2:f:
+    standard:
+      name: nist_800_53:rev4
+    family: CP
+    title: CP-2f.
+    description: 'Communicates contingency plan changes to [Assignment: organization-defined
+      key contingency personnel (identified by name and/or by role) and organizational
+      elements]; and'
+  nist_800_53:rev4:CP-2:g:
+    standard:
+      name: nist_800_53:rev4
+    family: CP
+    title: CP-2g.
+    description: Protects the contingency plan from unauthorized disclosure and modification.
+  nist_800_53:rev4:CP-2:1:
+    standard:
+      name: nist_800_53:rev4
+    family: CP
+    title: COORDINATE WITH RELATED PLANS
+    description: The organization coordinates contingency plan development with organizational
+      elements responsible for related plans.
+  nist_800_53:rev4:CP-2:2:
+    standard:
+      name: nist_800_53:rev4
+    family: CP
+    title: CAPACITY PLANNING
+    description: The organization conducts capacity planning so that necessary capacity
+      for information processing, telecommunications, and environmental support exists
+      during contingency operations.
+  nist_800_53:rev4:CP-2:3:
+    standard:
+      name: nist_800_53:rev4
+    family: CP
+    title: RESUME ESSENTIAL MISSIONS / BUSINESS FUNCTIONS
+    description: 'The organization plans for the resumption of essential missions
+      and business functions within [Assignment: organization-defined time period]
+      of contingency plan activation.'
+  nist_800_53:rev4:CP-2:4:
+    standard:
+      name: nist_800_53:rev4
+    family: CP
+    title: RESUME ALL MISSIONS / BUSINESS FUNCTIONS
+    description: 'The organization plans for the resumption of all missions and business
+      functions within [Assignment: organization-defined time period] of contingency
+      plan activation.'
+  nist_800_53:rev4:CP-2:5:
+    standard:
+      name: nist_800_53:rev4
+    family: CP
+    title: CONTINUE  ESSENTIAL MISSIONS / BUSINESS FUNCTIONS
+    description: The organization plans for the continuance of essential missions
+      and business functions with little or no loss of operational continuity and
+      sustains that continuity until full information system restoration at primary
+      processing and/or storage sites.
+  nist_800_53:rev4:CP-2:6:
+    standard:
+      name: nist_800_53:rev4
+    family: CP
+    title: ALTERNATE PROCESSING / STORAGE SITE
+    description: The organization plans for the transfer of essential missions and
+      business functions to alternate processing and/or storage sites with little
+      or no loss of operational continuity and sustains that continuity through information
+      system restoration to primary processing and/or storage sites.
+  nist_800_53:rev4:CP-2:7:
+    standard:
+      name: nist_800_53:rev4
+    family: CP
+    title: COORDINATE  WITH EXTERNAL SERVICE PROVIDERS
+    description: The organization coordinates its contingency plan with the contingency
+      plans of external service providers to ensure that contingency requirements
+      can be satisfied.
+  nist_800_53:rev4:CP-2:8:
+    standard:
+      name: nist_800_53:rev4
+    family: CP
+    title: IDENTIFY CRITICAL ASSETS
+    description: The organization identifies critical information system assets supporting
+      essential missions and business functions.
+  nist_800_53:rev4:CP-3:a:
+    standard:
+      name: nist_800_53:rev4
+    family: CP
+    title: CP-3a.
+    description: 'Within [Assignment: organization-defined time period] of assuming
+      a contingency role or responsibility;'
+  nist_800_53:rev4:CP-3:b:
+    standard:
+      name: nist_800_53:rev4
+    family: CP
+    title: CP-3b.
+    description: When required by information system changes; and
+  nist_800_53:rev4:CP-3:c:
+    standard:
+      name: nist_800_53:rev4
+    family: CP
+    title: CP-3c.
+    description: "[Assignment: organization-defined frequency] thereafter."
+  nist_800_53:rev4:CP-3:1:
+    standard:
+      name: nist_800_53:rev4
+    family: CP
+    title: SIMULATED EVENTS
+    description: The organization incorporates simulated events into contingency training
+      to facilitate effective response by personnel in crisis situations.
+  nist_800_53:rev4:CP-3:2:
+    standard:
+      name: nist_800_53:rev4
+    family: CP
+    title: AUTOMATED TRAINING ENVIRONMENTS
+    description: The organization employs automated mechanisms to provide a more thorough
+      and realistic contingency training environment.
+  nist_800_53:rev4:CP-4:a:
+    standard:
+      name: nist_800_53:rev4
+    family: CP
+    title: CP-4a.
+    description: 'Tests the contingency plan for the information system [Assignment:
+      organization-defined frequency] using [Assignment: organization-defined tests]
+      to determine the effectiveness of the plan and the organizational readiness
+      to execute the plan;'
+  nist_800_53:rev4:CP-4:b:
+    standard:
+      name: nist_800_53:rev4
+    family: CP
+    title: CP-4b.
+    description: Reviews the contingency plan test results; and
+  nist_800_53:rev4:CP-4:c:
+    standard:
+      name: nist_800_53:rev4
+    family: CP
+    title: CP-4c.
+    description: Initiates corrective actions, if needed.
+  nist_800_53:rev4:CP-4:1:
+    standard:
+      name: nist_800_53:rev4
+    family: CP
+    title: COORDINATE WITH RELATED PLANS
+    description: The organization coordinates contingency plan testing with organizational
+      elements responsible for related plans.
+  nist_800_53:rev4:CP-4:2:
+    standard:
+      name: nist_800_53:rev4
+    family: CP
+    title: ALTERNATE PROCESSING SITE
+    description: 'The organization tests the contingency plan at the alternate processing
+      site:'
+  nist_800_53:rev4:CP-4:2:a:
+    standard:
+      name: nist_800_53:rev4
+    family: CP
+    title: CP-4 (2)(a)
+    description: To familiarize contingency personnel with the facility and available
+      resources; and
+  nist_800_53:rev4:CP-4:2:b:
+    standard:
+      name: nist_800_53:rev4
+    family: CP
+    title: CP-4 (2)(b)
+    description: To evaluate the capabilities of the alternate processing site to
+      support contingency operations.
+  nist_800_53:rev4:CP-4:3:
+    standard:
+      name: nist_800_53:rev4
+    family: CP
+    title: AUTOMATED TESTING
+    description: The organization employs automated mechanisms to more thoroughly
+      and effectively test the contingency plan.
+  nist_800_53:rev4:CP-4:4:
+    standard:
+      name: nist_800_53:rev4
+    family: CP
+    title: FULL RECOVERY / RECONSTITUTION
+    description: The organization includes a full recovery and reconstitution of the
+      information system to a known state as part of contingency plan testing.
+  nist_800_53:rev4:CP-6:a:
+    standard:
+      name: nist_800_53:rev4
+    family: CP
+    title: CP-6a.
+    description: Establishes an alternate storage site including necessary agreements
+      to permit the storage and retrieval of information system backup information;
+      and
+  nist_800_53:rev4:CP-6:b:
+    standard:
+      name: nist_800_53:rev4
+    family: CP
+    title: CP-6b.
+    description: Ensures that the alternate storage site provides information security
+      safeguards equivalent to that of the primary site.
+  nist_800_53:rev4:CP-6:1:
+    standard:
+      name: nist_800_53:rev4
+    family: CP
+    title: SEPARATION FROM PRIMARY SITE
+    description: The organization identifies an alternate storage site that is separated
+      from the primary storage site to reduce susceptibility to the same threats.
+  nist_800_53:rev4:CP-6:2:
+    standard:
+      name: nist_800_53:rev4
+    family: CP
+    title: RECOVERY TIME / POINT OBJECTIVES
+    description: The organization configures the alternate storage site to facilitate
+      recovery operations in accordance with recovery time and recovery point objectives.
+  nist_800_53:rev4:CP-6:3:
+    standard:
+      name: nist_800_53:rev4
+    family: CP
+    title: ACCESSIBILITY
+    description: The organization identifies potential accessibility problems to the
+      alternate storage site in the event of an area-wide disruption or disaster and
+      outlines explicit mitigation actions.
+  nist_800_53:rev4:CP-7:a:
+    standard:
+      name: nist_800_53:rev4
+    family: CP
+    title: CP-7a.
+    description: 'Establishes an alternate processing site including necessary agreements
+      to permit the transfer and resumption of [Assignment: organization-defined information
+      system operations] for essential missions/business functions within [Assignment:
+      organization-defined time period consistent with recovery time and recovery
+      point objectives] when the primary processing capabilities are unavailable;'
+  nist_800_53:rev4:CP-7:b:
+    standard:
+      name: nist_800_53:rev4
+    family: CP
+    title: CP-7b.
+    description: Ensures that equipment and supplies required to transfer and resume
+      operations are available at the alternate processing site or contracts are in
+      place to support delivery to the site within the organization-defined time period
+      for transfer/resumption; and
+  nist_800_53:rev4:CP-7:c:
+    standard:
+      name: nist_800_53:rev4
+    family: CP
+    title: CP-7c.
+    description: Ensures that the alternate processing site provides information security
+      safeguards equivalent to those of the primary site.
+  nist_800_53:rev4:CP-7:1:
+    standard:
+      name: nist_800_53:rev4
+    family: CP
+    title: SEPARATION FROM PRIMARY SITE
+    description: The organization identifies an alternate processing site that is
+      separated from the primary processing site to reduce susceptibility to the same
+      threats.
+  nist_800_53:rev4:CP-7:2:
+    standard:
+      name: nist_800_53:rev4
+    family: CP
+    title: ACCESSIBILITY
+    description: The organization identifies potential accessibility problems to the
+      alternate processing site in the event of an area-wide disruption or disaster
+      and outlines explicit mitigation actions.
+  nist_800_53:rev4:CP-7:3:
+    standard:
+      name: nist_800_53:rev4
+    family: CP
+    title: PRIORITY OF SERVICE
+    description: The organization develops alternate processing site agreements that
+      contain priority-of-service provisions in accordance with organizational availability
+      requirements (including recovery time objectives).
+  nist_800_53:rev4:CP-7:4:
+    standard:
+      name: nist_800_53:rev4
+    family: CP
+    title: PREPARATION FOR USE
+    description: The organization prepares the alternate processing site so that the
+      site is ready to be used as the operational site supporting essential missions
+      and business functions.
+  nist_800_53:rev4:CP-7:5:
+    standard:
+      name: nist_800_53:rev4
+    family: CP
+    title: EQUIVALENT INFORMATION SECURITY SAFEGUARDS
+    description: "[Withdrawn: Incorporated into CP-7]."
+  nist_800_53:rev4:CP-7:6:
+    standard:
+      name: nist_800_53:rev4
+    family: CP
+    title: INABILITY TO RETURN TO PRIMARY SITE
+    description: The organization plans and prepares for circumstances that preclude
+      returning to the primary processing site.
+  nist_800_53:rev4:CP-8:1:
+    standard:
+      name: nist_800_53:rev4
+    family: CP
+    title: PRIORITY OF SERVICE PROVISIONS
+    description: 'The organization:'
+  nist_800_53:rev4:CP-8:1:a:
+    standard:
+      name: nist_800_53:rev4
+    family: CP
+    title: CP-8 (1)(a)
+    description: Develops primary and alternate telecommunications service agreements
+      that contain priority-of-service provisions in accordance with organizational
+      availability requirements (including recovery time objectives); and
+  nist_800_53:rev4:CP-8:1:b:
+    standard:
+      name: nist_800_53:rev4
+    family: CP
+    title: CP-8 (1)(b)
+    description: Requests Telecommunications Service Priority for all telecommunications
+      services used for national security emergency preparedness in the event that
+      the primary and/or alternate telecommunications services are provided by a common
+      carrier.
+  nist_800_53:rev4:CP-8:2:
+    standard:
+      name: nist_800_53:rev4
+    family: CP
+    title: SINGLE POINTS OF FAILURE
+    description: The organization obtains alternate telecommunications services to
+      reduce the likelihood of sharing a single point of failure with primary telecommunications
+      services.
+  nist_800_53:rev4:CP-8:3:
+    standard:
+      name: nist_800_53:rev4
+    family: CP
+    title: SEPARATION OF PRIMARY / ALTERNATE PROVIDERS
+    description: The organization obtains alternate telecommunications services from
+      providers that are separated from primary service providers to reduce susceptibility
+      to the same threats.
+  nist_800_53:rev4:CP-8:4:
+    standard:
+      name: nist_800_53:rev4
+    family: CP
+    title: PROVIDER CONTINGENCY PLAN
+    description: 'The organization:'
+  nist_800_53:rev4:CP-8:4:a:
+    standard:
+      name: nist_800_53:rev4
+    family: CP
+    title: CP-8 (4)(a)
+    description: Requires primary and alternate telecommunications service providers
+      to have contingency plans;
+  nist_800_53:rev4:CP-8:4:b:
+    standard:
+      name: nist_800_53:rev4
+    family: CP
+    title: CP-8 (4)(b)
+    description: Reviews provider contingency plans to ensure that the plans meet
+      organizational contingency requirements; and
+  nist_800_53:rev4:CP-8:4:c:
+    standard:
+      name: nist_800_53:rev4
+    family: CP
+    title: CP-8 (4)(c)
+    description: 'Obtains evidence of contingency testing/training by providers [Assignment:
+      organization-defined frequency].'
+  nist_800_53:rev4:CP-8:5:
+    standard:
+      name: nist_800_53:rev4
+    family: CP
+    title: ALTERNATE TELECOMMUNICATION SERVICE TESTING
+    description: 'The organization tests alternate telecommunication services [Assignment:
+      organization-defined frequency].'
+  nist_800_53:rev4:CP-9:a:
+    standard:
+      name: nist_800_53:rev4
+    family: CP
+    title: CP-9a.
+    description: 'Conducts backups of user-level information contained in the information
+      system [Assignment: organization-defined frequency consistent with recovery
+      time and recovery point objectives];'
+  nist_800_53:rev4:CP-9:b:
+    standard:
+      name: nist_800_53:rev4
+    family: CP
+    title: CP-9b.
+    description: 'Conducts backups of system-level information contained in the information
+      system [Assignment: organization-defined frequency consistent with recovery
+      time and recovery point objectives];'
+  nist_800_53:rev4:CP-9:c:
+    standard:
+      name: nist_800_53:rev4
+    family: CP
+    title: CP-9c.
+    description: 'Conducts backups of information system documentation including security-related
+      documentation [Assignment: organization-defined frequency consistent with recovery
+      time and recovery point objectives]; and'
+  nist_800_53:rev4:CP-9:d:
+    standard:
+      name: nist_800_53:rev4
+    family: CP
+    title: CP-9d.
+    description: Protects the confidentiality, integrity, and availability of backup
+      information at storage locations.
+  nist_800_53:rev4:CP-9:1:
+    standard:
+      name: nist_800_53:rev4
+    family: CP
+    title: TESTING FOR RELIABILITY / INTEGRITY
+    description: 'The organization tests backup information [Assignment: organization-defined
+      frequency] to verify media reliability and information integrity.'
+  nist_800_53:rev4:CP-9:2:
+    standard:
+      name: nist_800_53:rev4
+    family: CP
+    title: TEST RESTORATION USING SAMPLING
+    description: The organization uses a sample of backup information in the restoration
+      of selected information system functions as part of contingency plan testing.
+  nist_800_53:rev4:CP-9:3:
+    standard:
+      name: nist_800_53:rev4
+    family: CP
+    title: SEPARATE STORAGE FOR CRITICAL INFORMATION
+    description: 'The organization stores backup copies of [Assignment: organization-defined
+      critical information system software and other security-related information]
+      in a separate facility or in a fire-rated container that is not collocated with
+      the operational system.'
+  nist_800_53:rev4:CP-9:4:
+    standard:
+      name: nist_800_53:rev4
+    family: CP
+    title: PROTECTION FROM UNAUTHORIZED MODIFICATION
+    description: "[Withdrawn: Incorporated into CP-9]."
+  nist_800_53:rev4:CP-9:5:
+    standard:
+      name: nist_800_53:rev4
+    family: CP
+    title: TRANSFER TO ALTERNATE STORAGE SITE
+    description: 'The organization transfers information system backup information
+      to the alternate storage site [Assignment: organization-defined time period
+      and transfer rate consistent with the recovery time and recovery point objectives].'
+  nist_800_53:rev4:CP-9:6:
+    standard:
+      name: nist_800_53:rev4
+    family: CP
+    title: REDUNDANT SECONDARY SYSTEM
+    description: The organization accomplishes information system backup by maintaining
+      a redundant secondary system that is not collocated with the primary system
+      and that can be activated without loss of information or disruption to operations.
+  nist_800_53:rev4:CP-9:7:
+    standard:
+      name: nist_800_53:rev4
+    family: CP
+    title: DUAL AUTHORIZATION
+    description: 'The organization enforces dual authorization for the deletion or
+      destruction of [Assignment: organization-defined backup information].'
+  nist_800_53:rev4:CP-10:1:
+    standard:
+      name: nist_800_53:rev4
+    family: CP
+    title: CONTINGENCY PLAN TESTING
+    description: "[Withdrawn: Incorporated into CP-4]."
+  nist_800_53:rev4:CP-10:2:
+    standard:
+      name: nist_800_53:rev4
+    family: CP
+    title: TRANSACTION RECOVERY
+    description: The information system implements transaction recovery for systems
+      that are transaction-based.
+  nist_800_53:rev4:CP-10:3:
+    standard:
+      name: nist_800_53:rev4
+    family: CP
+    title: COMPENSATING SECURITY CONTROLS
+    description: "[Withdrawn: Addressed through tailoring procedures]."
+  nist_800_53:rev4:CP-10:4:
+    standard:
+      name: nist_800_53:rev4
+    family: CP
+    title: RESTORE WITHIN TIME PERIOD
+    description: 'The organization provides the capability to restore information
+      system components within [Assignment: organization-defined restoration time-periods]
+      from configuration-controlled and integrity-protected information representing
+      a known, operational state for the components.'
+  nist_800_53:rev4:CP-10:5:
+    standard:
+      name: nist_800_53:rev4
+    family: CP
+    title: FAILOVER CAPABILITY
+    description: "[Withdrawn: Incorporated into SI-13]."
+  nist_800_53:rev4:CP-10:6:
+    standard:
+      name: nist_800_53:rev4
+    family: CP
+    title: COMPONENT PROTECTION
+    description: The organization protects backup and restoration hardware, firmware,
+      and software.
+  nist_800_53:rev4:IA-1:a:
+    standard:
+      name: nist_800_53:rev4
+    family: IA
+    title: IA-1a.
+    description: 'Develops, documents, and disseminates to [Assignment: organization-defined
+      personnel or roles]:'
+  nist_800_53:rev4:IA-1:a:1:
+    standard:
+      name: nist_800_53:rev4
+    family: IA
+    title: IA-1a.1.
+    description: An identification and authentication policy that addresses purpose,
+      scope, roles, responsibilities, management commitment, coordination among organizational
+      entities, and compliance; and
+  nist_800_53:rev4:IA-1:a:2:
+    standard:
+      name: nist_800_53:rev4
+    family: IA
+    title: IA-1a.2.
+    description: Procedures to facilitate the implementation of the identification
+      and authentication policy and associated identification and authentication controls;
+      and
+  nist_800_53:rev4:IA-1:b:
+    standard:
+      name: nist_800_53:rev4
+    family: IA
+    title: IA-1b.
+    description: 'Reviews and updates the current:'
+  nist_800_53:rev4:IA-1:b:1:
+    standard:
+      name: nist_800_53:rev4
+    family: IA
+    title: IA-1b.1.
+    description: 'Identification and authentication policy [Assignment: organization-defined
+      frequency]; and'
+  nist_800_53:rev4:IA-1:b:2:
+    standard:
+      name: nist_800_53:rev4
+    family: IA
+    title: IA-1b.2.
+    description: 'Identification and authentication procedures [Assignment: organization-defined
+      frequency].'
+  nist_800_53:rev4:IA-2:1:
+    standard:
+      name: nist_800_53:rev4
+    family: IA
+    title: NETWORK ACCESS TO PRIVILEGED ACCOUNTS
+    description: The information system implements multifactor authentication for
+      network access to privileged accounts.
+  nist_800_53:rev4:IA-2:2:
+    standard:
+      name: nist_800_53:rev4
+    family: IA
+    title: NETWORK ACCESS TO NON-PRIVILEGED ACCOUNTS
+    description: The information system implements multifactor authentication for
+      network access to non-privileged accounts.
+  nist_800_53:rev4:IA-2:3:
+    standard:
+      name: nist_800_53:rev4
+    family: IA
+    title: LOCAL ACCESS TO PRIVILEGED ACCOUNTS
+    description: The information system implements multifactor authentication for
+      local access to privileged accounts.
+  nist_800_53:rev4:IA-2:4:
+    standard:
+      name: nist_800_53:rev4
+    family: IA
+    title: LOCAL ACCESS TO NON-PRIVILEGED ACCOUNTS
+    description: The information system implements multifactor authentication for
+      local access to non-privileged accounts.
+  nist_800_53:rev4:IA-2:5:
+    standard:
+      name: nist_800_53:rev4
+    family: IA
+    title: GROUP AUTHENTICATION
+    description: The organization requires individuals to be authenticated with an
+      individual authenticator when a group authenticator is employed.
+  nist_800_53:rev4:IA-2:6:
+    standard:
+      name: nist_800_53:rev4
+    family: IA
+    title: NETWORK ACCESS TO PRIVILEGED ACCOUNTS - SEPARATE DEVICE
+    description: 'The information system implements multifactor authentication for
+      network access to privileged accounts such that one of the factors is provided
+      by a device separate from the system gaining access and the device meets [Assignment:
+      organization-defined strength of mechanism requirements].'
+  nist_800_53:rev4:IA-2:7:
+    standard:
+      name: nist_800_53:rev4
+    family: IA
+    title: NETWORK ACCESS TO NON-PRIVILEGED ACCOUNTS - SEPARATE DEVICE
+    description: 'The information system implements multifactor authentication for
+      network access to non-privileged accounts such that one of the factors is provided
+      by a device separate from the system gaining access and the device meets [Assignment:
+      organization-defined strength of mechanism requirements].'
+  nist_800_53:rev4:IA-2:8:
+    standard:
+      name: nist_800_53:rev4
+    family: IA
+    title: NETWORK ACCESS TO PRIVILEGED ACCOUNTS - REPLAY RESISTANT
+    description: The information system implements replay-resistant authentication
+      mechanisms for network access to privileged accounts.
+  nist_800_53:rev4:IA-2:9:
+    standard:
+      name: nist_800_53:rev4
+    family: IA
+    title: NETWORK ACCESS TO NON-PRIVILEGED ACCOUNTS - REPLAY RESISTANT
+    description: The information system implements replay-resistant authentication
+      mechanisms for network access to non-privileged accounts.
+  nist_800_53:rev4:IA-2:10:
+    standard:
+      name: nist_800_53:rev4
+    family: IA
+    title: SINGLE SIGN-ON
+    description: 'The information system provides a single sign-on capability for
+      [Assignment: organization-defined information system accounts and services].'
+  nist_800_53:rev4:IA-2:11:
+    standard:
+      name: nist_800_53:rev4
+    family: IA
+    title: REMOTE ACCESS  - SEPARATE DEVICE
+    description: 'The information system implements multifactor authentication for
+      remote access to privileged and non-privileged accounts such that one of the
+      factors is provided by a device separate from the system gaining access and
+      the device meets [Assignment: organization-defined strength of mechanism requirements].'
+  nist_800_53:rev4:IA-2:12:
+    standard:
+      name: nist_800_53:rev4
+    family: IA
+    title: ACCEPTANCE OF PIV CREDENTIALS
+    description: The information system accepts and electronically verifies Personal
+      Identity Verification (PIV) credentials.
+  nist_800_53:rev4:IA-2:13:
+    standard:
+      name: nist_800_53:rev4
+    family: IA
+    title: OUT-OF-BAND AUTHENTICATION
+    description: 'The information system implements [Assignment: organization-defined
+      out-of-band authentication] under [Assignment: organization-defined conditions].'
+  nist_800_53:rev4:IA-3:1:
+    standard:
+      name: nist_800_53:rev4
+    family: IA
+    title: CRYPTOGRAPHIC BIDIRECTIONAL AUTHENTICATION
+    description: 'The information system authenticates [Assignment: organization-defined
+      specific devices and/or types of devices] before establishing [Selection (one
+      or more): local; remote; network] connection using bidirectional authentication
+      that is cryptographically based.'
+  nist_800_53:rev4:IA-3:2:
+    standard:
+      name: nist_800_53:rev4
+    family: IA
+    title: CRYPTOGRAPHIC BIDIRECTIONAL NETWORK AUTHENTICATION
+    description: "[Withdrawn: Incorporated into IA-3 (1)]."
+  nist_800_53:rev4:IA-3:3:
+    standard:
+      name: nist_800_53:rev4
+    family: IA
+    title: DYNAMIC ADDRESS ALLOCATION
+    description: 'The organization:'
+  nist_800_53:rev4:IA-3:3:a:
+    standard:
+      name: nist_800_53:rev4
+    family: IA
+    title: IA-3 (3)(a)
+    description: 'Standardizes dynamic address allocation lease information and the
+      lease duration assigned to devices in accordance with [Assignment: organization-defined
+      lease information and lease duration]; and'
+  nist_800_53:rev4:IA-3:3:b:
+    standard:
+      name: nist_800_53:rev4
+    family: IA
+    title: IA-3 (3)(b)
+    description: Audits lease information when assigned to a device.
+  nist_800_53:rev4:IA-3:4:
+    standard:
+      name: nist_800_53:rev4
+    family: IA
+    title: DEVICE ATTESTATION
+    description: 'The organization ensures that device identification and authentication
+      based on attestation is handled by [Assignment: organization-defined configuration
+      management process].'
+  nist_800_53:rev4:IA-4:a:
+    standard:
+      name: nist_800_53:rev4
+    family: IA
+    title: IA-4a.
+    description: 'Receiving authorization from [Assignment: organization-defined personnel
+      or roles] to assign an individual, group, role, or device identifier;'
+  nist_800_53:rev4:IA-4:b:
+    standard:
+      name: nist_800_53:rev4
+    family: IA
+    title: IA-4b.
+    description: Selecting an identifier that identifies an individual, group, role,
+      or device;
+  nist_800_53:rev4:IA-4:c:
+    standard:
+      name: nist_800_53:rev4
+    family: IA
+    title: IA-4c.
+    description: Assigning the identifier to the intended individual, group, role,
+      or device;
+  nist_800_53:rev4:IA-4:d:
+    standard:
+      name: nist_800_53:rev4
+    family: IA
+    title: IA-4d.
+    description: 'Preventing reuse of identifiers for [Assignment: organization-defined
+      time period]; and'
+  nist_800_53:rev4:IA-4:e:
+    standard:
+      name: nist_800_53:rev4
+    family: IA
+    title: IA-4e.
+    description: 'Disabling the identifier after [Assignment: organization-defined
+      time period of inactivity].'
+  nist_800_53:rev4:IA-4:1:
+    standard:
+      name: nist_800_53:rev4
+    family: IA
+    title: PROHIBIT ACCOUNT IDENTIFIERS AS PUBLIC IDENTIFIERS
+    description: The organization prohibits the use of information system account
+      identifiers that are the same as public identifiers for individual electronic
+      mail accounts.
+  nist_800_53:rev4:IA-4:2:
+    standard:
+      name: nist_800_53:rev4
+    family: IA
+    title: SUPERVISOR AUTHORIZATION
+    description: The organization requires that the registration process to receive
+      an individual identifier includes supervisor authorization.
+  nist_800_53:rev4:IA-4:3:
+    standard:
+      name: nist_800_53:rev4
+    family: IA
+    title: MULTIPLE FORMS OF CERTIFICATION
+    description: The organization requires multiple forms of certification of individual
+      identification be presented to the registration authority.
+  nist_800_53:rev4:IA-4:4:
+    standard:
+      name: nist_800_53:rev4
+    family: IA
+    title: IDENTIFY USER STATUS
+    description: 'The organization manages individual identifiers by uniquely identifying
+      each individual as [Assignment: organization-defined characteristic identifying
+      individual status].'
+  nist_800_53:rev4:IA-4:5:
+    standard:
+      name: nist_800_53:rev4
+    family: IA
+    title: DYNAMIC MANAGEMENT
+    description: The information system dynamically manages identifiers.
+  nist_800_53:rev4:IA-4:6:
+    standard:
+      name: nist_800_53:rev4
+    family: IA
+    title: CROSS-ORGANIZATION MANAGEMENT
+    description: 'The organization coordinates with [Assignment: organization-defined
+      external organizations] for cross-organization management of identifiers.'
+  nist_800_53:rev4:IA-4:7:
+    standard:
+      name: nist_800_53:rev4
+    family: IA
+    title: IN-PERSON REGISTRATION
+    description: The organization requires that the registration process to receive
+      an individual identifier be conducted in person before a designated registration
+      authority.
+  nist_800_53:rev4:IA-5:a:
+    standard:
+      name: nist_800_53:rev4
+    family: IA
+    title: IA-5a.
+    description: Verifying, as part of the initial authenticator distribution, the
+      identity of the individual, group, role, or device receiving the authenticator;
+  nist_800_53:rev4:IA-5:b:
+    standard:
+      name: nist_800_53:rev4
+    family: IA
+    title: IA-5b.
+    description: Establishing initial authenticator content for authenticators defined
+      by the organization;
+  nist_800_53:rev4:IA-5:c:
+    standard:
+      name: nist_800_53:rev4
+    family: IA
+    title: IA-5c.
+    description: Ensuring that authenticators have sufficient strength of mechanism
+      for their intended use;
+  nist_800_53:rev4:IA-5:d:
+    standard:
+      name: nist_800_53:rev4
+    family: IA
+    title: IA-5d.
+    description: Establishing and implementing administrative procedures for initial
+      authenticator distribution, for lost/compromised or damaged authenticators,
+      and for revoking authenticators;
+  nist_800_53:rev4:IA-5:e:
+    standard:
+      name: nist_800_53:rev4
+    family: IA
+    title: IA-5e.
+    description: Changing default content of authenticators prior to information system
+      installation;
+  nist_800_53:rev4:IA-5:f:
+    standard:
+      name: nist_800_53:rev4
+    family: IA
+    title: IA-5f.
+    description: Establishing minimum and maximum lifetime restrictions and reuse
+      conditions for authenticators;
+  nist_800_53:rev4:IA-5:g:
+    standard:
+      name: nist_800_53:rev4
+    family: IA
+    title: IA-5g.
+    description: 'Changing/refreshing authenticators [Assignment: organization-defined
+      time period by authenticator type];'
+  nist_800_53:rev4:IA-5:h:
+    standard:
+      name: nist_800_53:rev4
+    family: IA
+    title: IA-5h.
+    description: Protecting authenticator content from unauthorized disclosure and
+      modification;
+  nist_800_53:rev4:IA-5:i:
+    standard:
+      name: nist_800_53:rev4
+    family: IA
+    title: IA-5i.
+    description: Requiring individuals to take, and having devices implement, specific
+      security safeguards to protect authenticators; and
+  nist_800_53:rev4:IA-5:j:
+    standard:
+      name: nist_800_53:rev4
+    family: IA
+    title: IA-5j.
+    description: Changing authenticators for group/role accounts when membership to
+      those accounts changes.
+  nist_800_53:rev4:IA-5:1:
+    standard:
+      name: nist_800_53:rev4
+    family: IA
+    title: PASSWORD-BASED AUTHENTICATION
+    description: 'The information system, for password-based authentication:'
+  nist_800_53:rev4:IA-5:1:a:
+    standard:
+      name: nist_800_53:rev4
+    family: IA
+    title: IA-5 (1)(a)
+    description: 'Enforces minimum password complexity of [Assignment: organization-defined
+      requirements for case sensitivity, number of characters, mix of upper-case letters,
+      lower-case letters, numbers, and special characters, including minimum requirements
+      for each type];'
+  nist_800_53:rev4:IA-5:1:b:
+    standard:
+      name: nist_800_53:rev4
+    family: IA
+    title: IA-5 (1)(b)
+    description: 'Enforces at least the following number of changed characters when
+      new passwords are created: [Assignment: organization-defined number];'
+  nist_800_53:rev4:IA-5:1:c:
+    standard:
+      name: nist_800_53:rev4
+    family: IA
+    title: IA-5 (1)(c)
+    description: Stores and transmits only cryptographically-protected passwords;
+  nist_800_53:rev4:IA-5:1:d:
+    standard:
+      name: nist_800_53:rev4
+    family: IA
+    title: IA-5 (1)(d)
+    description: 'Enforces password minimum and maximum lifetime restrictions of [Assignment:
+      organization-defined numbers for lifetime minimum, lifetime maximum];'
+  nist_800_53:rev4:IA-5:1:e:
+    standard:
+      name: nist_800_53:rev4
+    family: IA
+    title: IA-5 (1)(e)
+    description: 'Prohibits password reuse for [Assignment: organization-defined number]
+      generations; and'
+  nist_800_53:rev4:IA-5:1:f:
+    standard:
+      name: nist_800_53:rev4
+    family: IA
+    title: IA-5 (1)(f)
+    description: Allows the use of a temporary password for system logons with an
+      immediate change to a permanent password.
+  nist_800_53:rev4:IA-5:2:
+    standard:
+      name: nist_800_53:rev4
+    family: IA
+    title: PKI-BASED AUTHENTICATION
+    description: 'The information system, for PKI-based authentication:'
+  nist_800_53:rev4:IA-5:2:a:
+    standard:
+      name: nist_800_53:rev4
+    family: IA
+    title: IA-5 (2)(a)
+    description: Validates certifications by constructing and verifying a certification
+      path to an accepted trust anchor including checking certificate status information;
+  nist_800_53:rev4:IA-5:2:b:
+    standard:
+      name: nist_800_53:rev4
+    family: IA
+    title: IA-5 (2)(b)
+    description: Enforces authorized access to the corresponding private key;
+  nist_800_53:rev4:IA-5:2:c:
+    standard:
+      name: nist_800_53:rev4
+    family: IA
+    title: IA-5 (2)(c)
+    description: Maps the authenticated identity to the account of the individual
+      or group; and
+  nist_800_53:rev4:IA-5:2:d:
+    standard:
+      name: nist_800_53:rev4
+    family: IA
+    title: IA-5 (2)(d)
+    description: Implements a local cache of revocation data to support path discovery
+      and validation in case of inability to access revocation information via the
+      network.
+  nist_800_53:rev4:IA-5:3:
+    standard:
+      name: nist_800_53:rev4
+    family: IA
+    title: IN-PERSON OR TRUSTED THIRD-PARTY REGISTRATION
+    description: 'The organization requires that the registration process to receive
+      [Assignment: organization-defined types of and/or specific authenticators] be
+      conducted [Selection: in person; by a trusted third party] before [Assignment:
+      organization-defined registration authority] with authorization by [Assignment:
+      organization-defined personnel or roles].'
+  nist_800_53:rev4:IA-5:4:
+    standard:
+      name: nist_800_53:rev4
+    family: IA
+    title: AUTOMATED SUPPORT  FOR PASSWORD STRENGTH DETERMINATION
+    description: 'The organization employs automated tools to determine if password
+      authenticators are sufficiently strong to satisfy [Assignment: organization-defined
+      requirements].'
+  nist_800_53:rev4:IA-5:5:
+    standard:
+      name: nist_800_53:rev4
+    family: IA
+    title: CHANGE AUTHENTICATORS PRIOR TO DELIVERY
+    description: The organization requires developers/installers of information system
+      components to provide unique authenticators or change default authenticators
+      prior to delivery/installation.
+  nist_800_53:rev4:IA-5:6:
+    standard:
+      name: nist_800_53:rev4
+    family: IA
+    title: PROTECTION OF AUTHENTICATORS
+    description: The organization protects authenticators commensurate with the security
+      category of the information to which use of the authenticator permits access.
+  nist_800_53:rev4:IA-5:7:
+    standard:
+      name: nist_800_53:rev4
+    family: IA
+    title: NO EMBEDDED UNENCRYPTED STATIC AUTHENTICATORS
+    description: The organization ensures that unencrypted static authenticators are
+      not embedded in applications or access scripts or stored on function keys.
+  nist_800_53:rev4:IA-5:8:
+    standard:
+      name: nist_800_53:rev4
+    family: IA
+    title: MULTIPLE INFORMATION SYSTEM ACCOUNTS
+    description: 'The organization implements [Assignment: organization-defined security
+      safeguards] to manage the risk of compromise due to individuals having accounts
+      on multiple information systems.'
+  nist_800_53:rev4:IA-5:9:
+    standard:
+      name: nist_800_53:rev4
+    family: IA
+    title: CROSS-ORGANIZATION CREDENTIAL MANAGEMENT
+    description: 'The organization coordinates with [Assignment: organization-defined
+      external organizations] for cross-organization management of credentials.'
+  nist_800_53:rev4:IA-5:10:
+    standard:
+      name: nist_800_53:rev4
+    family: IA
+    title: DYNAMIC CREDENTIAL ASSOCIATION
+    description: The information system dynamically provisions identities.
+  nist_800_53:rev4:IA-5:11:
+    standard:
+      name: nist_800_53:rev4
+    family: IA
+    title: HARDWARE TOKEN-BASED AUTHENTICATION
+    description: 'The information system, for hardware token-based authentication,
+      employs mechanisms that satisfy [Assignment: organization-defined token quality
+      requirements].'
+  nist_800_53:rev4:IA-5:12:
+    standard:
+      name: nist_800_53:rev4
+    family: IA
+    title: BIOMETRIC-BASED AUTHENTICATION
+    description: 'The information system, for biometric-based authentication, employs
+      mechanisms that satisfy [Assignment: organization-defined biometric quality
+      requirements].'
+  nist_800_53:rev4:IA-5:13:
+    standard:
+      name: nist_800_53:rev4
+    family: IA
+    title: EXPIRATION OF CACHED AUTHENTICATORS
+    description: 'The information system prohibits the use of cached authenticators
+      after [Assignment: organization-defined time period].'
+  nist_800_53:rev4:IA-5:14:
+    standard:
+      name: nist_800_53:rev4
+    family: IA
+    title: MANAGING CONTENT OF PKI TRUST STORES
+    description: The organization, for PKI-based authentication, employs a deliberate
+      organization-wide methodology for managing the content of PKI trust stores installed
+      across all platforms including networks, operating systems, browsers, and applications.
+  nist_800_53:rev4:IA-5:15:
+    standard:
+      name: nist_800_53:rev4
+    family: IA
+    title: FICAM-APPROVED PRODUCTS AND SERVICES
+    description: The organization uses only FICAM-approved path discovery and validation
+      products and services.
+  nist_800_53:rev4:IA-8:1:
+    standard:
+      name: nist_800_53:rev4
+    family: IA
+    title: ACCEPTANCE OF PIV CREDENTIALS FROM OTHER AGENCIES
+    description: The information system accepts and electronically verifies Personal
+      Identity Verification (PIV) credentials from other federal agencies.
+  nist_800_53:rev4:IA-8:2:
+    standard:
+      name: nist_800_53:rev4
+    family: IA
+    title: ACCEPTANCE OF THIRD-PARTY CREDENTIALS
+    description: The information system accepts only FICAM-approved third-party credentials.
+  nist_800_53:rev4:IA-8:3:
+    standard:
+      name: nist_800_53:rev4
+    family: IA
+    title: USE OF FICAM-APPROVED PRODUCTS
+    description: 'The organization employs only FICAM-approved information system
+      components in [Assignment: organization-defined information systems] to accept
+      third-party credentials.'
+  nist_800_53:rev4:IA-8:4:
+    standard:
+      name: nist_800_53:rev4
+    family: IA
+    title: USE OF FICAM-ISSUED PROFILES
+    description: The information system conforms to FICAM-issued profiles.
+  nist_800_53:rev4:IA-8:5:
+    standard:
+      name: nist_800_53:rev4
+    family: IA
+    title: ACCEPTANCE OF PIV-I CREDENTIALS
+    description: The information system accepts and electronically verifies Personal
+      Identity Verification-I (PIV-I) credentials.
+  nist_800_53:rev4:IA-9:1:
+    standard:
+      name: nist_800_53:rev4
+    family: IA
+    title: INFORMATION EXCHANGE
+    description: The organization ensures that service providers receive, validate,
+      and transmit identification and authentication information.
+  nist_800_53:rev4:IA-9:2:
+    standard:
+      name: nist_800_53:rev4
+    family: IA
+    title: TRANSMISSION OF DECISIONS
+    description: 'The organization ensures that identification and authentication
+      decisions are transmitted between [Assignment: organization-defined services]
+      consistent with organizational policies.'
+  nist_800_53:rev4:IR-1:a:
+    standard:
+      name: nist_800_53:rev4
+    family: IR
+    title: IR-1a.
+    description: 'Develops, documents, and disseminates to [Assignment: organization-defined
+      personnel or roles]:'
+  nist_800_53:rev4:IR-1:a:1:
+    standard:
+      name: nist_800_53:rev4
+    family: IR
+    title: IR-1a.1.
+    description: An incident response policy that addresses purpose, scope, roles,
+      responsibilities, management commitment, coordination among organizational entities,
+      and compliance; and
+  nist_800_53:rev4:IR-1:a:2:
+    standard:
+      name: nist_800_53:rev4
+    family: IR
+    title: IR-1a.2.
+    description: Procedures to facilitate the implementation of the incident response
+      policy and associated incident response controls; and
+  nist_800_53:rev4:IR-1:b:
+    standard:
+      name: nist_800_53:rev4
+    family: IR
+    title: IR-1b.
+    description: 'Reviews and updates the current:'
+  nist_800_53:rev4:IR-1:b:1:
+    standard:
+      name: nist_800_53:rev4
+    family: IR
+    title: IR-1b.1.
+    description: 'Incident response policy [Assignment: organization-defined frequency];
+      and'
+  nist_800_53:rev4:IR-1:b:2:
+    standard:
+      name: nist_800_53:rev4
+    family: IR
+    title: IR-1b.2.
+    description: 'Incident response procedures [Assignment: organization-defined frequency].'
+  nist_800_53:rev4:IR-2:a:
+    standard:
+      name: nist_800_53:rev4
+    family: IR
+    title: IR-2a.
+    description: 'Within [Assignment: organization-defined time period] of assuming
+      an incident response role or responsibility;'
+  nist_800_53:rev4:IR-2:b:
+    standard:
+      name: nist_800_53:rev4
+    family: IR
+    title: IR-2b.
+    description: When required by information system changes; and
+  nist_800_53:rev4:IR-2:c:
+    standard:
+      name: nist_800_53:rev4
+    family: IR
+    title: IR-2c.
+    description: "[Assignment: organization-defined frequency] thereafter."
+  nist_800_53:rev4:IR-2:1:
+    standard:
+      name: nist_800_53:rev4
+    family: IR
+    title: SIMULATED EVENTS
+    description: The organization incorporates simulated events into incident response
+      training to facilitate effective response by personnel in crisis situations.
+  nist_800_53:rev4:IR-2:2:
+    standard:
+      name: nist_800_53:rev4
+    family: IR
+    title: AUTOMATED TRAINING ENVIRONMENTS
+    description: The organization employs automated mechanisms to provide a more thorough
+      and realistic incident response training environment.
+  nist_800_53:rev4:IR-3:1:
+    standard:
+      name: nist_800_53:rev4
+    family: IR
+    title: AUTOMATED TESTING
+    description: The organization employs automated mechanisms to more thoroughly
+      and effectively test the incident response capability.
+  nist_800_53:rev4:IR-3:2:
+    standard:
+      name: nist_800_53:rev4
+    family: IR
+    title: COORDINATION WITH RELATED PLANS
+    description: The organization coordinates incident response testing with organizational
+      elements responsible for related plans.
+  nist_800_53:rev4:IR-4:a:
+    standard:
+      name: nist_800_53:rev4
+    family: IR
+    title: IR-4a.
+    description: Implements an incident handling capability for security incidents
+      that includes preparation, detection and analysis, containment, eradication,
+      and recovery;
+  nist_800_53:rev4:IR-4:b:
+    standard:
+      name: nist_800_53:rev4
+    family: IR
+    title: IR-4b.
+    description: Coordinates incident handling activities with contingency planning
+      activities; and
+  nist_800_53:rev4:IR-4:c:
+    standard:
+      name: nist_800_53:rev4
+    family: IR
+    title: IR-4c.
+    description: Incorporates lessons learned from ongoing incident handling activities
+      into incident response procedures, training, and testing, and implements the
+      resulting changes accordingly.
+  nist_800_53:rev4:IR-4:1:
+    standard:
+      name: nist_800_53:rev4
+    family: IR
+    title: AUTOMATED INCIDENT HANDLING PROCESSES
+    description: The organization employs automated mechanisms to support the incident
+      handling process.
+  nist_800_53:rev4:IR-4:2:
+    standard:
+      name: nist_800_53:rev4
+    family: IR
+    title: DYNAMIC RECONFIGURATION
+    description: 'The organization includes dynamic reconfiguration of [Assignment:
+      organization-defined information system components] as part of the incident
+      response capability.'
+  nist_800_53:rev4:IR-4:3:
+    standard:
+      name: nist_800_53:rev4
+    family: IR
+    title: CONTINUITY OF OPERATIONS
+    description: 'The organization identifies [Assignment: organization-defined classes
+      of incidents] and [Assignment: organization-defined actions to take in response
+      to classes of incidents] to ensure continuation of organizational missions and
+      business functions.'
+  nist_800_53:rev4:IR-4:4:
+    standard:
+      name: nist_800_53:rev4
+    family: IR
+    title: INFORMATION CORRELATION
+    description: The organization correlates incident information and individual incident
+      responses to achieve an organization-wide perspective on incident awareness
+      and response.
+  nist_800_53:rev4:IR-4:5:
+    standard:
+      name: nist_800_53:rev4
+    family: IR
+    title: AUTOMATIC DISABLING OF INFORMATION SYSTEM
+    description: 'The organization implements a configurable capability to automatically
+      disable the information system if [Assignment: organization-defined security
+      violations] are detected.'
+  nist_800_53:rev4:IR-4:6:
+    standard:
+      name: nist_800_53:rev4
+    family: IR
+    title: INSIDER THREATS - SPECIFIC CAPABILITIES
+    description: The organization implements incident handling capability for insider
+      threats.
+  nist_800_53:rev4:IR-4:7:
+    standard:
+      name: nist_800_53:rev4
+    family: IR
+    title: INSIDER THREATS - INTRA-ORGANIZATION COORDINATION
+    description: 'The organization coordinates incident handling capability for insider
+      threats across [Assignment: organization-defined components or elements of the
+      organization].'
+  nist_800_53:rev4:IR-4:8:
+    standard:
+      name: nist_800_53:rev4
+    family: IR
+    title: CORRELATION WITH EXTERNAL ORGANIZATIONS
+    description: 'The organization coordinates with [Assignment: organization-defined
+      external organizations] to correlate and share [Assignment: organization-defined
+      incident information] to achieve a cross-organization perspective on incident
+      awareness and more effective incident responses.'
+  nist_800_53:rev4:IR-4:9:
+    standard:
+      name: nist_800_53:rev4
+    family: IR
+    title: DYNAMIC RESPONSE CAPABILITY
+    description: 'The organization employs [Assignment: organization-defined dynamic
+      response capabilities] to effectively respond to security incidents.'
+  nist_800_53:rev4:IR-4:10:
+    standard:
+      name: nist_800_53:rev4
+    family: IR
+    title: SUPPLY CHAIN COORDINATION
+    description: The organization coordinates incident handling activities involving
+      supply chain events with other organizations involved in the supply chain.
+  nist_800_53:rev4:IR-5:1:
+    standard:
+      name: nist_800_53:rev4
+    family: IR
+    title: AUTOMATED TRACKING / DATA COLLECTION / ANALYSIS
+    description: The organization employs automated mechanisms to assist in the tracking
+      of security incidents and in the collection and analysis of incident information.
+  nist_800_53:rev4:IR-6:a:
+    standard:
+      name: nist_800_53:rev4
+    family: IR
+    title: IR-6a.
+    description: 'Requires personnel to report suspected security incidents to the
+      organizational incident response capability within [Assignment: organization-defined
+      time period]; and'
+  nist_800_53:rev4:IR-6:b:
+    standard:
+      name: nist_800_53:rev4
+    family: IR
+    title: IR-6b.
+    description: 'Reports security incident information to [Assignment: organization-defined
+      authorities].'
+  nist_800_53:rev4:IR-6:1:
+    standard:
+      name: nist_800_53:rev4
+    family: IR
+    title: AUTOMATED REPORTING
+    description: The organization employs automated mechanisms to assist in the reporting
+      of security incidents.
+  nist_800_53:rev4:IR-6:2:
+    standard:
+      name: nist_800_53:rev4
+    family: IR
+    title: VULNERABILITIES RELATED TO INCIDENTS
+    description: 'The organization reports information system vulnerabilities associated
+      with reported security incidents to [Assignment: organization-defined personnel
+      or roles].'
+  nist_800_53:rev4:IR-6:3:
+    standard:
+      name: nist_800_53:rev4
+    family: IR
+    title: COORDINATION WITH SUPPLY CHAIN
+    description: The organization provides security incident information to other
+      organizations involved in the supply chain for information systems or information
+      system components related to the incident.
+  nist_800_53:rev4:IR-7:1:
+    standard:
+      name: nist_800_53:rev4
+    family: IR
+    title: AUTOMATION SUPPORT FOR AVAILABILITY OF INFORMATION / SUPPORT
+    description: The organization employs automated mechanisms to increase the availability
+      of incident response-related information and support.
+  nist_800_53:rev4:IR-7:2:
+    standard:
+      name: nist_800_53:rev4
+    family: IR
+    title: COORDINATION WITH EXTERNAL PROVIDERS
+    description: 'The organization:'
+  nist_800_53:rev4:IR-7:2:a:
+    standard:
+      name: nist_800_53:rev4
+    family: IR
+    title: IR-7 (2)(a)
+    description: Establishes a direct, cooperative relationship between its incident
+      response capability and external providers of information system protection
+      capability; and
+  nist_800_53:rev4:IR-7:2:b:
+    standard:
+      name: nist_800_53:rev4
+    family: IR
+    title: IR-7 (2)(b)
+    description: Identifies organizational incident response team members to the external
+      providers.
+  nist_800_53:rev4:IR-8:a:
+    standard:
+      name: nist_800_53:rev4
+    family: IR
+    title: IR-8a.
+    description: 'Develops an incident response plan that:'
+  nist_800_53:rev4:IR-8:a:1:
+    standard:
+      name: nist_800_53:rev4
+    family: IR
+    title: IR-8a.1.
+    description: Provides the organization with a roadmap for implementing its incident
+      response capability;
+  nist_800_53:rev4:IR-8:a:2:
+    standard:
+      name: nist_800_53:rev4
+    family: IR
+    title: IR-8a.2.
+    description: Describes the structure and organization of the incident response
+      capability;
+  nist_800_53:rev4:IR-8:a:3:
+    standard:
+      name: nist_800_53:rev4
+    family: IR
+    title: IR-8a.3.
+    description: Provides a high-level approach for how the incident response capability
+      fits into the overall organization;
+  nist_800_53:rev4:IR-8:a:4:
+    standard:
+      name: nist_800_53:rev4
+    family: IR
+    title: IR-8a.4.
+    description: Meets the unique requirements of the organization, which relate to
+      mission, size, structure, and functions;
+  nist_800_53:rev4:IR-8:a:5:
+    standard:
+      name: nist_800_53:rev4
+    family: IR
+    title: IR-8a.5.
+    description: Defines reportable incidents;
+  nist_800_53:rev4:IR-8:a:6:
+    standard:
+      name: nist_800_53:rev4
+    family: IR
+    title: IR-8a.6.
+    description: Provides metrics for measuring the incident response capability within
+      the organization;
+  nist_800_53:rev4:IR-8:a:7:
+    standard:
+      name: nist_800_53:rev4
+    family: IR
+    title: IR-8a.7.
+    description: Defines the resources and management support needed to effectively
+      maintain and mature an incident response capability; and
+  nist_800_53:rev4:IR-8:a:8:
+    standard:
+      name: nist_800_53:rev4
+    family: IR
+    title: IR-8a.8.
+    description: 'Is reviewed and approved by [Assignment: organization-defined personnel
+      or roles];'
+  nist_800_53:rev4:IR-8:b:
+    standard:
+      name: nist_800_53:rev4
+    family: IR
+    title: IR-8b.
+    description: 'Distributes copies of the incident response plan to [Assignment:
+      organization-defined incident response personnel (identified by name and/or
+      by role) and organizational elements];'
+  nist_800_53:rev4:IR-8:c:
+    standard:
+      name: nist_800_53:rev4
+    family: IR
+    title: IR-8c.
+    description: 'Reviews the incident response plan [Assignment: organization-defined
+      frequency];'
+  nist_800_53:rev4:IR-8:d:
+    standard:
+      name: nist_800_53:rev4
+    family: IR
+    title: IR-8d.
+    description: Updates the incident response plan to address system/organizational
+      changes or problems encountered during plan implementation, execution, or testing;
+  nist_800_53:rev4:IR-8:e:
+    standard:
+      name: nist_800_53:rev4
+    family: IR
+    title: IR-8e.
+    description: 'Communicates incident response plan changes to [Assignment: organization-defined
+      incident response personnel (identified by name and/or by role) and organizational
+      elements]; and'
+  nist_800_53:rev4:IR-8:f:
+    standard:
+      name: nist_800_53:rev4
+    family: IR
+    title: IR-8f.
+    description: Protects the incident response plan from unauthorized disclosure
+      and modification.
+  nist_800_53:rev4:IR-9:a:
+    standard:
+      name: nist_800_53:rev4
+    family: IR
+    title: IR-9a.
+    description: Identifying the specific information involved in the information
+      system contamination;
+  nist_800_53:rev4:IR-9:b:
+    standard:
+      name: nist_800_53:rev4
+    family: IR
+    title: IR-9b.
+    description: 'Alerting [Assignment: organization-defined personnel or roles] of
+      the information spill using a method of communication not associated with the
+      spill;'
+  nist_800_53:rev4:IR-9:c:
+    standard:
+      name: nist_800_53:rev4
+    family: IR
+    title: IR-9c.
+    description: Isolating the contaminated information system or system component;
+  nist_800_53:rev4:IR-9:d:
+    standard:
+      name: nist_800_53:rev4
+    family: IR
+    title: IR-9d.
+    description: Eradicating the information from the contaminated information system
+      or component;
+  nist_800_53:rev4:IR-9:e:
+    standard:
+      name: nist_800_53:rev4
+    family: IR
+    title: IR-9e.
+    description: Identifying other information systems or system components that may
+      have been subsequently contaminated; and
+  nist_800_53:rev4:IR-9:f:
+    standard:
+      name: nist_800_53:rev4
+    family: IR
+    title: IR-9f.
+    description: 'Performing other [Assignment: organization-defined actions].'
+  nist_800_53:rev4:IR-9:1:
+    standard:
+      name: nist_800_53:rev4
+    family: IR
+    title: RESPONSIBLE PERSONNEL
+    description: 'The organization assigns [Assignment: organization-defined personnel
+      or roles] with responsibility for responding to information spills.'
+  nist_800_53:rev4:IR-9:2:
+    standard:
+      name: nist_800_53:rev4
+    family: IR
+    title: TRAINING
+    description: 'The organization provides information spillage response training
+      [Assignment: organization-defined frequency].'
+  nist_800_53:rev4:IR-9:3:
+    standard:
+      name: nist_800_53:rev4
+    family: IR
+    title: POST-SPILL OPERATIONS
+    description: 'The organization implements [Assignment: organization-defined procedures]
+      to ensure that organizational personnel impacted by information spills can continue
+      to carry out assigned tasks while contaminated systems are undergoing corrective
+      actions.'
+  nist_800_53:rev4:IR-9:4:
+    standard:
+      name: nist_800_53:rev4
+    family: IR
+    title: EXPOSURE TO UNAUTHORIZED PERSONNEL
+    description: 'The organization employs [Assignment: organization-defined security
+      safeguards] for personnel exposed to information not within assigned access
+      authorizations.'
+  nist_800_53:rev4:MA-1:a:
+    standard:
+      name: nist_800_53:rev4
+    family: MA
+    title: MA-1a.
+    description: 'Develops, documents, and disseminates to [Assignment: organization-defined
+      personnel or roles]:'
+  nist_800_53:rev4:MA-1:a:1:
+    standard:
+      name: nist_800_53:rev4
+    family: MA
+    title: MA-1a.1.
+    description: A system maintenance policy that addresses purpose, scope, roles,
+      responsibilities, management commitment, coordination among organizational entities,
+      and compliance; and
+  nist_800_53:rev4:MA-1:a:2:
+    standard:
+      name: nist_800_53:rev4
+    family: MA
+    title: MA-1a.2.
+    description: Procedures to facilitate the implementation of the system maintenance
+      policy and associated system maintenance controls; and
+  nist_800_53:rev4:MA-1:b:
+    standard:
+      name: nist_800_53:rev4
+    family: MA
+    title: MA-1b.
+    description: 'Reviews and updates the current:'
+  nist_800_53:rev4:MA-1:b:1:
+    standard:
+      name: nist_800_53:rev4
+    family: MA
+    title: MA-1b.1.
+    description: 'System maintenance policy [Assignment: organization-defined frequency];
+      and'
+  nist_800_53:rev4:MA-1:b:2:
+    standard:
+      name: nist_800_53:rev4
+    family: MA
+    title: MA-1b.2.
+    description: 'System maintenance procedures [Assignment: organization-defined
+      frequency].'
+  nist_800_53:rev4:MA-2:a:
+    standard:
+      name: nist_800_53:rev4
+    family: MA
+    title: MA-2a.
+    description: Schedules, performs, documents, and reviews records of maintenance
+      and repairs on information system components in accordance with manufacturer
+      or vendor specifications and/or organizational requirements;
+  nist_800_53:rev4:MA-2:b:
+    standard:
+      name: nist_800_53:rev4
+    family: MA
+    title: MA-2b.
+    description: Approves and monitors all maintenance activities, whether performed
+      on site or remotely and whether the equipment is serviced on site or removed
+      to another location;
+  nist_800_53:rev4:MA-2:c:
+    standard:
+      name: nist_800_53:rev4
+    family: MA
+    title: MA-2c.
+    description: 'Requires that [Assignment: organization-defined personnel or roles]
+      explicitly approve the removal of the information system or system components
+      from organizational facilities for off-site maintenance or repairs;'
+  nist_800_53:rev4:MA-2:d:
+    standard:
+      name: nist_800_53:rev4
+    family: MA
+    title: MA-2d.
+    description: Sanitizes equipment to remove all information from associated media
+      prior to removal from organizational facilities for off-site maintenance or
+      repairs;
+  nist_800_53:rev4:MA-2:e:
+    standard:
+      name: nist_800_53:rev4
+    family: MA
+    title: MA-2e.
+    description: Checks all potentially impacted security controls to verify that
+      the controls are still functioning properly following maintenance or repair
+      actions; and
+  nist_800_53:rev4:MA-2:f:
+    standard:
+      name: nist_800_53:rev4
+    family: MA
+    title: MA-2f.
+    description: 'Includes [Assignment: organization-defined maintenance-related information]
+      in organizational maintenance records.'
+  nist_800_53:rev4:MA-2:1:
+    standard:
+      name: nist_800_53:rev4
+    family: MA
+    title: RECORD CONTENT
+    description: "[Withdrawn: Incorporated into MA-2]."
+  nist_800_53:rev4:MA-2:2:
+    standard:
+      name: nist_800_53:rev4
+    family: MA
+    title: AUTOMATED MAINTENANCE ACTIVITIES
+    description: 'The organization:'
+  nist_800_53:rev4:MA-2:2:a:
+    standard:
+      name: nist_800_53:rev4
+    family: MA
+    title: MA-2 (2)(a)
+    description: Employs automated mechanisms to schedule, conduct, and document maintenance
+      and repairs; and
+  nist_800_53:rev4:MA-2:2:b:
+    standard:
+      name: nist_800_53:rev4
+    family: MA
+    title: MA-2 (2)(b)
+    description: Produces up-to date, accurate, and complete records of all maintenance
+      and repair actions requested, scheduled, in process, and completed.
+  nist_800_53:rev4:MA-3:1:
+    standard:
+      name: nist_800_53:rev4
+    family: MA
+    title: INSPECT TOOLS
+    description: The organization inspects the maintenance tools carried into a facility
+      by maintenance personnel for improper or unauthorized modifications.
+  nist_800_53:rev4:MA-3:2:
+    standard:
+      name: nist_800_53:rev4
+    family: MA
+    title: INSPECT MEDIA
+    description: The organization checks media containing diagnostic and test programs
+      for malicious code before the media are used in the information system.
+  nist_800_53:rev4:MA-3:3:
+    standard:
+      name: nist_800_53:rev4
+    family: MA
+    title: PREVENT UNAUTHORIZED REMOVAL
+    description: 'The organization prevents the unauthorized removal of maintenance
+      equipment containing organizational information by:'
+  nist_800_53:rev4:MA-3:3:a:
+    standard:
+      name: nist_800_53:rev4
+    family: MA
+    title: MA-3 (3)(a)
+    description: Verifying that there is no organizational information contained on
+      the equipment;
+  nist_800_53:rev4:MA-3:3:b:
+    standard:
+      name: nist_800_53:rev4
+    family: MA
+    title: MA-3 (3)(b)
+    description: Sanitizing or destroying the equipment;
+  nist_800_53:rev4:MA-3:3:c:
+    standard:
+      name: nist_800_53:rev4
+    family: MA
+    title: MA-3 (3)(c)
+    description: Retaining the equipment within the facility; or
+  nist_800_53:rev4:MA-3:3:d:
+    standard:
+      name: nist_800_53:rev4
+    family: MA
+    title: MA-3 (3)(d)
+    description: 'Obtaining an exemption from [Assignment: organization-defined personnel
+      or roles] explicitly authorizing removal of the equipment from the facility.'
+  nist_800_53:rev4:MA-3:4:
+    standard:
+      name: nist_800_53:rev4
+    family: MA
+    title: RESTRICTED TOOL USE
+    description: The information system restricts the use of maintenance tools to
+      authorized personnel only.
+  nist_800_53:rev4:MA-4:a:
+    standard:
+      name: nist_800_53:rev4
+    family: MA
+    title: MA-4a.
+    description: Approves and monitors nonlocal maintenance and diagnostic activities;
+  nist_800_53:rev4:MA-4:b:
+    standard:
+      name: nist_800_53:rev4
+    family: MA
+    title: MA-4b.
+    description: Allows the use of nonlocal maintenance and diagnostic tools only
+      as consistent with organizational policy and documented in the security plan
+      for the information system;
+  nist_800_53:rev4:MA-4:c:
+    standard:
+      name: nist_800_53:rev4
+    family: MA
+    title: MA-4c.
+    description: Employs strong authenticators in the establishment of nonlocal maintenance
+      and diagnostic sessions;
+  nist_800_53:rev4:MA-4:d:
+    standard:
+      name: nist_800_53:rev4
+    family: MA
+    title: MA-4d.
+    description: Maintains records for nonlocal maintenance and diagnostic activities;
+      and
+  nist_800_53:rev4:MA-4:e:
+    standard:
+      name: nist_800_53:rev4
+    family: MA
+    title: MA-4e.
+    description: Terminates session and network connections when nonlocal maintenance
+      is completed.
+  nist_800_53:rev4:MA-4:1:
+    standard:
+      name: nist_800_53:rev4
+    family: MA
+    title: AUDITING AND REVIEW
+    description: 'The organization:'
+  nist_800_53:rev4:MA-4:1:a:
+    standard:
+      name: nist_800_53:rev4
+    family: MA
+    title: MA-4 (1)(a)
+    description: 'Audits nonlocal maintenance and diagnostic sessions [Assignment:
+      organization-defined audit events]; and'
+  nist_800_53:rev4:MA-4:1:b:
+    standard:
+      name: nist_800_53:rev4
+    family: MA
+    title: MA-4 (1)(b)
+    description: Reviews the records of the maintenance and diagnostic sessions.
+  nist_800_53:rev4:MA-4:2:
+    standard:
+      name: nist_800_53:rev4
+    family: MA
+    title: DOCUMENT NONLOCAL MAINTENANCE
+    description: The organization documents in the security plan for the information
+      system, the policies and procedures for the establishment and use of nonlocal
+      maintenance and diagnostic connections.
+  nist_800_53:rev4:MA-4:3:
+    standard:
+      name: nist_800_53:rev4
+    family: MA
+    title: COMPARABLE SECURITY / SANITIZATION
+    description: 'The organization:'
+  nist_800_53:rev4:MA-4:3:a:
+    standard:
+      name: nist_800_53:rev4
+    family: MA
+    title: MA-4 (3)(a)
+    description: Requires that nonlocal maintenance and diagnostic services be performed
+      from an information system that implements a security capability comparable
+      to the capability implemented on the system being serviced; or
+  nist_800_53:rev4:MA-4:3:b:
+    standard:
+      name: nist_800_53:rev4
+    family: MA
+    title: MA-4 (3)(b)
+    description: Removes the component to be serviced from the information system
+      prior to nonlocal maintenance or diagnostic services, sanitizes the component
+      (with regard to organizational information) before removal from organizational
+      facilities, and after the service is performed, inspects and sanitizes the component
+      (with regard to potentially malicious software) before reconnecting the component
+      to the information system.
+  nist_800_53:rev4:MA-4:4:
+    standard:
+      name: nist_800_53:rev4
+    family: MA
+    title: AUTHENTICATION / SEPARATION OF MAINTENANCE SESSIONS
+    description: 'The organization protects nonlocal maintenance sessions by:'
+  nist_800_53:rev4:MA-4:4:a:
+    standard:
+      name: nist_800_53:rev4
+    family: MA
+    title: MA-4 (4)(a)
+    description: 'Employing [Assignment: organization-defined authenticators that
+      are replay resistant]; and'
+  nist_800_53:rev4:MA-4:4:b:
+    standard:
+      name: nist_800_53:rev4
+    family: MA
+    title: MA-4 (4)(b)
+    description: 'Separating the maintenance sessions from other network sessions
+      with the information system by either:'
+  nist_800_53:rev4:MA-4:4:b:1:
+    standard:
+      name: nist_800_53:rev4
+    family: MA
+    title: MA-4 (4)(b)(1)
+    description: Physically separated communications paths; or
+  nist_800_53:rev4:MA-4:4:b:2:
+    standard:
+      name: nist_800_53:rev4
+    family: MA
+    title: MA-4 (4)(b)(2)
+    description: Logically separated communications paths based upon encryption.
+  nist_800_53:rev4:MA-4:5:
+    standard:
+      name: nist_800_53:rev4
+    family: MA
+    title: APPROVALS AND NOTIFICATIONS
+    description: 'The organization:'
+  nist_800_53:rev4:MA-4:5:a:
+    standard:
+      name: nist_800_53:rev4
+    family: MA
+    title: MA-4 (5)(a)
+    description: 'Requires the approval of each nonlocal maintenance session by [Assignment:
+      organization-defined personnel or roles]; and'
+  nist_800_53:rev4:MA-4:5:b:
+    standard:
+      name: nist_800_53:rev4
+    family: MA
+    title: MA-4 (5)(b)
+    description: 'Notifies [Assignment: organization-defined personnel or roles] of
+      the date and time of planned nonlocal maintenance.'
+  nist_800_53:rev4:MA-4:6:
+    standard:
+      name: nist_800_53:rev4
+    family: MA
+    title: CRYPTOGRAPHIC PROTECTION
+    description: The information system implements cryptographic mechanisms to protect
+      the integrity and confidentiality of nonlocal maintenance and diagnostic communications.
+  nist_800_53:rev4:MA-4:7:
+    standard:
+      name: nist_800_53:rev4
+    family: MA
+    title: REMOTE DISCONNECT VERIFICATION
+    description: The information system implements remote disconnect verification
+      at the termination of nonlocal maintenance and diagnostic sessions.
+  nist_800_53:rev4:MA-5:a:
+    standard:
+      name: nist_800_53:rev4
+    family: MA
+    title: MA-5a.
+    description: Establishes a process for maintenance personnel authorization and
+      maintains a list of authorized maintenance organizations or personnel;
+  nist_800_53:rev4:MA-5:b:
+    standard:
+      name: nist_800_53:rev4
+    family: MA
+    title: MA-5b.
+    description: Ensures that non-escorted personnel performing maintenance on the
+      information system have required access authorizations; and
+  nist_800_53:rev4:MA-5:c:
+    standard:
+      name: nist_800_53:rev4
+    family: MA
+    title: MA-5c.
+    description: Designates organizational personnel with required access authorizations
+      and technical competence to supervise the maintenance activities of personnel
+      who do not possess the required access authorizations.
+  nist_800_53:rev4:MA-5:1:
+    standard:
+      name: nist_800_53:rev4
+    family: MA
+    title: INDIVIDUALS WITHOUT APPROPRIATE ACCESS
+    description: 'The organization:'
+  nist_800_53:rev4:MA-5:1:a:
+    standard:
+      name: nist_800_53:rev4
+    family: MA
+    title: MA-5 (1)(a)
+    description: 'Implements procedures for the use of maintenance personnel that
+      lack appropriate security clearances or are not U.S. citizens, that include
+      the following requirements:'
+  nist_800_53:rev4:MA-5:1:a:1:
+    standard:
+      name: nist_800_53:rev4
+    family: MA
+    title: MA-5 (1)(a)(1)
+    description: Maintenance personnel who do not have needed access authorizations,
+      clearances, or formal access approvals are escorted and supervised during the
+      performance of maintenance and diagnostic activities on the information system
+      by approved organizational personnel who are fully cleared, have appropriate
+      access authorizations, and are technically qualified;
+  nist_800_53:rev4:MA-5:1:a:2:
+    standard:
+      name: nist_800_53:rev4
+    family: MA
+    title: MA-5 (1)(a)(2)
+    description: Prior to initiating maintenance or diagnostic activities by personnel
+      who do not have needed access authorizations, clearances or formal access approvals,
+      all volatile information storage components within the information system are
+      sanitized and all nonvolatile storage media are removed or physically disconnected
+      from the system and secured; and
+  nist_800_53:rev4:MA-5:1:b:
+    standard:
+      name: nist_800_53:rev4
+    family: MA
+    title: MA-5 (1)(b)
+    description: Develops and implements alternate security safeguards in the event
+      an information system component cannot be sanitized, removed, or disconnected
+      from the system.
+  nist_800_53:rev4:MA-5:2:
+    standard:
+      name: nist_800_53:rev4
+    family: MA
+    title: SECURITY CLEARANCES FOR CLASSIFIED SYSTEMS
+    description: The organization ensures that personnel performing maintenance and
+      diagnostic activities on an information system processing, storing, or transmitting
+      classified information possess security clearances and formal access approvals
+      for at least the highest classification level and for all compartments of information
+      on the system.
+  nist_800_53:rev4:MA-5:3:
+    standard:
+      name: nist_800_53:rev4
+    family: MA
+    title: CITIZENSHIP REQUIREMENTS FOR CLASSIFIED SYSTEMS
+    description: The organization ensures that personnel performing maintenance and
+      diagnostic activities on an information system processing, storing, or transmitting
+      classified information are U.S. citizens.
+  nist_800_53:rev4:MA-5:4:
+    standard:
+      name: nist_800_53:rev4
+    family: MA
+    title: FOREIGN NATIONALS
+    description: 'The organization ensures that:'
+  nist_800_53:rev4:MA-5:4:a:
+    standard:
+      name: nist_800_53:rev4
+    family: MA
+    title: MA-5 (4)(a)
+    description: Cleared foreign nationals (i.e., foreign nationals with appropriate
+      security clearances), are used to conduct maintenance and diagnostic activities
+      on classified information systems only when the systems are jointly owned and
+      operated by the United States and foreign allied governments, or owned and operated
+      solely by foreign allied governments; and
+  nist_800_53:rev4:MA-5:4:b:
+    standard:
+      name: nist_800_53:rev4
+    family: MA
+    title: MA-5 (4)(b)
+    description: Approvals, consents, and detailed operational conditions regarding
+      the use of foreign nationals to conduct maintenance and diagnostic activities
+      on classified information systems are fully documented within Memoranda of Agreements.
+  nist_800_53:rev4:MA-5:5:
+    standard:
+      name: nist_800_53:rev4
+    family: MA
+    title: NONSYSTEM-RELATED MAINTENANCE
+    description: The organization ensures that non-escorted personnel performing maintenance
+      activities not directly associated with the information system but in the physical
+      proximity of the system, have required access authorizations.
+  nist_800_53:rev4:MA-6:1:
+    standard:
+      name: nist_800_53:rev4
+    family: MA
+    title: PREVENTIVE MAINTENANCE
+    description: 'The organization performs preventive maintenance on [Assignment:
+      organization-defined information system components] at [Assignment: organization-defined
+      time intervals].'
+  nist_800_53:rev4:MA-6:2:
+    standard:
+      name: nist_800_53:rev4
+    family: MA
+    title: PREDICTIVE MAINTENANCE
+    description: 'The organization performs predictive maintenance on [Assignment:
+      organization-defined information system components] at [Assignment: organization-defined
+      time intervals].'
+  nist_800_53:rev4:MA-6:3:
+    standard:
+      name: nist_800_53:rev4
+    family: MA
+    title: AUTOMATED SUPPORT FOR PREDICTIVE MAINTENANCE
+    description: The organization employs automated mechanisms to transfer predictive
+      maintenance data to a computerized maintenance management system.
+  nist_800_53:rev4:MP-1:a:
+    standard:
+      name: nist_800_53:rev4
+    family: MP
+    title: MP-1a.
+    description: 'Develops, documents, and disseminates to [Assignment: organization-defined
+      personnel or roles]:'
+  nist_800_53:rev4:MP-1:a:1:
+    standard:
+      name: nist_800_53:rev4
+    family: MP
+    title: MP-1a.1.
+    description: A media protection policy that addresses purpose, scope, roles, responsibilities,
+      management commitment, coordination among organizational entities, and compliance;
+      and
+  nist_800_53:rev4:MP-1:a:2:
+    standard:
+      name: nist_800_53:rev4
+    family: MP
+    title: MP-1a.2.
+    description: Procedures to facilitate the implementation of the media protection
+      policy and associated media protection controls; and
+  nist_800_53:rev4:MP-1:b:
+    standard:
+      name: nist_800_53:rev4
+    family: MP
+    title: MP-1b.
+    description: 'Reviews and updates the current:'
+  nist_800_53:rev4:MP-1:b:1:
+    standard:
+      name: nist_800_53:rev4
+    family: MP
+    title: MP-1b.1.
+    description: 'Media protection policy [Assignment: organization-defined frequency];
+      and'
+  nist_800_53:rev4:MP-1:b:2:
+    standard:
+      name: nist_800_53:rev4
+    family: MP
+    title: MP-1b.2.
+    description: 'Media protection procedures [Assignment: organization-defined frequency].'
+  nist_800_53:rev4:MP-2:1:
+    standard:
+      name: nist_800_53:rev4
+    family: MP
+    title: AUTOMATED RESTRICTED ACCESS
+    description: "[Withdrawn: Incorporated into MP-4 (2)]."
+  nist_800_53:rev4:MP-2:2:
+    standard:
+      name: nist_800_53:rev4
+    family: MP
+    title: CRYPTOGRAPHIC PROTECTION
+    description: "[Withdrawn: Incorporated into SC-28 (1)]."
+  nist_800_53:rev4:MP-3:a:
+    standard:
+      name: nist_800_53:rev4
+    family: MP
+    title: MP-3a.
+    description: Marks information system media indicating the distribution limitations,
+      handling caveats, and applicable security markings (if any) of the information;
+      and
+  nist_800_53:rev4:MP-3:b:
+    standard:
+      name: nist_800_53:rev4
+    family: MP
+    title: MP-3b.
+    description: 'Exempts [Assignment: organization-defined types of information system
+      media] from marking as long as the media remain within [Assignment: organization-defined
+      controlled areas].'
+  nist_800_53:rev4:MP-4:a:
+    standard:
+      name: nist_800_53:rev4
+    family: MP
+    title: MP-4a.
+    description: 'Physically controls and securely stores [Assignment: organization-defined
+      types of digital and/or non-digital media] within [Assignment: organization-defined
+      controlled areas]; and'
+  nist_800_53:rev4:MP-4:b:
+    standard:
+      name: nist_800_53:rev4
+    family: MP
+    title: MP-4b.
+    description: Protects information system media until the media are destroyed or
+      sanitized using approved equipment, techniques, and procedures.
+  nist_800_53:rev4:MP-4:1:
+    standard:
+      name: nist_800_53:rev4
+    family: MP
+    title: CRYPTOGRAPHIC PROTECTION
+    description: "[Withdrawn: Incorporated into SC-28 (1)]."
+  nist_800_53:rev4:MP-4:2:
+    standard:
+      name: nist_800_53:rev4
+    family: MP
+    title: AUTOMATED RESTRICTED ACCESS
+    description: The organization employs automated mechanisms to restrict access
+      to media storage areas and to audit access attempts and access granted.
+  nist_800_53:rev4:MP-5:a:
+    standard:
+      name: nist_800_53:rev4
+    family: MP
+    title: MP-5a.
+    description: 'Protects and controls [Assignment: organization-defined types of
+      information system media] during transport outside of controlled areas using
+      [Assignment: organization-defined security safeguards];'
+  nist_800_53:rev4:MP-5:b:
+    standard:
+      name: nist_800_53:rev4
+    family: MP
+    title: MP-5b.
+    description: Maintains accountability for information system media during transport
+      outside of controlled areas;
+  nist_800_53:rev4:MP-5:c:
+    standard:
+      name: nist_800_53:rev4
+    family: MP
+    title: MP-5c.
+    description: Documents activities associated with the transport of information
+      system media; and
+  nist_800_53:rev4:MP-5:d:
+    standard:
+      name: nist_800_53:rev4
+    family: MP
+    title: MP-5d.
+    description: Restricts the activities associated with the transport of information
+      system media to authorized personnel.
+  nist_800_53:rev4:MP-5:1:
+    standard:
+      name: nist_800_53:rev4
+    family: MP
+    title: PROTECTION OUTSIDE OF CONTROLLED AREAS
+    description: "[Withdrawn: Incorporated into MP-5]."
+  nist_800_53:rev4:MP-5:2:
+    standard:
+      name: nist_800_53:rev4
+    family: MP
+    title: DOCUMENTATION OF ACTIVITIES
+    description: "[Withdrawn: Incorporated into MP-5]."
+  nist_800_53:rev4:MP-5:3:
+    standard:
+      name: nist_800_53:rev4
+    family: MP
+    title: CUSTODIANS
+    description: The organization employs an identified custodian during transport
+      of information system media outside of controlled areas.
+  nist_800_53:rev4:MP-5:4:
+    standard:
+      name: nist_800_53:rev4
+    family: MP
+    title: CRYPTOGRAPHIC PROTECTION
+    description: The information system implements cryptographic mechanisms to protect
+      the confidentiality and integrity of information stored on digital media during
+      transport outside of controlled areas.
+  nist_800_53:rev4:MP-6:a:
+    standard:
+      name: nist_800_53:rev4
+    family: MP
+    title: MP-6a.
+    description: 'Sanitizes [Assignment: organization-defined information system media]
+      prior to disposal, release out of organizational control, or release for reuse
+      using [Assignment: organization-defined sanitization techniques and procedures]
+      in accordance with applicable federal and organizational standards and policies;
+      and'
+  nist_800_53:rev4:MP-6:b:
+    standard:
+      name: nist_800_53:rev4
+    family: MP
+    title: MP-6b.
+    description: Employs sanitization mechanisms with the strength and integrity commensurate
+      with the security category or classification of the information.
+  nist_800_53:rev4:MP-6:1:
+    standard:
+      name: nist_800_53:rev4
+    family: MP
+    title: REVIEW / APPROVE / TRACK / DOCUMENT / VERIFY
+    description: The organization reviews, approves, tracks, documents, and verifies
+      media sanitization and disposal actions.
+  nist_800_53:rev4:MP-6:2:
+    standard:
+      name: nist_800_53:rev4
+    family: MP
+    title: EQUIPMENT TESTING
+    description: 'The organization tests sanitization equipment and procedures [Assignment:
+      organization-defined frequency] to verify that the intended sanitization is
+      being achieved.'
+  nist_800_53:rev4:MP-6:3:
+    standard:
+      name: nist_800_53:rev4
+    family: MP
+    title: NONDESTRUCTIVE TECHNIQUES
+    description: 'The organization applies nondestructive sanitization techniques
+      to portable storage devices prior to connecting such devices to the information
+      system under the following circumstances: [Assignment: organization-defined
+      circumstances requiring sanitization of portable storage devices].'
+  nist_800_53:rev4:MP-6:4:
+    standard:
+      name: nist_800_53:rev4
+    family: MP
+    title: CONTROLLED UNCLASSIFIED INFORMATION
+    description: "[Withdrawn: Incorporated into MP-6]."
+  nist_800_53:rev4:MP-6:5:
+    standard:
+      name: nist_800_53:rev4
+    family: MP
+    title: CLASSIFIED INFORMATION
+    description: "[Withdrawn: Incorporated into MP-6]."
+  nist_800_53:rev4:MP-6:6:
+    standard:
+      name: nist_800_53:rev4
+    family: MP
+    title: MEDIA DESTRUCTION
+    description: "[Withdrawn: Incorporated into MP-6]."
+  nist_800_53:rev4:MP-6:7:
+    standard:
+      name: nist_800_53:rev4
+    family: MP
+    title: DUAL AUTHORIZATION
+    description: 'The organization enforces dual authorization for the sanitization
+      of [Assignment: organization-defined information system media].'
+  nist_800_53:rev4:MP-6:8:
+    standard:
+      name: nist_800_53:rev4
+    family: MP
+    title: REMOTE PURGING / WIPING OF INFORMATION
+    description: 'The organization provides the capability to purge/wipe information
+      from [Assignment: organization-defined information systems, system components,
+      or devices] either remotely or under the following conditions: [Assignment:
+      organization-defined conditions].'
+  nist_800_53:rev4:MP-7:1:
+    standard:
+      name: nist_800_53:rev4
+    family: MP
+    title: PROHIBIT USE WITHOUT OWNER
+    description: The organization prohibits the use of portable storage devices in
+      organizational information systems when such devices have no identifiable owner.
+  nist_800_53:rev4:MP-7:2:
+    standard:
+      name: nist_800_53:rev4
+    family: MP
+    title: PROHIBIT USE OF SANITIZATION-RESISTANT MEDIA
+    description: The organization prohibits the use of sanitization-resistant media
+      in organizational information systems.
+  nist_800_53:rev4:MP-8:a:
+    standard:
+      name: nist_800_53:rev4
+    family: MP
+    title: MP-8a.
+    description: 'Establishes [Assignment: organization-defined information system
+      media downgrading process] that includes employing downgrading mechanisms with
+      [Assignment: organization-defined strength and integrity];'
+  nist_800_53:rev4:MP-8:b:
+    standard:
+      name: nist_800_53:rev4
+    family: MP
+    title: MP-8b.
+    description: Ensures that the information system media downgrading process is
+      commensurate with the security category and/or classification level of the information
+      to be removed and the access authorizations of the potential recipients of the
+      downgraded information;
+  nist_800_53:rev4:MP-8:c:
+    standard:
+      name: nist_800_53:rev4
+    family: MP
+    title: MP-8c.
+    description: 'Identifies [Assignment: organization-defined information system
+      media requiring downgrading]; and'
+  nist_800_53:rev4:MP-8:d:
+    standard:
+      name: nist_800_53:rev4
+    family: MP
+    title: MP-8d.
+    description: Downgrades the identified information system media using the established
+      process.
+  nist_800_53:rev4:MP-8:1:
+    standard:
+      name: nist_800_53:rev4
+    family: MP
+    title: DOCUMENTATION OF PROCESS
+    description: The organization documents information system media downgrading actions.
+  nist_800_53:rev4:MP-8:2:
+    standard:
+      name: nist_800_53:rev4
+    family: MP
+    title: EQUIPMENT TESTING
+    description: 'The organization employs [Assignment: organization-defined tests]
+      of downgrading equipment and procedures to verify correct performance [Assignment:
+      organization-defined frequency].'
+  nist_800_53:rev4:MP-8:3:
+    standard:
+      name: nist_800_53:rev4
+    family: MP
+    title: CONTROLLED UNCLASSIFIED INFORMATION
+    description: 'The organization downgrades information system media containing
+      [Assignment: organization-defined Controlled Unclassified Information (CUI)]
+      prior to public release in accordance with applicable federal and organizational
+      standards and policies.'
+  nist_800_53:rev4:MP-8:4:
+    standard:
+      name: nist_800_53:rev4
+    family: MP
+    title: CLASSIFIED INFORMATION
+    description: The organization downgrades information system media containing classified
+      information prior to release to individuals without required access authorizations
+      in accordance with NSA standards and policies.
+  nist_800_53:rev4:PE-1:a:
+    standard:
+      name: nist_800_53:rev4
+    family: PE
+    title: PE-1a.
+    description: 'Develops, documents, and disseminates to [Assignment: organization-defined
+      personnel or roles]:'
+  nist_800_53:rev4:PE-1:a:1:
+    standard:
+      name: nist_800_53:rev4
+    family: PE
+    title: PE-1a.1.
+    description: A physical and environmental protection policy that addresses purpose,
+      scope, roles, responsibilities, management commitment, coordination among organizational
+      entities, and compliance; and
+  nist_800_53:rev4:PE-1:a:2:
+    standard:
+      name: nist_800_53:rev4
+    family: PE
+    title: PE-1a.2.
+    description: Procedures to facilitate the implementation of the physical and environmental
+      protection policy and associated physical and environmental protection controls;
+      and
+  nist_800_53:rev4:PE-1:b:
+    standard:
+      name: nist_800_53:rev4
+    family: PE
+    title: PE-1b.
+    description: 'Reviews and updates the current:'
+  nist_800_53:rev4:PE-1:b:1:
+    standard:
+      name: nist_800_53:rev4
+    family: PE
+    title: PE-1b.1.
+    description: 'Physical and environmental protection  policy [Assignment: organization-defined
+      frequency]; and'
+  nist_800_53:rev4:PE-1:b:2:
+    standard:
+      name: nist_800_53:rev4
+    family: PE
+    title: PE-1b.2.
+    description: 'Physical and environmental protection procedures [Assignment: organization-defined
+      frequency].'
+  nist_800_53:rev4:PE-2:a:
+    standard:
+      name: nist_800_53:rev4
+    family: PE
+    title: PE-2a.
+    description: Develops, approves, and maintains a list of individuals with authorized
+      access to the facility where the information system resides;
+  nist_800_53:rev4:PE-2:b:
+    standard:
+      name: nist_800_53:rev4
+    family: PE
+    title: PE-2b.
+    description: Issues authorization credentials for facility access;
+  nist_800_53:rev4:PE-2:c:
+    standard:
+      name: nist_800_53:rev4
+    family: PE
+    title: PE-2c.
+    description: 'Reviews the access list detailing authorized facility access by
+      individuals [Assignment: organization-defined frequency]; and'
+  nist_800_53:rev4:PE-2:d:
+    standard:
+      name: nist_800_53:rev4
+    family: PE
+    title: PE-2d.
+    description: Removes individuals from the facility access list when access is
+      no longer required.
+  nist_800_53:rev4:PE-2:1:
+    standard:
+      name: nist_800_53:rev4
+    family: PE
+    title: ACCESS BY POSITION / ROLE
+    description: The organization authorizes physical access to the facility where
+      the information system resides based on position or role.
+  nist_800_53:rev4:PE-2:2:
+    standard:
+      name: nist_800_53:rev4
+    family: PE
+    title: TWO FORMS OF IDENTIFICATION
+    description: 'The organization requires two forms of identification from [Assignment:
+      organization-defined list of acceptable forms of identification] for visitor
+      access to the facility where the information system resides.'
+  nist_800_53:rev4:PE-2:3:
+    standard:
+      name: nist_800_53:rev4
+    family: PE
+    title: RESTRICT UNESCORTED ACCESS
+    description: 'The organization restricts unescorted access to the facility where
+      the information system resides to personnel with [Selection (one or more): security
+      clearances for all information contained within the system; formal access authorizations
+      for all information contained within the system; need for access to all information
+      contained within the system; [Assignment: organization-defined credentials]].'
+  nist_800_53:rev4:PE-3:a:
+    standard:
+      name: nist_800_53:rev4
+    family: PE
+    title: PE-3a.
+    description: 'Enforces physical access authorizations at [Assignment: organization-defined
+      entry/exit points to the facility where the information system resides] by;'
+  nist_800_53:rev4:PE-3:a:1:
+    standard:
+      name: nist_800_53:rev4
+    family: PE
+    title: PE-3a.1.
+    description: Verifying individual access authorizations before granting access
+      to the facility; and
+  nist_800_53:rev4:PE-3:a:2:
+    standard:
+      name: nist_800_53:rev4
+    family: PE
+    title: PE-3a.2.
+    description: 'Controlling ingress/egress to the facility using [Selection (one
+      or more): [Assignment: organization-defined physical access control systems/devices];
+      guards];'
+  nist_800_53:rev4:PE-3:b:
+    standard:
+      name: nist_800_53:rev4
+    family: PE
+    title: PE-3b.
+    description: 'Maintains physical access audit logs for [Assignment: organization-defined
+      entry/exit points];'
+  nist_800_53:rev4:PE-3:c:
+    standard:
+      name: nist_800_53:rev4
+    family: PE
+    title: PE-3c.
+    description: 'Provides [Assignment: organization-defined security safeguards]
+      to control access to areas within the facility officially designated as publicly
+      accessible;'
+  nist_800_53:rev4:PE-3:d:
+    standard:
+      name: nist_800_53:rev4
+    family: PE
+    title: PE-3d.
+    description: 'Escorts visitors and monitors visitor activity [Assignment: organization-defined
+      circumstances requiring visitor escorts and monitoring];'
+  nist_800_53:rev4:PE-3:e:
+    standard:
+      name: nist_800_53:rev4
+    family: PE
+    title: PE-3e.
+    description: Secures keys, combinations, and other physical access devices;
+  nist_800_53:rev4:PE-3:f:
+    standard:
+      name: nist_800_53:rev4
+    family: PE
+    title: PE-3f.
+    description: 'Inventories [Assignment: organization-defined physical access devices]
+      every [Assignment: organization-defined frequency]; and'
+  nist_800_53:rev4:PE-3:g:
+    standard:
+      name: nist_800_53:rev4
+    family: PE
+    title: PE-3g.
+    description: 'Changes combinations and keys [Assignment: organization-defined
+      frequency] and/or when keys are lost, combinations are compromised, or individuals
+      are transferred or terminated.'
+  nist_800_53:rev4:PE-3:1:
+    standard:
+      name: nist_800_53:rev4
+    family: PE
+    title: INFORMATION SYSTEM ACCESS
+    description: 'The organization enforces physical access authorizations to the
+      information system in addition to the physical access controls for the facility
+      at [Assignment: organization-defined physical spaces containing one or more
+      components of the information system].'
+  nist_800_53:rev4:PE-3:2:
+    standard:
+      name: nist_800_53:rev4
+    family: PE
+    title: FACILITY / INFORMATION SYSTEM BOUNDARIES
+    description: 'The organization performs security checks [Assignment: organization-defined
+      frequency] at the physical boundary of the facility or information system for
+      unauthorized exfiltration of information or removal of information system components.'
+  nist_800_53:rev4:PE-3:3:
+    standard:
+      name: nist_800_53:rev4
+    family: PE
+    title: CONTINUOUS GUARDS / ALARMS / MONITORING
+    description: The organization employs guards and/or alarms to monitor every physical
+      access point to the facility where the information system resides 24 hours per
+      day, 7 days per week.
+  nist_800_53:rev4:PE-3:4:
+    standard:
+      name: nist_800_53:rev4
+    family: PE
+    title: LOCKABLE CASINGS
+    description: 'The organization uses lockable physical casings to protect [Assignment:
+      organization-defined information system components] from unauthorized physical
+      access.'
+  nist_800_53:rev4:PE-3:5:
+    standard:
+      name: nist_800_53:rev4
+    family: PE
+    title: TAMPER PROTECTION
+    description: 'The organization employs [Assignment: organization-defined security
+      safeguards] to [Selection (one or more): detect; prevent] physical tampering
+      or alteration of [Assignment: organization-defined hardware components] within
+      the information system.'
+  nist_800_53:rev4:PE-3:6:
+    standard:
+      name: nist_800_53:rev4
+    family: PE
+    title: FACILITY PENETRATION TESTING
+    description: 'The organization employs a penetration testing process that includes
+      [Assignment: organization-defined frequency], unannounced attempts to bypass
+      or circumvent security controls associated with physical access points to the
+      facility.'
+  nist_800_53:rev4:PE-5:1:
+    standard:
+      name: nist_800_53:rev4
+    family: PE
+    title: ACCESS TO OUTPUT BY AUTHORIZED INDIVIDUALS
+    description: 'The organization:'
+  nist_800_53:rev4:PE-5:1:a:
+    standard:
+      name: nist_800_53:rev4
+    family: PE
+    title: PE-5 (1)(a)
+    description: 'Controls physical access to output from [Assignment: organization-defined
+      output devices]; and'
+  nist_800_53:rev4:PE-5:1:b:
+    standard:
+      name: nist_800_53:rev4
+    family: PE
+    title: PE-5 (1)(b)
+    description: Ensures that only authorized individuals receive output from the
+      device.
+  nist_800_53:rev4:PE-5:2:
+    standard:
+      name: nist_800_53:rev4
+    family: PE
+    title: ACCESS TO OUTPUT BY INDIVIDUAL IDENTITY
+    description: 'The information system:'
+  nist_800_53:rev4:PE-5:2:a:
+    standard:
+      name: nist_800_53:rev4
+    family: PE
+    title: PE-5 (2)(a)
+    description: 'Controls physical access to output from [Assignment: organization-defined
+      output devices]; and'
+  nist_800_53:rev4:PE-5:2:b:
+    standard:
+      name: nist_800_53:rev4
+    family: PE
+    title: PE-5 (2)(b)
+    description: Links individual identity to receipt of the output from the device.
+  nist_800_53:rev4:PE-5:3:
+    standard:
+      name: nist_800_53:rev4
+    family: PE
+    title: MARKING OUTPUT DEVICES
+    description: 'The organization marks [Assignment: organization-defined information
+      system output devices] indicating the appropriate security marking of the information
+      permitted to be output from the device.'
+  nist_800_53:rev4:PE-6:a:
+    standard:
+      name: nist_800_53:rev4
+    family: PE
+    title: PE-6a.
+    description: Monitors physical access to the facility where the information system
+      resides to detect and respond to physical security incidents;
+  nist_800_53:rev4:PE-6:b:
+    standard:
+      name: nist_800_53:rev4
+    family: PE
+    title: PE-6b.
+    description: 'Reviews physical access logs [Assignment: organization-defined frequency]
+      and upon occurrence of [Assignment: organization-defined events or potential
+      indications of events]; and'
+  nist_800_53:rev4:PE-6:c:
+    standard:
+      name: nist_800_53:rev4
+    family: PE
+    title: PE-6c.
+    description: Coordinates results of reviews and investigations with the organizational
+      incident response capability.
+  nist_800_53:rev4:PE-6:1:
+    standard:
+      name: nist_800_53:rev4
+    family: PE
+    title: INTRUSION ALARMS / SURVEILLANCE EQUIPMENT
+    description: The organization monitors physical intrusion alarms and surveillance
+      equipment.
+  nist_800_53:rev4:PE-6:2:
+    standard:
+      name: nist_800_53:rev4
+    family: PE
+    title: AUTOMATED INTRUSION RECOGNITION / RESPONSES
+    description: 'The organization employs automated mechanisms to recognize [Assignment:
+      organization-defined classes/types of intrusions] and initiate [Assignment:
+      organization-defined response actions].'
+  nist_800_53:rev4:PE-6:3:
+    standard:
+      name: nist_800_53:rev4
+    family: PE
+    title: VIDEO SURVEILLANCE
+    description: 'The organization employs video surveillance of [Assignment: organization-defined
+      operational areas] and retains video recordings for [Assignment: organization-defined
+      time period].'
+  nist_800_53:rev4:PE-6:4:
+    standard:
+      name: nist_800_53:rev4
+    family: PE
+    title: MONITORING PHYSICAL ACCESS TO INFORMATION SYSTEMS
+    description: 'The organization monitors physical access to the information system
+      in addition to the physical access monitoring of the facility as [Assignment:
+      organization-defined physical spaces containing one or more components of the
+      information system].'
+  nist_800_53:rev4:PE-8:a:
+    standard:
+      name: nist_800_53:rev4
+    family: PE
+    title: PE-8a.
+    description: 'Maintains visitor access records to the facility where the information
+      system resides for [Assignment: organization-defined time period]; and'
+  nist_800_53:rev4:PE-8:b:
+    standard:
+      name: nist_800_53:rev4
+    family: PE
+    title: PE-8b.
+    description: 'Reviews visitor access records [Assignment: organization-defined
+      frequency].'
+  nist_800_53:rev4:PE-8:1:
+    standard:
+      name: nist_800_53:rev4
+    family: PE
+    title: AUTOMATED RECORDS MAINTENANCE / REVIEW
+    description: The organization employs automated mechanisms to facilitate the maintenance
+      and review of visitor access records.
+  nist_800_53:rev4:PE-8:2:
+    standard:
+      name: nist_800_53:rev4
+    family: PE
+    title: PHYSICAL ACCESS RECORDS
+    description: "[Withdrawn: Incorporated into PE-2]."
+  nist_800_53:rev4:PE-9:1:
+    standard:
+      name: nist_800_53:rev4
+    family: PE
+    title: REDUNDANT CABLING
+    description: 'The organization employs redundant power cabling paths that are
+      physically separated by [Assignment: organization-defined distance].'
+  nist_800_53:rev4:PE-9:2:
+    standard:
+      name: nist_800_53:rev4
+    family: PE
+    title: AUTOMATIC VOLTAGE CONTROLS
+    description: 'The organization employs automatic voltage controls for [Assignment:
+      organization-defined critical information system components].'
+  nist_800_53:rev4:PE-10:a:
+    standard:
+      name: nist_800_53:rev4
+    family: PE
+    title: PE-10a.
+    description: Provides the capability of shutting off power to the information
+      system or individual system components in emergency situations;
+  nist_800_53:rev4:PE-10:b:
+    standard:
+      name: nist_800_53:rev4
+    family: PE
+    title: PE-10b.
+    description: 'Places emergency shutoff switches or devices in [Assignment: organization-defined
+      location by information system or system component] to facilitate safe and easy
+      access for personnel; and'
+  nist_800_53:rev4:PE-10:c:
+    standard:
+      name: nist_800_53:rev4
+    family: PE
+    title: PE-10c.
+    description: Protects emergency power shutoff capability from unauthorized activation.
+  nist_800_53:rev4:PE-10:1:
+    standard:
+      name: nist_800_53:rev4
+    family: PE
+    title: ACCIDENTAL / UNAUTHORIZED ACTIVATION
+    description: "[Withdrawn: Incorporated into PE-10]."
+  nist_800_53:rev4:PE-11:1:
+    standard:
+      name: nist_800_53:rev4
+    family: PE
+    title: LONG-TERM ALTERNATE POWER SUPPLY - MINIMAL OPERATIONAL CAPABILITY
+    description: The organization provides a long-term alternate power supply for
+      the information system that is capable of maintaining minimally required operational
+      capability in the event of an extended loss of the primary power source.
+  nist_800_53:rev4:PE-11:2:
+    standard:
+      name: nist_800_53:rev4
+    family: PE
+    title: LONG-TERM ALTERNATE POWER SUPPLY - SELF-CONTAINED
+    description: 'The organization provides a long-term alternate power supply for
+      the information system that is:'
+  nist_800_53:rev4:PE-11:2:a:
+    standard:
+      name: nist_800_53:rev4
+    family: PE
+    title: PE-11 (2)(a)
+    description: Self-contained;
+  nist_800_53:rev4:PE-11:2:b:
+    standard:
+      name: nist_800_53:rev4
+    family: PE
+    title: PE-11 (2)(b)
+    description: Not reliant on external power generation; and
+  nist_800_53:rev4:PE-11:2:c:
+    standard:
+      name: nist_800_53:rev4
+    family: PE
+    title: PE-11 (2)(c)
+    description: 'Capable of maintaining [Selection: minimally required operational
+      capability; full operational capability] in the event of an extended loss of
+      the primary power source.'
+  nist_800_53:rev4:PE-12:1:
+    standard:
+      name: nist_800_53:rev4
+    family: PE
+    title: ESSENTIAL MISSIONS / BUSINESS FUNCTIONS
+    description: The organization provides emergency lighting for all areas within
+      the facility supporting essential missions and business functions.
+  nist_800_53:rev4:PE-13:1:
+    standard:
+      name: nist_800_53:rev4
+    family: PE
+    title: DETECTION DEVICES / SYSTEMS
+    description: 'The organization employs fire detection devices/systems for the
+      information system that activate automatically and notify [Assignment: organization-defined
+      personnel or roles] and [Assignment: organization-defined emergency responders]
+      in the event of a fire.'
+  nist_800_53:rev4:PE-13:2:
+    standard:
+      name: nist_800_53:rev4
+    family: PE
+    title: SUPPRESSION DEVICES / SYSTEMS
+    description: 'The organization employs fire suppression devices/systems for the
+      information system that provide automatic notification of any activation to
+      Assignment: organization-defined personnel or roles] and [Assignment: organization-defined
+      emergency responders].'
+  nist_800_53:rev4:PE-13:3:
+    standard:
+      name: nist_800_53:rev4
+    family: PE
+    title: AUTOMATIC FIRE SUPPRESSION
+    description: The organization employs an automatic fire suppression capability
+      for the information system when the facility is not staffed on a continuous
+      basis.
+  nist_800_53:rev4:PE-13:4:
+    standard:
+      name: nist_800_53:rev4
+    family: PE
+    title: INSPECTIONS
+    description: 'The organization ensures that the facility undergoes [Assignment:
+      organization-defined frequency] inspections by authorized and qualified inspectors
+      and resolves identified deficiencies within [Assignment: organization-defined
+      time period].'
+  nist_800_53:rev4:PE-14:a:
+    standard:
+      name: nist_800_53:rev4
+    family: PE
+    title: PE-14a.
+    description: 'Maintains temperature and humidity levels within the facility where
+      the information system resides at [Assignment: organization-defined acceptable
+      levels]; and'
+  nist_800_53:rev4:PE-14:b:
+    standard:
+      name: nist_800_53:rev4
+    family: PE
+    title: PE-14b.
+    description: 'Monitors temperature and humidity levels [Assignment: organization-defined
+      frequency].'
+  nist_800_53:rev4:PE-14:1:
+    standard:
+      name: nist_800_53:rev4
+    family: PE
+    title: AUTOMATIC CONTROLS
+    description: The organization employs automatic temperature and humidity controls
+      in the facility to prevent fluctuations potentially harmful to the information
+      system.
+  nist_800_53:rev4:PE-14:2:
+    standard:
+      name: nist_800_53:rev4
+    family: PE
+    title: MONITORING WITH ALARMS / NOTIFICATIONS
+    description: The organization employs temperature and humidity monitoring that
+      provides an alarm or notification of changes potentially harmful to personnel
+      or equipment.
+  nist_800_53:rev4:PE-15:1:
+    standard:
+      name: nist_800_53:rev4
+    family: PE
+    title: AUTOMATION SUPPORT
+    description: 'The organization employs automated mechanisms to detect the presence
+      of water in the vicinity of the information system and alerts [Assignment: organization-defined
+      personnel or roles].'
+  nist_800_53:rev4:PE-17:a:
+    standard:
+      name: nist_800_53:rev4
+    family: PE
+    title: PE-17a.
+    description: 'Employs [Assignment: organization-defined security controls] at
+      alternate work sites;'
+  nist_800_53:rev4:PE-17:b:
+    standard:
+      name: nist_800_53:rev4
+    family: PE
+    title: PE-17b.
+    description: Assesses as feasible, the effectiveness of security controls at alternate
+      work sites; and
+  nist_800_53:rev4:PE-17:c:
+    standard:
+      name: nist_800_53:rev4
+    family: PE
+    title: PE-17c.
+    description: Provides a means for employees to communicate with information security
+      personnel in case of security incidents or problems.
+  nist_800_53:rev4:PE-18:1:
+    standard:
+      name: nist_800_53:rev4
+    family: PE
+    title: FACILITY SITE
+    description: The organization plans the location or site of the facility where
+      the information system resides with regard to physical and environmental hazards
+      and for existing facilities, considers the physical and environmental hazards
+      in its risk mitigation strategy.
+  nist_800_53:rev4:PE-19:1:
+    standard:
+      name: nist_800_53:rev4
+    family: PE
+    title: NATIONAL EMISSIONS / TEMPEST POLICIES AND PROCEDURES
+    description: The organization ensures that information system components, associated
+      data communications, and networks are protected in accordance with national
+      emissions and TEMPEST policies and procedures based on the security category
+      or classification of the information.
+  nist_800_53:rev4:PE-20:a:
+    standard:
+      name: nist_800_53:rev4
+    family: PE
+    title: PE-20a.
+    description: 'Employs [Assignment: organization-defined asset location technologies]
+      to track and monitor the location and movement of [Assignment: organization-defined
+      assets] within [Assignment: organization-defined controlled areas]; and'
+  nist_800_53:rev4:PE-20:b:
+    standard:
+      name: nist_800_53:rev4
+    family: PE
+    title: PE-20b.
+    description: Ensures that asset location technologies are employed in accordance
+      with applicable federal laws, Executive Orders, directives, regulations, policies,
+      standards, and guidance.
+  nist_800_53:rev4:PL-1:a:
+    standard:
+      name: nist_800_53:rev4
+    family: PL
+    title: PL-1a.
+    description: 'Develops, documents, and disseminates to [Assignment: organization-defined
+      personnel or roles]:'
+  nist_800_53:rev4:PL-1:a:1:
+    standard:
+      name: nist_800_53:rev4
+    family: PL
+    title: PL-1a.1.
+    description: A security planning policy that addresses purpose, scope, roles,
+      responsibilities, management commitment, coordination among organizational entities,
+      and compliance; and
+  nist_800_53:rev4:PL-1:a:2:
+    standard:
+      name: nist_800_53:rev4
+    family: PL
+    title: PL-1a.2.
+    description: Procedures to facilitate the implementation of the security planning
+      policy and associated security planning controls; and
+  nist_800_53:rev4:PL-1:b:
+    standard:
+      name: nist_800_53:rev4
+    family: PL
+    title: PL-1b.
+    description: 'Reviews and updates the current:'
+  nist_800_53:rev4:PL-1:b:1:
+    standard:
+      name: nist_800_53:rev4
+    family: PL
+    title: PL-1b.1.
+    description: 'Security planning policy [Assignment: organization-defined frequency];
+      and'
+  nist_800_53:rev4:PL-1:b:2:
+    standard:
+      name: nist_800_53:rev4
+    family: PL
+    title: PL-1b.2.
+    description: 'Security planning procedures [Assignment: organization-defined frequency].'
+  nist_800_53:rev4:PL-2:a:
+    standard:
+      name: nist_800_53:rev4
+    family: PL
+    title: PL-2a.
+    description: 'Develops a security plan for the information system that:'
+  nist_800_53:rev4:PL-2:a:1:
+    standard:
+      name: nist_800_53:rev4
+    family: PL
+    title: PL-2a.1.
+    description: Is consistent with the organization�s enterprise architecture;
+  nist_800_53:rev4:PL-2:a:2:
+    standard:
+      name: nist_800_53:rev4
+    family: PL
+    title: PL-2a.2.
+    description: Explicitly defines the authorization boundary for the system;
+  nist_800_53:rev4:PL-2:a:3:
+    standard:
+      name: nist_800_53:rev4
+    family: PL
+    title: PL-2a.3.
+    description: Describes the operational context of the information system in terms
+      of missions and business processes;
+  nist_800_53:rev4:PL-2:a:4:
+    standard:
+      name: nist_800_53:rev4
+    family: PL
+    title: PL-2a.4.
+    description: Provides the security categorization of the information system including
+      supporting rationale;
+  nist_800_53:rev4:PL-2:a:5:
+    standard:
+      name: nist_800_53:rev4
+    family: PL
+    title: PL-2a.5.
+    description: Describes the operational environment for the information system
+      and relationships with or connections to other information systems;
+  nist_800_53:rev4:PL-2:a:6:
+    standard:
+      name: nist_800_53:rev4
+    family: PL
+    title: PL-2a.6.
+    description: Provides an overview of the security requirements for the system;
+  nist_800_53:rev4:PL-2:a:7:
+    standard:
+      name: nist_800_53:rev4
+    family: PL
+    title: PL-2a.7.
+    description: Identifies any relevant overlays, if applicable;
+  nist_800_53:rev4:PL-2:a:8:
+    standard:
+      name: nist_800_53:rev4
+    family: PL
+    title: PL-2a.8.
+    description: Describes the security controls in place or planned for meeting those
+      requirements including a rationale for the tailoring decisions; and
+  nist_800_53:rev4:PL-2:a:9:
+    standard:
+      name: nist_800_53:rev4
+    family: PL
+    title: PL-2a.9.
+    description: Is reviewed and approved by the authorizing official or designated
+      representative prior to plan implementation;
+  nist_800_53:rev4:PL-2:b:
+    standard:
+      name: nist_800_53:rev4
+    family: PL
+    title: PL-2b.
+    description: 'Distributes copies of the security plan and communicates subsequent
+      changes to the plan to [Assignment: organization-defined personnel or roles];'
+  nist_800_53:rev4:PL-2:c:
+    standard:
+      name: nist_800_53:rev4
+    family: PL
+    title: PL-2c.
+    description: 'Reviews the security plan for the information system [Assignment:
+      organization-defined frequency];'
+  nist_800_53:rev4:PL-2:d:
+    standard:
+      name: nist_800_53:rev4
+    family: PL
+    title: PL-2d.
+    description: Updates the plan to address changes to the information system/environment
+      of operation or problems identified during plan implementation or security control
+      assessments; and
+  nist_800_53:rev4:PL-2:e:
+    standard:
+      name: nist_800_53:rev4
+    family: PL
+    title: PL-2e.
+    description: Protects the security plan from unauthorized disclosure and modification.
+  nist_800_53:rev4:PL-2:1:
+    standard:
+      name: nist_800_53:rev4
+    family: PL
+    title: CONCEPT OF OPERATIONS
+    description: "[Withdrawn: Incorporated into PL-7]."
+  nist_800_53:rev4:PL-2:2:
+    standard:
+      name: nist_800_53:rev4
+    family: PL
+    title: FUNCTIONAL ARCHITECTURE
+    description: "[Withdrawn: Incorporated into PL-8]."
+  nist_800_53:rev4:PL-2:3:
+    standard:
+      name: nist_800_53:rev4
+    family: PL
+    title: PLAN / COORDINATE WITH OTHER ORGANIZATIONAL ENTITIES
+    description: 'The organization plans and coordinates security-related activities
+      affecting the information system with [Assignment: organization-defined individuals
+      or groups] before conducting such activities in order to reduce the impact on
+      other organizational entities.'
+  nist_800_53:rev4:PL-4:a:
+    standard:
+      name: nist_800_53:rev4
+    family: PL
+    title: PL-4a.
+    description: Establishes and makes readily available to individuals requiring
+      access to the information system, the rules that describe their responsibilities
+      and expected behavior with regard to information and information system usage;
+  nist_800_53:rev4:PL-4:b:
+    standard:
+      name: nist_800_53:rev4
+    family: PL
+    title: PL-4b.
+    description: Receives a signed acknowledgment from such individuals, indicating
+      that they have read, understand, and agree to abide by the rules of behavior,
+      before authorizing access to information and the information system;
+  nist_800_53:rev4:PL-4:c:
+    standard:
+      name: nist_800_53:rev4
+    family: PL
+    title: PL-4c.
+    description: 'Reviews and updates the rules of behavior [Assignment: organization-defined
+      frequency]; and'
+  nist_800_53:rev4:PL-4:d:
+    standard:
+      name: nist_800_53:rev4
+    family: PL
+    title: PL-4d.
+    description: Requires individuals who have signed a previous version of the rules
+      of behavior to read and re-sign when the rules of behavior are revised/updated.
+  nist_800_53:rev4:PL-4:1:
+    standard:
+      name: nist_800_53:rev4
+    family: PL
+    title: SOCIAL MEDIA AND NETWORKING RESTRICTIONS
+    description: The organization includes in the rules of behavior, explicit restrictions
+      on the use of social media/networking sites and posting organizational information
+      on public websites.
+  nist_800_53:rev4:PL-7:a:
+    standard:
+      name: nist_800_53:rev4
+    family: PL
+    title: PL-7a.
+    description: Develops a security Concept of Operations (CONOPS) for the information
+      system containing at a minimum, how the organization intends to operate the
+      system from the perspective of information security; and
+  nist_800_53:rev4:PL-7:b:
+    standard:
+      name: nist_800_53:rev4
+    family: PL
+    title: PL-7b.
+    description: 'Reviews and updates the CONOPS [Assignment: organization-defined
+      frequency].'
+  nist_800_53:rev4:PL-8:a:
+    standard:
+      name: nist_800_53:rev4
+    family: PL
+    title: PL-8a.
+    description: 'Develops an information security architecture for the information
+      system that:'
+  nist_800_53:rev4:PL-8:a:1:
+    standard:
+      name: nist_800_53:rev4
+    family: PL
+    title: PL-8a.1.
+    description: Describes the overall philosophy, requirements, and approach to be
+      taken with regard to protecting the confidentiality, integrity, and availability
+      of organizational information;
+  nist_800_53:rev4:PL-8:a:2:
+    standard:
+      name: nist_800_53:rev4
+    family: PL
+    title: PL-8a.2.
+    description: Describes how the information security architecture is integrated
+      into and supports the enterprise architecture; and
+  nist_800_53:rev4:PL-8:a:3:
+    standard:
+      name: nist_800_53:rev4
+    family: PL
+    title: PL-8a.3.
+    description: Describes any information security assumptions about, and dependencies
+      on, external services;
+  nist_800_53:rev4:PL-8:b:
+    standard:
+      name: nist_800_53:rev4
+    family: PL
+    title: PL-8b.
+    description: 'Reviews and updates the information security architecture [Assignment:
+      organization-defined frequency] to reflect updates in the enterprise architecture;
+      and'
+  nist_800_53:rev4:PL-8:c:
+    standard:
+      name: nist_800_53:rev4
+    family: PL
+    title: PL-8c.
+    description: Ensures that planned information security architecture changes are
+      reflected in the security plan, the security Concept of Operations (CONOPS),
+      and organizational procurements/acquisitions.
+  nist_800_53:rev4:PL-8:1:
+    standard:
+      name: nist_800_53:rev4
+    family: PL
+    title: DEFENSE-IN-DEPTH
+    description: 'The organization designs its security architecture using a defense-in-depth
+      approach that:'
+  nist_800_53:rev4:PL-8:1:a:
+    standard:
+      name: nist_800_53:rev4
+    family: PL
+    title: PL-8 (1)(a)
+    description: 'Allocates [Assignment: organization-defined security safeguards]
+      to [Assignment: organization-defined locations and architectural layers]; and'
+  nist_800_53:rev4:PL-8:1:b:
+    standard:
+      name: nist_800_53:rev4
+    family: PL
+    title: PL-8 (1)(b)
+    description: Ensures that the allocated security safeguards operate in a coordinated
+      and mutually reinforcing manner.
+  nist_800_53:rev4:PL-8:2:
+    standard:
+      name: nist_800_53:rev4
+    family: PL
+    title: SUPPLIER DIVERSITY
+    description: 'The organization requires that [Assignment: organization-defined
+      security safeguards] allocated to [Assignment: organization-defined locations
+      and architectural layers] are obtained from different suppliers.'
+  nist_800_53:rev4:PS-1:a:
+    standard:
+      name: nist_800_53:rev4
+    family: PS
+    title: PS-1a.
+    description: 'Develops, documents, and disseminates to [Assignment: organization-defined
+      personnel or roles]:'
+  nist_800_53:rev4:PS-1:a:1:
+    standard:
+      name: nist_800_53:rev4
+    family: PS
+    title: PS-1a.1.
+    description: A personnel security policy that addresses purpose, scope, roles,
+      responsibilities, management commitment, coordination among organizational entities,
+      and compliance; and
+  nist_800_53:rev4:PS-1:a:2:
+    standard:
+      name: nist_800_53:rev4
+    family: PS
+    title: PS-1a.2.
+    description: Procedures to facilitate the implementation of the personnel security
+      policy and associated personnel security controls; and
+  nist_800_53:rev4:PS-1:b:
+    standard:
+      name: nist_800_53:rev4
+    family: PS
+    title: PS-1b.
+    description: 'Reviews and updates the current:'
+  nist_800_53:rev4:PS-1:b:1:
+    standard:
+      name: nist_800_53:rev4
+    family: PS
+    title: PS-1b.1.
+    description: 'Personnel security policy [Assignment: organization-defined frequency];
+      and'
+  nist_800_53:rev4:PS-1:b:2:
+    standard:
+      name: nist_800_53:rev4
+    family: PS
+    title: PS-1b.2.
+    description: 'Personnel security procedures [Assignment: organization-defined
+      frequency].'
+  nist_800_53:rev4:PS-2:a:
+    standard:
+      name: nist_800_53:rev4
+    family: PS
+    title: PS-2a.
+    description: Assigns a risk designation to all organizational positions;
+  nist_800_53:rev4:PS-2:b:
+    standard:
+      name: nist_800_53:rev4
+    family: PS
+    title: PS-2b.
+    description: Establishes screening criteria for individuals filling those positions;
+      and
+  nist_800_53:rev4:PS-2:c:
+    standard:
+      name: nist_800_53:rev4
+    family: PS
+    title: PS-2c.
+    description: 'Reviews and updates position risk designations [Assignment: organization-defined
+      frequency].'
+  nist_800_53:rev4:PS-3:a:
+    standard:
+      name: nist_800_53:rev4
+    family: PS
+    title: PS-3a.
+    description: Screens individuals prior to authorizing access to the information
+      system; and
+  nist_800_53:rev4:PS-3:b:
+    standard:
+      name: nist_800_53:rev4
+    family: PS
+    title: PS-3b.
+    description: 'Rescreens individuals according to [Assignment: organization-defined
+      conditions requiring rescreening and, where rescreening is so indicated, the
+      frequency of such rescreening].'
+  nist_800_53:rev4:PS-3:1:
+    standard:
+      name: nist_800_53:rev4
+    family: PS
+    title: CLASSIFIED INFORMATION
+    description: The organization ensures that individuals accessing an information
+      system processing, storing, or transmitting classified information are cleared
+      and indoctrinated to the highest classification level of the information to
+      which they have access on the system.
+  nist_800_53:rev4:PS-3:2:
+    standard:
+      name: nist_800_53:rev4
+    family: PS
+    title: FORMAL INDOCTRINATION
+    description: The organization ensures that individuals accessing an information
+      system processing, storing, or transmitting types of classified information
+      which require formal indoctrination, are formally indoctrinated for all of the
+      relevant types of information to which they have access on the system.
+  nist_800_53:rev4:PS-3:3:
+    standard:
+      name: nist_800_53:rev4
+    family: PS
+    title: INFORMATION WITH SPECIAL PROTECTION MEASURES
+    description: 'The organization ensures that individuals accessing an information
+      system processing, storing, or transmitting information requiring special protection:'
+  nist_800_53:rev4:PS-3:3:a:
+    standard:
+      name: nist_800_53:rev4
+    family: PS
+    title: PS-3 (3)(a)
+    description: Have valid access authorizations that are demonstrated by assigned
+      official government duties; and
+  nist_800_53:rev4:PS-3:3:b:
+    standard:
+      name: nist_800_53:rev4
+    family: PS
+    title: PS-3 (3)(b)
+    description: 'Satisfy [Assignment: organization-defined additional personnel screening
+      criteria].'
+  nist_800_53:rev4:PS-4:a:
+    standard:
+      name: nist_800_53:rev4
+    family: PS
+    title: PS-4a.
+    description: 'Disables information system access within [Assignment: organization-defined
+      time period];'
+  nist_800_53:rev4:PS-4:b:
+    standard:
+      name: nist_800_53:rev4
+    family: PS
+    title: PS-4b.
+    description: Terminates/revokes any authenticators/credentials associated with
+      the individual;
+  nist_800_53:rev4:PS-4:c:
+    standard:
+      name: nist_800_53:rev4
+    family: PS
+    title: PS-4c.
+    description: 'Conducts exit interviews that include a discussion of [Assignment:
+      organization-defined information security topics];'
+  nist_800_53:rev4:PS-4:d:
+    standard:
+      name: nist_800_53:rev4
+    family: PS
+    title: PS-4d.
+    description: Retrieves all security-related organizational information system-related
+      property;
+  nist_800_53:rev4:PS-4:e:
+    standard:
+      name: nist_800_53:rev4
+    family: PS
+    title: PS-4e.
+    description: Retains access to organizational information and information systems
+      formerly controlled by terminated individual; and
+  nist_800_53:rev4:PS-4:f:
+    standard:
+      name: nist_800_53:rev4
+    family: PS
+    title: PS-4f.
+    description: 'Notifies [Assignment: organization-defined personnel or roles] within
+      [Assignment: organization-defined time period].'
+  nist_800_53:rev4:PS-4:1:
+    standard:
+      name: nist_800_53:rev4
+    family: PS
+    title: POST-EMPLOYMENT REQUIREMENTS
+    description: 'The organization:'
+  nist_800_53:rev4:PS-4:1:a:
+    standard:
+      name: nist_800_53:rev4
+    family: PS
+    title: PS-4 (1)(a)
+    description: Notifies terminated individuals of applicable, legally binding post-employment
+      requirements for the protection of organizational information; and
+  nist_800_53:rev4:PS-4:1:b:
+    standard:
+      name: nist_800_53:rev4
+    family: PS
+    title: PS-4 (1)(b)
+    description: Requires terminated individuals to sign an acknowledgment of post-employment
+      requirements as part of the organizational termination process.
+  nist_800_53:rev4:PS-4:2:
+    standard:
+      name: nist_800_53:rev4
+    family: PS
+    title: AUTOMATED NOTIFICATION
+    description: 'The organization employs automated mechanisms to notify [Assignment:
+      organization-defined personnel or roles] upon termination of an individual.'
+  nist_800_53:rev4:PS-5:a:
+    standard:
+      name: nist_800_53:rev4
+    family: PS
+    title: PS-5a.
+    description: Reviews and confirms ongoing operational need for current logical
+      and physical access authorizations to information systems/facilities when individuals
+      are reassigned or transferred to other positions within the organization;
+  nist_800_53:rev4:PS-5:b:
+    standard:
+      name: nist_800_53:rev4
+    family: PS
+    title: PS-5b.
+    description: 'Initiates [Assignment: organization-defined transfer or reassignment
+      actions] within [Assignment: organization-defined time period following the
+      formal transfer action];'
+  nist_800_53:rev4:PS-5:c:
+    standard:
+      name: nist_800_53:rev4
+    family: PS
+    title: PS-5c.
+    description: Modifies access authorization as needed to correspond with any changes
+      in operational need due to reassignment or transfer; and
+  nist_800_53:rev4:PS-5:d:
+    standard:
+      name: nist_800_53:rev4
+    family: PS
+    title: PS-5d.
+    description: 'Notifies [Assignment: organization-defined personnel or roles] within
+      [Assignment: organization-defined time period].'
+  nist_800_53:rev4:PS-6:a:
+    standard:
+      name: nist_800_53:rev4
+    family: PS
+    title: PS-6a.
+    description: Develops and documents access agreements for organizational information
+      systems;
+  nist_800_53:rev4:PS-6:b:
+    standard:
+      name: nist_800_53:rev4
+    family: PS
+    title: PS-6b.
+    description: 'Reviews and updates the access agreements [Assignment: organization-defined
+      frequency]; and'
+  nist_800_53:rev4:PS-6:c:
+    standard:
+      name: nist_800_53:rev4
+    family: PS
+    title: PS-6c.
+    description: 'Ensures that individuals requiring access to organizational information
+      and information systems:'
+  nist_800_53:rev4:PS-6:c:1:
+    standard:
+      name: nist_800_53:rev4
+    family: PS
+    title: PS-6c.1.
+    description: Sign appropriate access agreements prior to being granted access;
+      and
+  nist_800_53:rev4:PS-6:c:2:
+    standard:
+      name: nist_800_53:rev4
+    family: PS
+    title: PS-6c.2.
+    description: 'Re-sign access agreements to maintain access to organizational information
+      systems when access agreements have been updated or [Assignment: organization-defined
+      frequency].'
+  nist_800_53:rev4:PS-6:1:
+    standard:
+      name: nist_800_53:rev4
+    family: PS
+    title: INFORMATION REQUIRING SPECIAL PROTECTION
+    description: "[Withdrawn: Incorporated into PS-3]."
+  nist_800_53:rev4:PS-6:2:
+    standard:
+      name: nist_800_53:rev4
+    family: PS
+    title: CLASSIFIED INFORMATION REQUIRING SPECIAL PROTECTION
+    description: 'The organization ensures that access to classified information requiring
+      special protection is granted only to individuals who:'
+  nist_800_53:rev4:PS-6:2:a:
+    standard:
+      name: nist_800_53:rev4
+    family: PS
+    title: PS-6 (2)(a)
+    description: Have a valid access authorization that is demonstrated by assigned
+      official government duties;
+  nist_800_53:rev4:PS-6:2:b:
+    standard:
+      name: nist_800_53:rev4
+    family: PS
+    title: PS-6 (2)(b)
+    description: Satisfy associated personnel security criteria; and
+  nist_800_53:rev4:PS-6:2:c:
+    standard:
+      name: nist_800_53:rev4
+    family: PS
+    title: PS-6 (2)(c)
+    description: Have read, understood, and signed a nondisclosure agreement.
+  nist_800_53:rev4:PS-6:3:
+    standard:
+      name: nist_800_53:rev4
+    family: PS
+    title: POST-EMPLOYMENT REQUIREMENTS
+    description: 'The organization:'
+  nist_800_53:rev4:PS-6:3:a:
+    standard:
+      name: nist_800_53:rev4
+    family: PS
+    title: PS-6 (3)(a)
+    description: Notifies individuals of applicable, legally binding post-employment
+      requirements for protection of organizational information; and
+  nist_800_53:rev4:PS-6:3:b:
+    standard:
+      name: nist_800_53:rev4
+    family: PS
+    title: PS-6 (3)(b)
+    description: Requires individuals to sign an acknowledgment of these requirements,
+      if applicable, as part of granting initial access to covered information.
+  nist_800_53:rev4:PS-7:a:
+    standard:
+      name: nist_800_53:rev4
+    family: PS
+    title: PS-7a.
+    description: Establishes personnel security requirements including security roles
+      and responsibilities for third-party providers;
+  nist_800_53:rev4:PS-7:b:
+    standard:
+      name: nist_800_53:rev4
+    family: PS
+    title: PS-7b.
+    description: Requires third-party providers to comply with personnel security
+      policies and procedures established by the organization;
+  nist_800_53:rev4:PS-7:c:
+    standard:
+      name: nist_800_53:rev4
+    family: PS
+    title: PS-7c.
+    description: Documents personnel security requirements;
+  nist_800_53:rev4:PS-7:d:
+    standard:
+      name: nist_800_53:rev4
+    family: PS
+    title: PS-7d.
+    description: 'Requires third-party providers to notify [Assignment: organization-defined
+      personnel or roles] of any personnel transfers or terminations of third-party
+      personnel who possess organizational credentials and/or badges, or who have
+      information system privileges within [Assignment: organization-defined time
+      period]; and'
+  nist_800_53:rev4:PS-7:e:
+    standard:
+      name: nist_800_53:rev4
+    family: PS
+    title: PS-7e.
+    description: Monitors provider compliance.
+  nist_800_53:rev4:PS-8:a:
+    standard:
+      name: nist_800_53:rev4
+    family: PS
+    title: PS-8a.
+    description: Employs a formal sanctions process for individuals failing to comply
+      with established information security policies and procedures; and
+  nist_800_53:rev4:PS-8:b:
+    standard:
+      name: nist_800_53:rev4
+    family: PS
+    title: PS-8b.
+    description: 'Notifies [Assignment: organization-defined personnel or roles] within
+      [Assignment: organization-defined time period] when a formal employee sanctions
+      process is initiated, identifying the individual sanctioned and the reason for
+      the sanction.'
+  nist_800_53:rev4:RA-1:a:
+    standard:
+      name: nist_800_53:rev4
+    family: RA
+    title: RA-1a.
+    description: 'Develops, documents, and disseminates to [Assignment: organization-defined
+      personnel or roles]:'
+  nist_800_53:rev4:RA-1:a:1:
+    standard:
+      name: nist_800_53:rev4
+    family: RA
+    title: RA-1a.1.
+    description: A risk assessment policy that addresses purpose, scope, roles, responsibilities,
+      management commitment, coordination among organizational entities, and compliance;
+      and
+  nist_800_53:rev4:RA-1:a:2:
+    standard:
+      name: nist_800_53:rev4
+    family: RA
+    title: RA-1a.2.
+    description: Procedures to facilitate the implementation of the risk assessment
+      policy and associated risk assessment controls; and
+  nist_800_53:rev4:RA-1:b:
+    standard:
+      name: nist_800_53:rev4
+    family: RA
+    title: RA-1b.
+    description: 'Reviews and updates the current:'
+  nist_800_53:rev4:RA-1:b:1:
+    standard:
+      name: nist_800_53:rev4
+    family: RA
+    title: RA-1b.1.
+    description: 'Risk assessment policy [Assignment: organization-defined frequency];
+      and'
+  nist_800_53:rev4:RA-1:b:2:
+    standard:
+      name: nist_800_53:rev4
+    family: RA
+    title: RA-1b.2.
+    description: 'Risk assessment procedures [Assignment: organization-defined frequency].'
+  nist_800_53:rev4:RA-2:a:
+    standard:
+      name: nist_800_53:rev4
+    family: RA
+    title: RA-2a.
+    description: Categorizes information and the information system in accordance
+      with applicable federal laws, Executive Orders, directives, policies, regulations,
+      standards, and guidance;
+  nist_800_53:rev4:RA-2:b:
+    standard:
+      name: nist_800_53:rev4
+    family: RA
+    title: RA-2b.
+    description: Documents the security categorization results (including supporting
+      rationale) in the security plan for the information system; and
+  nist_800_53:rev4:RA-2:c:
+    standard:
+      name: nist_800_53:rev4
+    family: RA
+    title: RA-2c.
+    description: Ensures that the authorizing official or authorizing official designated
+      representative reviews and approves the security categorization decision.
+  nist_800_53:rev4:RA-3:a:
+    standard:
+      name: nist_800_53:rev4
+    family: RA
+    title: RA-3a.
+    description: Conducts an assessment of risk, including the likelihood and magnitude
+      of harm, from the unauthorized access, use, disclosure, disruption, modification,
+      or destruction of the information system and the information it processes, stores,
+      or transmits;
+  nist_800_53:rev4:RA-3:b:
+    standard:
+      name: nist_800_53:rev4
+    family: RA
+    title: RA-3b.
+    description: 'Documents risk assessment results in [Selection: security plan;
+      risk assessment report; [Assignment: organization-defined document]];'
+  nist_800_53:rev4:RA-3:c:
+    standard:
+      name: nist_800_53:rev4
+    family: RA
+    title: RA-3c.
+    description: 'Reviews risk assessment results [Assignment: organization-defined
+      frequency];'
+  nist_800_53:rev4:RA-3:d:
+    standard:
+      name: nist_800_53:rev4
+    family: RA
+    title: RA-3d.
+    description: 'Disseminates risk assessment results to [Assignment: organization-defined
+      personnel or roles]; and'
+  nist_800_53:rev4:RA-3:e:
+    standard:
+      name: nist_800_53:rev4
+    family: RA
+    title: RA-3e.
+    description: 'Updates the risk assessment [Assignment: organization-defined frequency]
+      or whenever there are significant changes to the information system or environment
+      of operation (including the identification of new threats and vulnerabilities),
+      or other conditions that may impact the security state of the system.'
+  nist_800_53:rev4:RA-5:a:
+    standard:
+      name: nist_800_53:rev4
+    family: RA
+    title: RA-5a.
+    description: 'Scans for vulnerabilities in the information system and hosted applications
+      [Assignment: organization-defined frequency and/or randomly in accordance with
+      organization-defined process] and when new vulnerabilities potentially affecting
+      the system/applications are identified and reported;'
+  nist_800_53:rev4:RA-5:b:
+    standard:
+      name: nist_800_53:rev4
+    family: RA
+    title: RA-5b.
+    description: 'Employs vulnerability scanning tools and techniques that facilitate
+      interoperability among tools and automate parts of the vulnerability management
+      process by using standards for:'
+  nist_800_53:rev4:RA-5:b:1:
+    standard:
+      name: nist_800_53:rev4
+    family: RA
+    title: RA-5b.1.
+    description: Enumerating platforms, software flaws, and improper configurations;
+  nist_800_53:rev4:RA-5:b:2:
+    standard:
+      name: nist_800_53:rev4
+    family: RA
+    title: RA-5b.2.
+    description: Formatting checklists and test procedures; and
+  nist_800_53:rev4:RA-5:b:3:
+    standard:
+      name: nist_800_53:rev4
+    family: RA
+    title: RA-5b.3.
+    description: Measuring vulnerability impact;
+  nist_800_53:rev4:RA-5:c:
+    standard:
+      name: nist_800_53:rev4
+    family: RA
+    title: RA-5c.
+    description: Analyzes vulnerability scan reports and results from security control
+      assessments;
+  nist_800_53:rev4:RA-5:d:
+    standard:
+      name: nist_800_53:rev4
+    family: RA
+    title: RA-5d.
+    description: 'Remediates legitimate vulnerabilities [Assignment: organization-defined
+      response times] in accordance with an organizational assessment of risk; and'
+  nist_800_53:rev4:RA-5:e:
+    standard:
+      name: nist_800_53:rev4
+    family: RA
+    title: RA-5e.
+    description: 'Shares information obtained from the vulnerability scanning process
+      and security control assessments with [Assignment: organization-defined personnel
+      or roles] to help eliminate similar vulnerabilities in other information systems
+      (i.e., systemic weaknesses or deficiencies).'
+  nist_800_53:rev4:RA-5:1:
+    standard:
+      name: nist_800_53:rev4
+    family: RA
+    title: UPDATE TOOL CAPABILITY
+    description: The organization employs vulnerability scanning tools that include
+      the capability to readily update the information system vulnerabilities to be
+      scanned.
+  nist_800_53:rev4:RA-5:2:
+    standard:
+      name: nist_800_53:rev4
+    family: RA
+    title: UPDATE BY FREQUENCY / PRIOR TO NEW SCAN / WHEN IDENTIFIED
+    description: 'The organization updates the information system vulnerabilities
+      scanned [Selection (one or more): [Assignment: organization-defined frequency];
+      prior to a new scan; when new vulnerabilities are identified and reported].'
+  nist_800_53:rev4:RA-5:3:
+    standard:
+      name: nist_800_53:rev4
+    family: RA
+    title: BREADTH / DEPTH OF COVERAGE
+    description: The organization employs vulnerability scanning procedures that can
+      identify the breadth and depth of coverage (i.e., information system components
+      scanned and vulnerabilities checked).
+  nist_800_53:rev4:RA-5:4:
+    standard:
+      name: nist_800_53:rev4
+    family: RA
+    title: DISCOVERABLE INFORMATION
+    description: 'The organization determines what information about the information
+      system is discoverable by adversaries and subsequently takes [Assignment: organization-defined
+      corrective actions].'
+  nist_800_53:rev4:RA-5:5:
+    standard:
+      name: nist_800_53:rev4
+    family: RA
+    title: PRIVILEGED ACCESS
+    description: 'The information system implements privileged access authorization
+      to [Assignment: organization-identified information system components] for selected
+      [Assignment: organization-defined vulnerability scanning activities].'
+  nist_800_53:rev4:RA-5:6:
+    standard:
+      name: nist_800_53:rev4
+    family: RA
+    title: AUTOMATED TREND ANALYSES
+    description: The organization employs automated mechanisms to compare the results
+      of vulnerability scans over time to determine trends in information system vulnerabilities.
+  nist_800_53:rev4:RA-5:7:
+    standard:
+      name: nist_800_53:rev4
+    family: RA
+    title: AUTOMATED DETECTION AND NOTIFICATION OF UNAUTHORIZED COMPONENTS
+    description: "[Withdrawn: Incorporated into CM-8]."
+  nist_800_53:rev4:RA-5:8:
+    standard:
+      name: nist_800_53:rev4
+    family: RA
+    title: REVIEW HISTORIC AUDIT LOGS
+    description: The organization reviews historic audit logs to determine if a vulnerability
+      identified in the information system has been previously exploited.
+  nist_800_53:rev4:RA-5:9:
+    standard:
+      name: nist_800_53:rev4
+    family: RA
+    title: PENETRATION TESTING AND ANALYSES
+    description: "[Withdrawn: Incorporated into CA-8]."
+  nist_800_53:rev4:RA-5:10:
+    standard:
+      name: nist_800_53:rev4
+    family: RA
+    title: CORRELATE SCANNING INFORMATION
+    description: The organization correlates the output from vulnerability scanning
+      tools to determine the presence of multi-vulnerability/multi-hop attack vectors.
+  nist_800_53:rev4:SA-1:a:
+    standard:
+      name: nist_800_53:rev4
+    family: SA
+    title: SA-1a.
+    description: 'Develops, documents, and disseminates to [Assignment: organization-defined
+      personnel or roles]:'
+  nist_800_53:rev4:SA-1:a:1:
+    standard:
+      name: nist_800_53:rev4
+    family: SA
+    title: SA-1a.1.
+    description: A system and services acquisition policy that addresses purpose,
+      scope, roles, responsibilities, management commitment, coordination among organizational
+      entities, and compliance; and
+  nist_800_53:rev4:SA-1:a:2:
+    standard:
+      name: nist_800_53:rev4
+    family: SA
+    title: SA-1a.2.
+    description: Procedures to facilitate the implementation of the system and services
+      acquisition policy and associated system and services acquisition controls;
+      and
+  nist_800_53:rev4:SA-1:b:
+    standard:
+      name: nist_800_53:rev4
+    family: SA
+    title: SA-1b.
+    description: 'Reviews and updates the current:'
+  nist_800_53:rev4:SA-1:b:1:
+    standard:
+      name: nist_800_53:rev4
+    family: SA
+    title: SA-1b.1.
+    description: 'System and services acquisition policy [Assignment: organization-defined
+      frequency]; and'
+  nist_800_53:rev4:SA-1:b:2:
+    standard:
+      name: nist_800_53:rev4
+    family: SA
+    title: SA-1b.2.
+    description: 'System and services acquisition procedures [Assignment: organization-defined
+      frequency].'
+  nist_800_53:rev4:SA-2:a:
+    standard:
+      name: nist_800_53:rev4
+    family: SA
+    title: SA-2a.
+    description: Determines information security requirements for the information
+      system or information system service in mission/business process planning;
+  nist_800_53:rev4:SA-2:b:
+    standard:
+      name: nist_800_53:rev4
+    family: SA
+    title: SA-2b.
+    description: Determines, documents, and allocates the resources required to protect
+      the information system or information system service as part of its capital
+      planning and investment control process; and
+  nist_800_53:rev4:SA-2:c:
+    standard:
+      name: nist_800_53:rev4
+    family: SA
+    title: SA-2c.
+    description: Establishes a discrete line item for information security in organizational
+      programming and budgeting documentation.
+  nist_800_53:rev4:SA-3:a:
+    standard:
+      name: nist_800_53:rev4
+    family: SA
+    title: SA-3a.
+    description: 'Manages the information system using [Assignment: organization-defined
+      system development life cycle] that incorporates information security considerations;'
+  nist_800_53:rev4:SA-3:b:
+    standard:
+      name: nist_800_53:rev4
+    family: SA
+    title: SA-3b.
+    description: Defines and documents information security roles and responsibilities
+      throughout the system development life cycle;
+  nist_800_53:rev4:SA-3:c:
+    standard:
+      name: nist_800_53:rev4
+    family: SA
+    title: SA-3c.
+    description: Identifies individuals having information security roles and responsibilities;
+      and
+  nist_800_53:rev4:SA-3:d:
+    standard:
+      name: nist_800_53:rev4
+    family: SA
+    title: SA-3d.
+    description: Integrates the organizational information security risk management
+      process into system development life cycle activities.
+  nist_800_53:rev4:SA-4:a:
+    standard:
+      name: nist_800_53:rev4
+    family: SA
+    title: SA-4a.
+    description: Security functional requirements;
+  nist_800_53:rev4:SA-4:b:
+    standard:
+      name: nist_800_53:rev4
+    family: SA
+    title: SA-4b.
+    description: Security strength requirements;
+  nist_800_53:rev4:SA-4:c:
+    standard:
+      name: nist_800_53:rev4
+    family: SA
+    title: SA-4c.
+    description: Security assurance requirements;
+  nist_800_53:rev4:SA-4:d:
+    standard:
+      name: nist_800_53:rev4
+    family: SA
+    title: SA-4d.
+    description: Security-related documentation requirements;
+  nist_800_53:rev4:SA-4:e:
+    standard:
+      name: nist_800_53:rev4
+    family: SA
+    title: SA-4e.
+    description: Requirements for protecting security-related documentation;
+  nist_800_53:rev4:SA-4:f:
+    standard:
+      name: nist_800_53:rev4
+    family: SA
+    title: SA-4f.
+    description: Description of the information system development environment and
+      environment in which the system is intended to operate; and
+  nist_800_53:rev4:SA-4:g:
+    standard:
+      name: nist_800_53:rev4
+    family: SA
+    title: SA-4g.
+    description: Acceptance criteria.
+  nist_800_53:rev4:SA-4:1:
+    standard:
+      name: nist_800_53:rev4
+    family: SA
+    title: FUNCTIONAL PROPERTIES OF SECURITY CONTROLS
+    description: The organization requires the developer of the information system,
+      system component, or information system service to provide a description of
+      the functional properties of the security controls to be employed.
+  nist_800_53:rev4:SA-4:2:
+    standard:
+      name: nist_800_53:rev4
+    family: SA
+    title: DESIGN / IMPLEMENTATION INFORMATION FOR SECURITY CONTROLS
+    description: 'The organization requires the developer of the information system,
+      system component, or information system service to provide design and implementation
+      information for the security controls to be employed that includes: [Selection
+      (one or more): security-relevant external system interfaces; high-level design;
+      low-level design; source code or hardware schematics; [Assignment: organization-defined
+      design/implementation information]] at [Assignment: organization-defined level
+      of detail].'
+  nist_800_53:rev4:SA-4:3:
+    standard:
+      name: nist_800_53:rev4
+    family: SA
+    title: DEVELOPMENT METHODS / TECHNIQUES / PRACTICES
+    description: 'The organization requires the developer of the information system,
+      system component, or information system service to demonstrate the use of a
+      system development life cycle that includes [Assignment: organization-defined
+      state-of-the-practice system/security engineering methods, software development
+      methods, testing/evaluation/validation techniques, and quality control processes].'
+  nist_800_53:rev4:SA-4:4:
+    standard:
+      name: nist_800_53:rev4
+    family: SA
+    title: ASSIGNMENT OF COMPONENTS TO SYSTEMS
+    description: "[Withdrawn: Incorporated into CM-8 (9)]."
+  nist_800_53:rev4:SA-4:5:
+    standard:
+      name: nist_800_53:rev4
+    family: SA
+    title: SYSTEM / COMPONENT / SERVICE CONFIGURATIONS
+    description: 'The organization requires the developer of the information system,
+      system component, or information system service to:'
+  nist_800_53:rev4:SA-4:5:a:
+    standard:
+      name: nist_800_53:rev4
+    family: SA
+    title: SA-4 (5)(a)
+    description: 'Deliver the system, component, or service with [Assignment: organization-defined
+      security configurations] implemented; and'
+  nist_800_53:rev4:SA-4:5:b:
+    standard:
+      name: nist_800_53:rev4
+    family: SA
+    title: SA-4 (5)(b)
+    description: Use the configurations as the default for any subsequent system,
+      component, or service reinstallation or upgrade.
+  nist_800_53:rev4:SA-4:6:
+    standard:
+      name: nist_800_53:rev4
+    family: SA
+    title: USE OF INFORMATION ASSURANCE PRODUCTS
+    description: 'The organization:'
+  nist_800_53:rev4:SA-4:6:a:
+    standard:
+      name: nist_800_53:rev4
+    family: SA
+    title: SA-4 (6)(a)
+    description: Employs only government off-the-shelf (GOTS) or commercial off-the-shelf
+      (COTS) information assurance (IA) and IA-enabled information technology products
+      that compose an NSA-approved solution to protect classified information when
+      the networks used to transmit the information are at a lower classification
+      level than the information being transmitted; and
+  nist_800_53:rev4:SA-4:6:b:
+    standard:
+      name: nist_800_53:rev4
+    family: SA
+    title: SA-4 (6)(b)
+    description: Ensures that these products have been evaluated and/or validated
+      by NSA or in accordance with NSA-approved procedures.
+  nist_800_53:rev4:SA-4:7:
+    standard:
+      name: nist_800_53:rev4
+    family: SA
+    title: NIAP-APPROVED  PROTECTION PROFILES
+    description: 'The organization:'
+  nist_800_53:rev4:SA-4:7:a:
+    standard:
+      name: nist_800_53:rev4
+    family: SA
+    title: SA-4 (7)(a)
+    description: Limits the use of commercially provided information assurance (IA)
+      and IA-enabled information technology products to those products that have been
+      successfully evaluated against a National Information Assurance partnership
+      (NIAP)-approved Protection Profile for a specific technology type, if such a
+      profile exists; and
+  nist_800_53:rev4:SA-4:7:b:
+    standard:
+      name: nist_800_53:rev4
+    family: SA
+    title: SA-4 (7)(b)
+    description: Requires, if no NIAP-approved Protection Profile exists for a specific
+      technology type but a commercially provided information technology product relies
+      on cryptographic functionality to enforce its security policy, that the cryptographic
+      module is FIPS-validated.
+  nist_800_53:rev4:SA-4:8:
+    standard:
+      name: nist_800_53:rev4
+    family: SA
+    title: CONTINUOUS MONITORING PLAN
+    description: 'The organization requires the developer of the information system,
+      system component, or information system service to produce a plan for the continuous
+      monitoring of security control effectiveness that contains [Assignment: organization-defined
+      level of detail].'
+  nist_800_53:rev4:SA-4:9:
+    standard:
+      name: nist_800_53:rev4
+    family: SA
+    title: FUNCTIONS / PORTS / PROTOCOLS / SERVICES IN USE
+    description: The organization requires the developer of the information system,
+      system component, or information system service to identify early in the system
+      development life cycle, the functions, ports, protocols, and services intended
+      for organizational use.
+  nist_800_53:rev4:SA-4:10:
+    standard:
+      name: nist_800_53:rev4
+    family: SA
+    title: USE OF APPROVED PIV PRODUCTS
+    description: The organization employs only information technology products on
+      the FIPS 201-approved products list for Personal Identity Verification (PIV)
+      capability implemented within organizational information systems.
+  nist_800_53:rev4:SA-5:a:
+    standard:
+      name: nist_800_53:rev4
+    family: SA
+    title: SA-5a.
+    description: 'Obtains administrator documentation for the information system,
+      system component, or information system service that describes:'
+  nist_800_53:rev4:SA-5:a:1:
+    standard:
+      name: nist_800_53:rev4
+    family: SA
+    title: SA-5a.1.
+    description: Secure configuration, installation, and operation of the system,
+      component, or service;
+  nist_800_53:rev4:SA-5:a:2:
+    standard:
+      name: nist_800_53:rev4
+    family: SA
+    title: SA-5a.2.
+    description: Effective use and maintenance of security functions/mechanisms; and
+  nist_800_53:rev4:SA-5:a:3:
+    standard:
+      name: nist_800_53:rev4
+    family: SA
+    title: SA-5a.3.
+    description: Known vulnerabilities regarding configuration and use of administrative
+      (i.e., privileged) functions;
+  nist_800_53:rev4:SA-5:b:
+    standard:
+      name: nist_800_53:rev4
+    family: SA
+    title: SA-5b.
+    description: 'Obtains user documentation for the information system, system component,
+      or information system service that describes:'
+  nist_800_53:rev4:SA-5:b:1:
+    standard:
+      name: nist_800_53:rev4
+    family: SA
+    title: SA-5b.1.
+    description: User-accessible security functions/mechanisms and how to effectively
+      use those security functions/mechanisms;
+  nist_800_53:rev4:SA-5:b:2:
+    standard:
+      name: nist_800_53:rev4
+    family: SA
+    title: SA-5b.2.
+    description: Methods for user interaction, which enables individuals to use the
+      system, component, or service in a more secure manner; and
+  nist_800_53:rev4:SA-5:b:3:
+    standard:
+      name: nist_800_53:rev4
+    family: SA
+    title: SA-5b.3.
+    description: User responsibilities in maintaining the security of the system,
+      component, or service;
+  nist_800_53:rev4:SA-5:c:
+    standard:
+      name: nist_800_53:rev4
+    family: SA
+    title: SA-5c.
+    description: 'Documents attempts to obtain information system, system component,
+      or information system service documentation when such documentation is either
+      unavailable or nonexistent and takes [Assignment: organization-defined actions]
+      in response;'
+  nist_800_53:rev4:SA-5:d:
+    standard:
+      name: nist_800_53:rev4
+    family: SA
+    title: SA-5d.
+    description: Protects documentation as required, in accordance with the risk management
+      strategy; and
+  nist_800_53:rev4:SA-5:e:
+    standard:
+      name: nist_800_53:rev4
+    family: SA
+    title: SA-5e.
+    description: 'Distributes documentation to [Assignment: organization-defined personnel
+      or roles].'
+  nist_800_53:rev4:SA-5:1:
+    standard:
+      name: nist_800_53:rev4
+    family: SA
+    title: FUNCTIONAL PROPERTIES OF SECURITY CONTROLS
+    description: "[Withdrawn: Incorporated into SA-4 (1)]."
+  nist_800_53:rev4:SA-5:2:
+    standard:
+      name: nist_800_53:rev4
+    family: SA
+    title: SECURITY-RELEVANT EXTERNAL SYSTEM INTERFACES
+    description: "[Withdrawn: Incorporated into SA-4 (2)]."
+  nist_800_53:rev4:SA-5:3:
+    standard:
+      name: nist_800_53:rev4
+    family: SA
+    title: HIGH-LEVEL DESIGN
+    description: "[Withdrawn: Incorporated into SA-4 (2)]."
+  nist_800_53:rev4:SA-5:4:
+    standard:
+      name: nist_800_53:rev4
+    family: SA
+    title: LOW-LEVEL DESIGN
+    description: "[Withdrawn: Incorporated into SA-4 (2)]."
+  nist_800_53:rev4:SA-5:5:
+    standard:
+      name: nist_800_53:rev4
+    family: SA
+    title: SOURCE CODE
+    description: "[Withdrawn: Incorporated into SA-4 (2)]."
+  nist_800_53:rev4:SA-9:a:
+    standard:
+      name: nist_800_53:rev4
+    family: SA
+    title: SA-9a.
+    description: 'Requires that providers of external information system services
+      comply with organizational information security requirements and employ [Assignment:
+      organization-defined security controls] in accordance with applicable federal
+      laws, Executive Orders, directives, policies, regulations, standards, and guidance;'
+  nist_800_53:rev4:SA-9:b:
+    standard:
+      name: nist_800_53:rev4
+    family: SA
+    title: SA-9b.
+    description: Defines and documents government oversight and user roles and responsibilities
+      with regard  to external information system services; and
+  nist_800_53:rev4:SA-9:c:
+    standard:
+      name: nist_800_53:rev4
+    family: SA
+    title: SA-9c.
+    description: 'Employs [Assignment: organization-defined processes, methods, and
+      techniques] to monitor security control compliance by external service providers
+      on an ongoing basis.'
+  nist_800_53:rev4:SA-9:1:
+    standard:
+      name: nist_800_53:rev4
+    family: SA
+    title: RISK ASSESSMENTS / ORGANIZATIONAL APPROVALS
+    description: 'The organization:'
+  nist_800_53:rev4:SA-9:1:a:
+    standard:
+      name: nist_800_53:rev4
+    family: SA
+    title: SA-9 (1)(a)
+    description: Conducts an organizational assessment of risk prior to the acquisition
+      or outsourcing of dedicated information security services; and
+  nist_800_53:rev4:SA-9:1:b:
+    standard:
+      name: nist_800_53:rev4
+    family: SA
+    title: SA-9 (1)(b)
+    description: 'Ensures that the acquisition or outsourcing of dedicated information
+      security services is approved by [Assignment: organization-defined personnel
+      or roles].'
+  nist_800_53:rev4:SA-9:2:
+    standard:
+      name: nist_800_53:rev4
+    family: SA
+    title: IDENTIFICATION OF FUNCTIONS / PORTS / PROTOCOLS / SERVICES
+    description: 'The organization requires providers of [Assignment: organization-defined
+      external information system services] to identify the functions, ports, protocols,
+      and other services required for the use of such services.'
+  nist_800_53:rev4:SA-9:3:
+    standard:
+      name: nist_800_53:rev4
+    family: SA
+    title: ESTABLISH / MAINTAIN TRUST RELATIONSHIP WITH PROVIDERS
+    description: 'The organization establishes, documents, and maintains trust relationships
+      with external service providers based on [Assignment: organization-defined security
+      requirements, properties, factors, or conditions defining acceptable trust relationships].'
+  nist_800_53:rev4:SA-9:4:
+    standard:
+      name: nist_800_53:rev4
+    family: SA
+    title: CONSISTENT INTERESTS OF CONSUMERS AND PROVIDERS
+    description: 'The organization employs [Assignment: organization-defined security
+      safeguards] to ensure that the interests of [Assignment: organization-defined
+      external service providers] are consistent with and reflect organizational interests.'
+  nist_800_53:rev4:SA-9:5:
+    standard:
+      name: nist_800_53:rev4
+    family: SA
+    title: PROCESSING, STORAGE, AND SERVICE LOCATION
+    description: 'The organization restricts the location of [Selection (one or more):
+      information processing; information/data; information system services] to [Assignment:
+      organization-defined locations] based on [Assignment: organization-defined requirements
+      or conditions].'
+  nist_800_53:rev4:SA-10:a:
+    standard:
+      name: nist_800_53:rev4
+    family: SA
+    title: SA-10a.
+    description: 'Perform configuration management during system, component, or service
+      [Selection (one or more): design; development; implementation; operation];'
+  nist_800_53:rev4:SA-10:b:
+    standard:
+      name: nist_800_53:rev4
+    family: SA
+    title: SA-10b.
+    description: 'Document, manage, and control the integrity of changes to [Assignment:
+      organization-defined configuration items under configuration management];'
+  nist_800_53:rev4:SA-10:c:
+    standard:
+      name: nist_800_53:rev4
+    family: SA
+    title: SA-10c.
+    description: Implement only organization-approved changes to the system, component,
+      or service;
+  nist_800_53:rev4:SA-10:d:
+    standard:
+      name: nist_800_53:rev4
+    family: SA
+    title: SA-10d.
+    description: Document approved changes to the system, component, or service and
+      the potential security impacts of such changes; and
+  nist_800_53:rev4:SA-10:e:
+    standard:
+      name: nist_800_53:rev4
+    family: SA
+    title: SA-10e.
+    description: 'Track security flaws and flaw resolution within the system, component,
+      or service and report findings to [Assignment: organization-defined personnel].'
+  nist_800_53:rev4:SA-10:1:
+    standard:
+      name: nist_800_53:rev4
+    family: SA
+    title: SOFTWARE / FIRMWARE INTEGRITY VERIFICATION
+    description: The organization requires the developer of the information system,
+      system component, or information system service to enable integrity verification
+      of software and firmware components.
+  nist_800_53:rev4:SA-10:2:
+    standard:
+      name: nist_800_53:rev4
+    family: SA
+    title: ALTERNATIVE CONFIGURATION MANAGEMENT PROCESSES
+    description: The organization provides an alternate configuration management process
+      using organizational personnel in the absence of a dedicated developer configuration
+      management team.
+  nist_800_53:rev4:SA-10:3:
+    standard:
+      name: nist_800_53:rev4
+    family: SA
+    title: HARDWARE INTEGRITY VERIFICATION
+    description: The organization requires the developer of the information system,
+      system component, or information system service to enable integrity verification
+      of hardware components.
+  nist_800_53:rev4:SA-10:4:
+    standard:
+      name: nist_800_53:rev4
+    family: SA
+    title: TRUSTED GENERATION
+    description: The organization requires the developer of the information system,
+      system component, or information system service to employ tools for comparing
+      newly generated versions of security-relevant hardware descriptions and software/firmware
+      source and object code with previous versions.
+  nist_800_53:rev4:SA-10:5:
+    standard:
+      name: nist_800_53:rev4
+    family: SA
+    title: MAPPING INTEGRITY FOR VERSION CONTROL
+    description: The organization requires the developer of the information system,
+      system component, or information system service to maintain the integrity of
+      the mapping between the  master build data (hardware drawings and software/firmware
+      code) describing the current version of security-relevant hardware, software,
+      and firmware and the on-site master copy of the data for the current version.
+  nist_800_53:rev4:SA-10:6:
+    standard:
+      name: nist_800_53:rev4
+    family: SA
+    title: TRUSTED DISTRIBUTION
+    description: The organization requires the developer of the information system,
+      system component, or information system service to execute procedures for ensuring
+      that security-relevant hardware, software, and firmware updates distributed
+      to the organization are exactly as specified by the master copies.
+  nist_800_53:rev4:SA-11:a:
+    standard:
+      name: nist_800_53:rev4
+    family: SA
+    title: SA-11a.
+    description: Create and implement a security assessment plan;
+  nist_800_53:rev4:SA-11:b:
+    standard:
+      name: nist_800_53:rev4
+    family: SA
+    title: SA-11b.
+    description: 'Perform [Selection (one or more): unit; integration; system; regression]
+      testing/evaluation at [Assignment: organization-defined depth and coverage];'
+  nist_800_53:rev4:SA-11:c:
+    standard:
+      name: nist_800_53:rev4
+    family: SA
+    title: SA-11c.
+    description: Produce evidence of the execution of the security assessment plan
+      and the results of the security testing/evaluation;
+  nist_800_53:rev4:SA-11:d:
+    standard:
+      name: nist_800_53:rev4
+    family: SA
+    title: SA-11d.
+    description: Implement a verifiable flaw remediation process; and
+  nist_800_53:rev4:SA-11:e:
+    standard:
+      name: nist_800_53:rev4
+    family: SA
+    title: SA-11e.
+    description: Correct flaws identified during security testing/evaluation.
+  nist_800_53:rev4:SA-11:1:
+    standard:
+      name: nist_800_53:rev4
+    family: SA
+    title: STATIC CODE ANALYSIS
+    description: The organization requires the developer of the information system,
+      system component, or information system service to employ static code analysis
+      tools to identify common flaws and document the results of the analysis.
+  nist_800_53:rev4:SA-11:2:
+    standard:
+      name: nist_800_53:rev4
+    family: SA
+    title: THREAT AND VULNERABILITY ANALYSES
+    description: The organization requires the developer of the information system,
+      system component, or information system service to perform threat and vulnerability
+      analyses and subsequent testing/evaluation of the as-built system, component,
+      or service.
+  nist_800_53:rev4:SA-11:3:
+    standard:
+      name: nist_800_53:rev4
+    family: SA
+    title: INDEPENDENT VERIFICATION OF ASSESSMENT PLANS / EVIDENCE
+    description: 'The organization:'
+  nist_800_53:rev4:SA-11:3:a:
+    standard:
+      name: nist_800_53:rev4
+    family: SA
+    title: SA-11 (3)(a)
+    description: 'Requires an independent agent satisfying [Assignment: organization-defined
+      independence criteria] to verify the correct implementation of the developer
+      security assessment plan and the evidence produced during security testing/evaluation;
+      and'
+  nist_800_53:rev4:SA-11:3:b:
+    standard:
+      name: nist_800_53:rev4
+    family: SA
+    title: SA-11 (3)(b)
+    description: Ensures that the independent agent is either provided with sufficient
+      information to complete the verification process or granted the authority to
+      obtain such information.
+  nist_800_53:rev4:SA-11:4:
+    standard:
+      name: nist_800_53:rev4
+    family: SA
+    title: MANUAL CODE REVIEWS
+    description: 'The organization requires the developer of the information system,
+      system component, or information system service to perform a manual code review
+      of [Assignment: organization-defined specific code] using [Assignment: organization-defined
+      processes, procedures, and/or techniques].'
+  nist_800_53:rev4:SA-11:5:
+    standard:
+      name: nist_800_53:rev4
+    family: SA
+    title: PENETRATION TESTING
+    description: 'The organization requires the developer of the information system,
+      system component, or information system service to perform penetration testing
+      at [Assignment: organization-defined breadth/depth] and with [Assignment: organization-defined
+      constraints].'
+  nist_800_53:rev4:SA-11:6:
+    standard:
+      name: nist_800_53:rev4
+    family: SA
+    title: ATTACK SURFACE REVIEWS
+    description: The organization requires the developer of the information system,
+      system component, or information system service to perform attack surface reviews.
+  nist_800_53:rev4:SA-11:7:
+    standard:
+      name: nist_800_53:rev4
+    family: SA
+    title: VERIFY SCOPE OF TESTING / EVALUATION
+    description: 'The organization requires the developer of the information system,
+      system component, or information system service to verify that the scope of
+      security testing/evaluation provides complete coverage of required security
+      controls at [Assignment: organization-defined depth of testing/evaluation].'
+  nist_800_53:rev4:SA-11:8:
+    standard:
+      name: nist_800_53:rev4
+    family: SA
+    title: DYNAMIC CODE ANALYSIS
+    description: The organization requires the developer of the information system,
+      system component, or information system service to employ dynamic code analysis
+      tools to identify common flaws and document the results of the analysis.
+  nist_800_53:rev4:SA-12:1:
+    standard:
+      name: nist_800_53:rev4
+    family: SA
+    title: ACQUISITION STRATEGIES / TOOLS / METHODS
+    description: 'The organization employs [Assignment: organization-defined tailored
+      acquisition strategies, contract tools, and procurement methods] for the purchase
+      of the information system, system component, or information system service from
+      suppliers.'
+  nist_800_53:rev4:SA-12:2:
+    standard:
+      name: nist_800_53:rev4
+    family: SA
+    title: SUPPLIER REVIEWS
+    description: The organization conducts a supplier review prior to entering into
+      a contractual agreement to acquire the information system, system component,
+      or information system service.
+  nist_800_53:rev4:SA-12:3:
+    standard:
+      name: nist_800_53:rev4
+    family: SA
+    title: TRUSTED SHIPPING AND WAREHOUSING
+    description: "[Withdrawn: Incorporated into SA-12 (1)]."
+  nist_800_53:rev4:SA-12:4:
+    standard:
+      name: nist_800_53:rev4
+    family: SA
+    title: DIVERSITY OF SUPPLIERS
+    description: "[Withdrawn: Incorporated into SA-12 (13)]."
+  nist_800_53:rev4:SA-12:5:
+    standard:
+      name: nist_800_53:rev4
+    family: SA
+    title: LIMITATION OF HARM
+    description: 'The organization employs [Assignment: organization-defined security
+      safeguards] to limit harm from potential adversaries identifying and targeting
+      the organizational supply chain.'
+  nist_800_53:rev4:SA-12:6:
+    standard:
+      name: nist_800_53:rev4
+    family: SA
+    title: MINIMIZING PROCUREMENT TIME
+    description: "[Withdrawn: Incorporated into SA-12 (1)]."
+  nist_800_53:rev4:SA-12:7:
+    standard:
+      name: nist_800_53:rev4
+    family: SA
+    title: ASSESSMENTS PRIOR TO SELECTION / ACCEPTANCE / UPDATE
+    description: The organization conducts an assessment of the information system,
+      system component, or information system service prior to selection, acceptance,
+      or update.
+  nist_800_53:rev4:SA-12:8:
+    standard:
+      name: nist_800_53:rev4
+    family: SA
+    title: USE OF ALL-SOURCE INTELLIGENCE
+    description: The organization uses all-source intelligence analysis of suppliers
+      and potential suppliers of the information system, system component, or information
+      system service.
+  nist_800_53:rev4:SA-12:9:
+    standard:
+      name: nist_800_53:rev4
+    family: SA
+    title: OPERATIONS SECURITY
+    description: 'The organization employs [Assignment: organization-defined Operations
+      Security (OPSEC) safeguards] in accordance with classification guides to protect
+      supply chain-related information for the information system, system component,
+      or information system service.'
+  nist_800_53:rev4:SA-12:10:
+    standard:
+      name: nist_800_53:rev4
+    family: SA
+    title: VALIDATE AS GENUINE AND NOT ALTERED
+    description: 'The organization employs [Assignment: organization-defined security
+      safeguards] to validate that the information system or system component received
+      is genuine and has not been altered.'
+  nist_800_53:rev4:SA-12:11:
+    standard:
+      name: nist_800_53:rev4
+    family: SA
+    title: PENETRATION TESTING / ANALYSIS OF ELEMENTS, PROCESSES, AND ACTORS
+    description: 'The organization employs [Selection (one or more): organizational
+      analysis, independent third-party analysis, organizational penetration testing,
+      independent third-party penetration testing] of [Assignment: organization-defined
+      supply chain elements, processes, and actors] associated with the information
+      system, system component, or information system service.'
+  nist_800_53:rev4:SA-12:12:
+    standard:
+      name: nist_800_53:rev4
+    family: SA
+    title: INTER-ORGANIZATIONAL AGREEMENTS
+    description: The organization establishes inter-organizational agreements and
+      procedures with entities involved in the supply chain for the information system,
+      system component, or information system service.
+  nist_800_53:rev4:SA-12:13:
+    standard:
+      name: nist_800_53:rev4
+    family: SA
+    title: CRITICAL INFORMATION SYSTEM COMPONENTS
+    description: 'The organization employs [Assignment: organization-defined security
+      safeguards] to ensure an adequate supply of [Assignment: organization-defined
+      critical information system components].'
+  nist_800_53:rev4:SA-12:14:
+    standard:
+      name: nist_800_53:rev4
+    family: SA
+    title: IDENTITY AND TRACEABILITY
+    description: 'The organization establishes and retains unique identification of
+      [Assignment: organization-defined supply chain elements, processes, and actors]
+      for the information system, system component, or information system service.'
+  nist_800_53:rev4:SA-12:15:
+    standard:
+      name: nist_800_53:rev4
+    family: SA
+    title: PROCESSES TO ADDRESS WEAKNESSES OR DEFICIENCIES
+    description: The organization establishes a process to address weaknesses or deficiencies
+      in supply chain elements identified during independent or organizational assessments
+      of such elements.
+  nist_800_53:rev4:SA-13:a:
+    standard:
+      name: nist_800_53:rev4
+    family: SA
+    title: SA-13a.
+    description: 'Describes the trustworthiness required in the [Assignment: organization-defined
+      information system, information system component, or information system service]
+      supporting its critical missions/business functions; and'
+  nist_800_53:rev4:SA-13:b:
+    standard:
+      name: nist_800_53:rev4
+    family: SA
+    title: SA-13b.
+    description: 'Implements [Assignment: organization-defined assurance overlay]
+      to achieve such trustworthiness.'
+  nist_800_53:rev4:SA-14:1:
+    standard:
+      name: nist_800_53:rev4
+    family: SA
+    title: CRITICAL COMPONENTS WITH  NO VIABLE ALTERNATIVE SOURCING
+    description: "[Withdrawn: Incorporated into SA-20]."
+  nist_800_53:rev4:SA-15:a:
+    standard:
+      name: nist_800_53:rev4
+    family: SA
+    title: SA-15a.
+    description: 'Requires the developer of the information system, system component,
+      or information system service to follow a documented development process that:'
+  nist_800_53:rev4:SA-15:a:1:
+    standard:
+      name: nist_800_53:rev4
+    family: SA
+    title: SA-15a.1.
+    description: Explicitly addresses security requirements;
+  nist_800_53:rev4:SA-15:a:2:
+    standard:
+      name: nist_800_53:rev4
+    family: SA
+    title: SA-15a.2.
+    description: Identifies the standards and tools used in the development process;
+  nist_800_53:rev4:SA-15:a:3:
+    standard:
+      name: nist_800_53:rev4
+    family: SA
+    title: SA-15a.3.
+    description: Documents the specific tool options and tool configurations used
+      in the development process; and
+  nist_800_53:rev4:SA-15:a:4:
+    standard:
+      name: nist_800_53:rev4
+    family: SA
+    title: SA-15a.4.
+    description: Documents, manages, and ensures the integrity of changes to the process
+      and/or tools used in development; and
+  nist_800_53:rev4:SA-15:b:
+    standard:
+      name: nist_800_53:rev4
+    family: SA
+    title: SA-15b.
+    description: 'Reviews the development process, standards, tools, and tool options/configurations
+      [Assignment: organization-defined frequency] to determine if the process, standards,
+      tools, and tool options/configurations selected and employed can satisfy [Assignment:
+      organization-defined security requirements].'
+  nist_800_53:rev4:SA-15:1:
+    standard:
+      name: nist_800_53:rev4
+    family: SA
+    title: QUALITY METRICS
+    description: 'The organization requires the developer of the information system,
+      system component, or information system service to:'
+  nist_800_53:rev4:SA-15:1:a:
+    standard:
+      name: nist_800_53:rev4
+    family: SA
+    title: SA-15 (1)(a)
+    description: Define quality metrics at the beginning of the development process;
+      and
+  nist_800_53:rev4:SA-15:1:b:
+    standard:
+      name: nist_800_53:rev4
+    family: SA
+    title: SA-15 (1)(b)
+    description: 'Provide evidence of meeting the quality metrics [Selection (one
+      or more): [Assignment: organization-defined frequency]; [Assignment: organization-defined
+      program review milestones]; upon delivery].'
+  nist_800_53:rev4:SA-15:2:
+    standard:
+      name: nist_800_53:rev4
+    family: SA
+    title: SECURITY TRACKING TOOLS
+    description: The organization requires the developer of the information system,
+      system component, or information system service to select and employ a security
+      tracking tool for use during the development process.
+  nist_800_53:rev4:SA-15:3:
+    standard:
+      name: nist_800_53:rev4
+    family: SA
+    title: CRITICALITY ANALYSIS
+    description: 'The organization requires the developer of the information system,
+      system component, or information system service to perform a criticality analysis
+      at [Assignment: organization-defined breadth/depth] and at [Assignment: organization-defined
+      decision points in the system development life cycle].'
+  nist_800_53:rev4:SA-15:4:
+    standard:
+      name: nist_800_53:rev4
+    family: SA
+    title: THREAT MODELING / VULNERABILITY ANALYSIS
+    description: 'The organization requires that developers perform threat modeling
+      and a vulnerability analysis for the information system at [Assignment: organization-defined
+      breadth/depth] that:'
+  nist_800_53:rev4:SA-15:4:a:
+    standard:
+      name: nist_800_53:rev4
+    family: SA
+    title: SA-15 (4)(a)
+    description: 'Uses [Assignment: organization-defined information concerning impact,
+      environment of operations, known or assumed threats, and acceptable risk levels];'
+  nist_800_53:rev4:SA-15:4:b:
+    standard:
+      name: nist_800_53:rev4
+    family: SA
+    title: SA-15 (4)(b)
+    description: 'Employs [Assignment: organization-defined tools and methods]; and'
+  nist_800_53:rev4:SA-15:4:c:
+    standard:
+      name: nist_800_53:rev4
+    family: SA
+    title: SA-15 (4)(c)
+    description: 'Produces evidence that meets [Assignment: organization-defined acceptance
+      criteria].'
+  nist_800_53:rev4:SA-15:5:
+    standard:
+      name: nist_800_53:rev4
+    family: SA
+    title: ATTACK SURFACE REDUCTION
+    description: 'The organization requires the developer of the information system,
+      system component, or information system service to reduce attack surfaces to
+      [Assignment: organization-defined thresholds].'
+  nist_800_53:rev4:SA-15:6:
+    standard:
+      name: nist_800_53:rev4
+    family: SA
+    title: CONTINUOUS IMPROVEMENT
+    description: The organization requires the developer of the information system,
+      system component, or information system service to implement an explicit process
+      to continuously improve the development process.
+  nist_800_53:rev4:SA-15:7:
+    standard:
+      name: nist_800_53:rev4
+    family: SA
+    title: AUTOMATED VULNERABILITY ANALYSIS
+    description: 'The organization requires the developer of the information system,
+      system component, or information system service to:'
+  nist_800_53:rev4:SA-15:7:a:
+    standard:
+      name: nist_800_53:rev4
+    family: SA
+    title: SA-15 (7)(a)
+    description: 'Perform an automated vulnerability analysis using [Assignment: organization-defined
+      tools];'
+  nist_800_53:rev4:SA-15:7:b:
+    standard:
+      name: nist_800_53:rev4
+    family: SA
+    title: SA-15 (7)(b)
+    description: Determine the exploitation potential for discovered vulnerabilities;
+  nist_800_53:rev4:SA-15:7:c:
+    standard:
+      name: nist_800_53:rev4
+    family: SA
+    title: SA-15 (7)(c)
+    description: Determine potential risk mitigations for delivered vulnerabilities;
+      and
+  nist_800_53:rev4:SA-15:7:d:
+    standard:
+      name: nist_800_53:rev4
+    family: SA
+    title: SA-15 (7)(d)
+    description: 'Deliver the outputs of the tools and results of the analysis to
+      [Assignment: organization-defined personnel or roles].'
+  nist_800_53:rev4:SA-15:8:
+    standard:
+      name: nist_800_53:rev4
+    family: SA
+    title: REUSE OF THREAT / VULNERABILITY INFORMATION
+    description: The organization requires the developer of the information system,
+      system component, or information system service to use threat modeling and vulnerability
+      analyses from similar systems, components, or services to inform the current
+      development process.
+  nist_800_53:rev4:SA-15:9:
+    standard:
+      name: nist_800_53:rev4
+    family: SA
+    title: USE OF LIVE DATA
+    description: The organization approves, documents, and controls the use of live
+      data in development and test environments for the information system, system
+      component, or information system service.
+  nist_800_53:rev4:SA-15:10:
+    standard:
+      name: nist_800_53:rev4
+    family: SA
+    title: INCIDENT RESPONSE PLAN
+    description: The organization requires the developer of the information system,
+      system component, or information system service to provide an incident response
+      plan.
+  nist_800_53:rev4:SA-15:11:
+    standard:
+      name: nist_800_53:rev4
+    family: SA
+    title: ARCHIVE INFORMATION SYSTEM / COMPONENT
+    description: The organization requires the developer of the information system
+      or system component to archive the system or component to be released or delivered
+      together with the corresponding evidence supporting the final security review.
+  nist_800_53:rev4:SA-17:a:
+    standard:
+      name: nist_800_53:rev4
+    family: SA
+    title: SA-17a.
+    description: Is consistent with and supportive of the organization�s security
+      architecture which is established within and is an integrated part of the organization�s
+      enterprise architecture;
+  nist_800_53:rev4:SA-17:b:
+    standard:
+      name: nist_800_53:rev4
+    family: SA
+    title: SA-17b.
+    description: Accurately and completely describes the required security functionality,
+      and the allocation of security controls among physical and logical components;
+      and
+  nist_800_53:rev4:SA-17:c:
+    standard:
+      name: nist_800_53:rev4
+    family: SA
+    title: SA-17c.
+    description: Expresses how individual security functions, mechanisms, and services
+      work together to provide required security capabilities and a unified approach
+      to protection.
+  nist_800_53:rev4:SA-17:1:
+    standard:
+      name: nist_800_53:rev4
+    family: SA
+    title: FORMAL POLICY MODEL
+    description: 'The organization requires the developer of the information system,
+      system component, or information system service to:'
+  nist_800_53:rev4:SA-17:1:a:
+    standard:
+      name: nist_800_53:rev4
+    family: SA
+    title: SA-17 (1)(a)
+    description: 'Produce, as an integral part of the development process, a formal
+      policy model describing the [Assignment: organization-defined elements of organizational
+      security policy] to be enforced; and'
+  nist_800_53:rev4:SA-17:1:b:
+    standard:
+      name: nist_800_53:rev4
+    family: SA
+    title: SA-17 (1)(b)
+    description: Prove that the formal policy model is internally consistent and sufficient
+      to enforce the defined elements of the organizational security policy when implemented.
+  nist_800_53:rev4:SA-17:2:
+    standard:
+      name: nist_800_53:rev4
+    family: SA
+    title: SECURITY-RELEVANT COMPONENTS
+    description: 'The organization requires the developer of the information system,
+      system component, or information system service to:'
+  nist_800_53:rev4:SA-17:2:a:
+    standard:
+      name: nist_800_53:rev4
+    family: SA
+    title: SA-17 (2)(a)
+    description: Define security-relevant hardware, software, and firmware; and
+  nist_800_53:rev4:SA-17:2:b:
+    standard:
+      name: nist_800_53:rev4
+    family: SA
+    title: SA-17 (2)(b)
+    description: Provide a rationale that the definition for security-relevant hardware,
+      software, and firmware is complete.
+  nist_800_53:rev4:SA-17:3:
+    standard:
+      name: nist_800_53:rev4
+    family: SA
+    title: FORMAL CORRESPONDENCE
+    description: 'The organization requires the developer of the information system,
+      system component, or information system service to:'
+  nist_800_53:rev4:SA-17:3:a:
+    standard:
+      name: nist_800_53:rev4
+    family: SA
+    title: SA-17 (3)(a)
+    description: Produce, as an integral part of the development process, a formal
+      top-level specification that specifies the interfaces to security-relevant hardware,
+      software, and firmware in terms of exceptions, error messages, and effects;
+  nist_800_53:rev4:SA-17:3:b:
+    standard:
+      name: nist_800_53:rev4
+    family: SA
+    title: SA-17 (3)(b)
+    description: Show via proof to the extent feasible with additional informal demonstration
+      as necessary, that the formal top-level specification is consistent with the
+      formal policy model;
+  nist_800_53:rev4:SA-17:3:c:
+    standard:
+      name: nist_800_53:rev4
+    family: SA
+    title: SA-17 (3)(c)
+    description: Show via informal demonstration, that the formal top-level specification
+      completely covers the interfaces to security-relevant hardware, software, and
+      firmware;
+  nist_800_53:rev4:SA-17:3:d:
+    standard:
+      name: nist_800_53:rev4
+    family: SA
+    title: SA-17 (3)(d)
+    description: Show that the formal top-level specification is an accurate description
+      of the implemented security-relevant hardware, software, and firmware; and
+  nist_800_53:rev4:SA-17:3:e:
+    standard:
+      name: nist_800_53:rev4
+    family: SA
+    title: SA-17 (3)(e)
+    description: Describe the security-relevant hardware, software, and firmware mechanisms
+      not addressed in the formal top-level specification but strictly internal to
+      the security-relevant hardware, software, and firmware.
+  nist_800_53:rev4:SA-17:4:
+    standard:
+      name: nist_800_53:rev4
+    family: SA
+    title: INFORMAL CORRESPONDENCE
+    description: 'The organization requires the developer of the information system,
+      system component, or information system service to:'
+  nist_800_53:rev4:SA-17:4:a:
+    standard:
+      name: nist_800_53:rev4
+    family: SA
+    title: SA-17 (4)(a)
+    description: Produce, as an integral part of the development process, an informal
+      descriptive top-level specification that specifies the interfaces to security-relevant
+      hardware, software, and firmware in terms of exceptions, error messages, and
+      effects;
+  nist_800_53:rev4:SA-17:4:b:
+    standard:
+      name: nist_800_53:rev4
+    family: SA
+    title: SA-17 (4)(b)
+    description: 'Show via [Selection: informal demonstration, convincing argument
+      with formal methods as feasible] that the descriptive top-level specification
+      is consistent with the formal policy model;'
+  nist_800_53:rev4:SA-17:4:c:
+    standard:
+      name: nist_800_53:rev4
+    family: SA
+    title: SA-17 (4)(c)
+    description: Show via informal demonstration, that the descriptive top-level specification
+      completely  covers the interfaces to security-relevant hardware, software, and
+      firmware;
+  nist_800_53:rev4:SA-17:4:d:
+    standard:
+      name: nist_800_53:rev4
+    family: SA
+    title: SA-17 (4)(d)
+    description: Show that the descriptive top-level specification is an accurate
+      description of the interfaces to security-relevant hardware, software, and firmware;
+      and
+  nist_800_53:rev4:SA-17:4:e:
+    standard:
+      name: nist_800_53:rev4
+    family: SA
+    title: SA-17 (4)(e)
+    description: Describe the security-relevant hardware, software, and firmware mechanisms
+      not addressed in the descriptive top-level specification but strictly internal
+      to the security-relevant hardware, software, and firmware.
+  nist_800_53:rev4:SA-17:5:
+    standard:
+      name: nist_800_53:rev4
+    family: SA
+    title: CONCEPTUALLY SIMPLE DESIGN
+    description: 'The organization requires the developer of the information system,
+      system component, or information system service to:'
+  nist_800_53:rev4:SA-17:5:a:
+    standard:
+      name: nist_800_53:rev4
+    family: SA
+    title: SA-17 (5)(a)
+    description: Design and structure the security-relevant hardware, software, and
+      firmware to use a complete, conceptually simple protection mechanism with precisely
+      defined semantics; and
+  nist_800_53:rev4:SA-17:5:b:
+    standard:
+      name: nist_800_53:rev4
+    family: SA
+    title: SA-17 (5)(b)
+    description: Internally structure the security-relevant hardware, software, and
+      firmware with specific regard for this mechanism.
+  nist_800_53:rev4:SA-17:6:
+    standard:
+      name: nist_800_53:rev4
+    family: SA
+    title: STRUCTURE FOR TESTING
+    description: The organization requires the developer of the information system,
+      system component, or information system service to structure security-relevant
+      hardware, software, and firmware to facilitate testing.
+  nist_800_53:rev4:SA-17:7:
+    standard:
+      name: nist_800_53:rev4
+    family: SA
+    title: STRUCTURE FOR LEAST PRIVILEGE
+    description: The organization requires the developer of the information system,
+      system component, or information system service to structure security-relevant
+      hardware, software, and firmware to facilitate controlling access with least
+      privilege.
+  nist_800_53:rev4:SA-18:1:
+    standard:
+      name: nist_800_53:rev4
+    family: SA
+    title: MULTIPLE PHASES OF SDLC
+    description: The organization employs anti-tamper technologies and techniques
+      during multiple phases in the system development life cycle including design,
+      development, integration, operations, and maintenance.
+  nist_800_53:rev4:SA-18:2:
+    standard:
+      name: nist_800_53:rev4
+    family: SA
+    title: INSPECTION OF INFORMATION SYSTEMS, COMPONENTS, OR DEVICES
+    description: 'The organization inspects [Assignment: organization-defined information
+      systems, system components, or devices] [Selection (one or more): at random;
+      at [Assignment: organization-defined frequency], upon [Assignment: organization-defined
+      indications of need for inspection]] to detect tampering.'
+  nist_800_53:rev4:SA-19:a:
+    standard:
+      name: nist_800_53:rev4
+    family: SA
+    title: SA-19a.
+    description: Develops and implements anti-counterfeit policy and procedures that
+      include the means to detect and prevent counterfeit components from entering
+      the information system; and
+  nist_800_53:rev4:SA-19:b:
+    standard:
+      name: nist_800_53:rev4
+    family: SA
+    title: SA-19b.
+    description: 'Reports counterfeit information system components to [Selection
+      (one or more): source of counterfeit component; [Assignment: organization-defined
+      external reporting organizations]; [Assignment: organization-defined personnel
+      or roles]].'
+  nist_800_53:rev4:SA-19:1:
+    standard:
+      name: nist_800_53:rev4
+    family: SA
+    title: ANTI-COUNTERFEIT TRAINING
+    description: 'The organization trains [Assignment: organization-defined personnel
+      or roles] to detect counterfeit information system components (including hardware,
+      software, and firmware).'
+  nist_800_53:rev4:SA-19:2:
+    standard:
+      name: nist_800_53:rev4
+    family: SA
+    title: CONFIGURATION CONTROL FOR COMPONENT SERVICE / REPAIR
+    description: 'The organization maintains configuration control over [Assignment:
+      organization-defined information system components] awaiting service/repair
+      and serviced/repaired components awaiting return to service.'
+  nist_800_53:rev4:SA-19:3:
+    standard:
+      name: nist_800_53:rev4
+    family: SA
+    title: COMPONENT DISPOSAL
+    description: 'The organization disposes of information system components using
+      [Assignment: organization-defined techniques and methods].'
+  nist_800_53:rev4:SA-19:4:
+    standard:
+      name: nist_800_53:rev4
+    family: SA
+    title: ANTI-COUNTERFEIT SCANNING
+    description: 'The organization scans for counterfeit information system components
+      [Assignment: organization-defined frequency].'
+  nist_800_53:rev4:SA-21:a:
+    standard:
+      name: nist_800_53:rev4
+    family: SA
+    title: SA-21a.
+    description: 'Have appropriate access authorizations as determined by assigned
+      [Assignment: organization-defined official government duties]; and'
+  nist_800_53:rev4:SA-21:b:
+    standard:
+      name: nist_800_53:rev4
+    family: SA
+    title: SA-21b.
+    description: 'Satisfy [Assignment: organization-defined additional personnel screening
+      criteria].'
+  nist_800_53:rev4:SA-21:1:
+    standard:
+      name: nist_800_53:rev4
+    family: SA
+    title: VALIDATION OF SCREENING
+    description: 'The organization requires the developer of the information system,
+      system component, or information system service take [Assignment: organization-defined
+      actions] to ensure that the required access authorizations and screening criteria
+      are satisfied.'
+  nist_800_53:rev4:SA-22:a:
+    standard:
+      name: nist_800_53:rev4
+    family: SA
+    title: SA-22a.
+    description: Replaces information system components when support for the components
+      is no longer available from the developer, vendor, or manufacturer; and
+  nist_800_53:rev4:SA-22:b:
+    standard:
+      name: nist_800_53:rev4
+    family: SA
+    title: SA-22b.
+    description: Provides justification and documents approval for the continued use
+      of unsupported system components required to satisfy mission/business needs.
+  nist_800_53:rev4:SA-22:1:
+    standard:
+      name: nist_800_53:rev4
+    family: SA
+    title: ALTERNATIVE SOURCES FOR CONTINUED SUPPORT
+    description: 'The organization provides [Selection (one or more): in-house support;
+      [Assignment: organization-defined support from external providers]] for unsupported
+      information system components.'
+  nist_800_53:rev4:SC-1:a:
+    standard:
+      name: nist_800_53:rev4
+    family: SC
+    title: SC-1a.
+    description: 'Develops, documents, and disseminates to [Assignment: organization-defined
+      personnel or roles]:'
+  nist_800_53:rev4:SC-1:a:1:
+    standard:
+      name: nist_800_53:rev4
+    family: SC
+    title: SC-1a.1.
+    description: A system and communications protection policy that addresses purpose,
+      scope, roles, responsibilities, management commitment, coordination among organizational
+      entities, and compliance; and
+  nist_800_53:rev4:SC-1:a:2:
+    standard:
+      name: nist_800_53:rev4
+    family: SC
+    title: SC-1a.2.
+    description: Procedures to facilitate the implementation of the system and communications
+      protection policy and associated system and communications protection controls;
+      and
+  nist_800_53:rev4:SC-1:b:
+    standard:
+      name: nist_800_53:rev4
+    family: SC
+    title: SC-1b.
+    description: 'Reviews and updates the current:'
+  nist_800_53:rev4:SC-1:b:1:
+    standard:
+      name: nist_800_53:rev4
+    family: SC
+    title: SC-1b.1.
+    description: 'System and communications protection policy [Assignment: organization-defined
+      frequency]; and'
+  nist_800_53:rev4:SC-1:b:2:
+    standard:
+      name: nist_800_53:rev4
+    family: SC
+    title: SC-1b.2.
+    description: 'System and communications protection procedures [Assignment: organization-defined
+      frequency].'
+  nist_800_53:rev4:SC-2:1:
+    standard:
+      name: nist_800_53:rev4
+    family: SC
+    title: INTERFACES FOR NON-PRIVILEGED USERS
+    description: The information system prevents the presentation of information system
+      management-related functionality at an interface for non-privileged users.
+  nist_800_53:rev4:SC-3:1:
+    standard:
+      name: nist_800_53:rev4
+    family: SC
+    title: HARDWARE SEPARATION
+    description: The information system utilizes underlying hardware separation mechanisms
+      to implement security function isolation.
+  nist_800_53:rev4:SC-3:2:
+    standard:
+      name: nist_800_53:rev4
+    family: SC
+    title: ACCESS / FLOW CONTROL FUNCTIONS
+    description: The information system isolates security functions enforcing access
+      and information flow control from nonsecurity functions and from other security
+      functions.
+  nist_800_53:rev4:SC-3:3:
+    standard:
+      name: nist_800_53:rev4
+    family: SC
+    title: MINIMIZE NONSECURITY FUNCTIONALITY
+    description: The organization minimizes the number of nonsecurity functions included
+      within the isolation boundary containing security functions.
+  nist_800_53:rev4:SC-3:4:
+    standard:
+      name: nist_800_53:rev4
+    family: SC
+    title: MODULE COUPLING AND COHESIVENESS
+    description: The organization implements security functions as largely independent
+      modules that maximize internal cohesiveness within modules and minimize coupling
+      between modules.
+  nist_800_53:rev4:SC-3:5:
+    standard:
+      name: nist_800_53:rev4
+    family: SC
+    title: LAYERED STRUCTURES
+    description: The organization implements security functions as a layered structure
+      minimizing interactions between layers of the design and avoiding any dependence
+      by lower layers on the functionality or correctness of higher layers.
+  nist_800_53:rev4:SC-4:1:
+    standard:
+      name: nist_800_53:rev4
+    family: SC
+    title: SECURITY LEVELS
+    description: "[Withdrawn: Incorporated into SC-4]."
+  nist_800_53:rev4:SC-4:2:
+    standard:
+      name: nist_800_53:rev4
+    family: SC
+    title: PERIODS PROCESSING
+    description: 'The information system prevents unauthorized information transfer
+      via shared resources in accordance with [Assignment: organization-defined procedures]
+      when system processing explicitly switches between different information classification
+      levels or security categories.'
+  nist_800_53:rev4:SC-5:1:
+    standard:
+      name: nist_800_53:rev4
+    family: SC
+    title: RESTRICT INTERNAL USERS
+    description: 'The information system restricts the ability of individuals to launch
+      [Assignment: organization-defined denial of service attacks] against other information
+      systems.'
+  nist_800_53:rev4:SC-5:2:
+    standard:
+      name: nist_800_53:rev4
+    family: SC
+    title: EXCESS CAPACITY / BANDWIDTH / REDUNDANCY
+    description: The information system manages excess capacity, bandwidth, or other
+      redundancy to limit the effects of information flooding denial of service attacks.
+  nist_800_53:rev4:SC-5:3:
+    standard:
+      name: nist_800_53:rev4
+    family: SC
+    title: DETECTION / MONITORING
+    description: 'The organization:'
+  nist_800_53:rev4:SC-5:3:a:
+    standard:
+      name: nist_800_53:rev4
+    family: SC
+    title: SC-5 (3)(a)
+    description: 'Employs [Assignment: organization-defined monitoring tools] to detect
+      indicators of denial of service attacks against the information system; and'
+  nist_800_53:rev4:SC-5:3:b:
+    standard:
+      name: nist_800_53:rev4
+    family: SC
+    title: SC-5 (3)(b)
+    description: 'Monitors [Assignment: organization-defined information system resources]
+      to determine if sufficient resources exist to prevent effective denial of service
+      attacks.'
+  nist_800_53:rev4:SC-7:a:
+    standard:
+      name: nist_800_53:rev4
+    family: SC
+    title: SC-7a.
+    description: Monitors and controls communications at the external boundary of
+      the system and at key internal boundaries within the system;
+  nist_800_53:rev4:SC-7:b:
+    standard:
+      name: nist_800_53:rev4
+    family: SC
+    title: SC-7b.
+    description: 'Implements subnetworks for publicly accessible system components
+      that are [Selection: physically; logically] separated from internal organizational
+      networks; and'
+  nist_800_53:rev4:SC-7:c:
+    standard:
+      name: nist_800_53:rev4
+    family: SC
+    title: SC-7c.
+    description: Connects to external networks or information systems only through
+      managed interfaces consisting of boundary protection devices arranged in accordance
+      with an organizational security architecture.
+  nist_800_53:rev4:SC-7:1:
+    standard:
+      name: nist_800_53:rev4
+    family: SC
+    title: PHYSICALLY SEPARATED SUBNETWORKS
+    description: "[Withdrawn: Incorporated into SC-7]."
+  nist_800_53:rev4:SC-7:2:
+    standard:
+      name: nist_800_53:rev4
+    family: SC
+    title: PUBLIC ACCESS
+    description: "[Withdrawn: Incorporated into SC-7]."
+  nist_800_53:rev4:SC-7:3:
+    standard:
+      name: nist_800_53:rev4
+    family: SC
+    title: ACCESS POINTS
+    description: The organization limits the number of external network connections
+      to the information system.
+  nist_800_53:rev4:SC-7:4:
+    standard:
+      name: nist_800_53:rev4
+    family: SC
+    title: EXTERNAL TELECOMMUNICATIONS SERVICES
+    description: 'The organization:'
+  nist_800_53:rev4:SC-7:4:a:
+    standard:
+      name: nist_800_53:rev4
+    family: SC
+    title: SC-7 (4)(a)
+    description: Implements a managed interface for each external telecommunication
+      service;
+  nist_800_53:rev4:SC-7:4:b:
+    standard:
+      name: nist_800_53:rev4
+    family: SC
+    title: SC-7 (4)(b)
+    description: Establishes a traffic flow policy for each managed interface;
+  nist_800_53:rev4:SC-7:4:c:
+    standard:
+      name: nist_800_53:rev4
+    family: SC
+    title: SC-7 (4)(c)
+    description: Protects the confidentiality and integrity of the information being
+      transmitted across each interface;
+  nist_800_53:rev4:SC-7:4:d:
+    standard:
+      name: nist_800_53:rev4
+    family: SC
+    title: SC-7 (4)(d)
+    description: Documents each exception to the traffic flow policy with a supporting
+      mission/business need and duration of that need; and
+  nist_800_53:rev4:SC-7:4:e:
+    standard:
+      name: nist_800_53:rev4
+    family: SC
+    title: SC-7 (4)(e)
+    description: 'Reviews exceptions to the traffic flow policy [Assignment: organization-defined
+      frequency] and removes exceptions that are no longer supported by an explicit
+      mission/business need.'
+  nist_800_53:rev4:SC-7:5:
+    standard:
+      name: nist_800_53:rev4
+    family: SC
+    title: DENY BY DEFAULT / ALLOW BY EXCEPTION
+    description: The information system at managed interfaces denies network communications
+      traffic by default and allows network communications traffic by exception (i.e.,
+      deny all, permit by exception).
+  nist_800_53:rev4:SC-7:6:
+    standard:
+      name: nist_800_53:rev4
+    family: SC
+    title: RESPONSE TO RECOGNIZED FAILURES
+    description: "[Withdrawn: Incorporated into SC-7 (18)]."
+  nist_800_53:rev4:SC-7:7:
+    standard:
+      name: nist_800_53:rev4
+    family: SC
+    title: PREVENT SPLIT TUNNELING FOR REMOTE DEVICES
+    description: The information system, in conjunction with a remote device, prevents
+      the device from simultaneously establishing non-remote connections with the
+      system and communicating via some other connection to resources in external
+      networks.
+  nist_800_53:rev4:SC-7:8:
+    standard:
+      name: nist_800_53:rev4
+    family: SC
+    title: ROUTE TRAFFIC TO AUTHENTICATED PROXY SERVERS
+    description: 'The information system routes [Assignment: organization-defined
+      internal communications traffic] to [Assignment: organization-defined external
+      networks] through authenticated proxy servers at managed interfaces.'
+  nist_800_53:rev4:SC-7:9:
+    standard:
+      name: nist_800_53:rev4
+    family: SC
+    title: RESTRICT THREATENING OUTGOING COMMUNICATIONS TRAFFIC
+    description: 'The information system:'
+  nist_800_53:rev4:SC-7:9:a:
+    standard:
+      name: nist_800_53:rev4
+    family: SC
+    title: SC-7 (9)(a)
+    description: Detects and denies outgoing communications traffic posing a threat
+      to external information systems; and
+  nist_800_53:rev4:SC-7:9:b:
+    standard:
+      name: nist_800_53:rev4
+    family: SC
+    title: SC-7 (9)(b)
+    description: Audits the identity of internal users associated with denied communications.
+  nist_800_53:rev4:SC-7:10:
+    standard:
+      name: nist_800_53:rev4
+    family: SC
+    title: PREVENT UNAUTHORIZED EXFILTRATION
+    description: The organization prevents the unauthorized exfiltration of information
+      across managed interfaces.
+  nist_800_53:rev4:SC-7:11:
+    standard:
+      name: nist_800_53:rev4
+    family: SC
+    title: RESTRICT INCOMING COMMUNICATIONS TRAFFIC
+    description: 'The information system only allows incoming communications from
+      [Assignment: organization-defined authorized sources] to be routed to [Assignment:
+      organization-defined authorized destinations].'
+  nist_800_53:rev4:SC-7:12:
+    standard:
+      name: nist_800_53:rev4
+    family: SC
+    title: HOST-BASED PROTECTION
+    description: 'The organization implements [Assignment: organization-defined host-based
+      boundary protection mechanisms] at [Assignment: organization-defined information
+      system components].'
+  nist_800_53:rev4:SC-7:13:
+    standard:
+      name: nist_800_53:rev4
+    family: SC
+    title: ISOLATION OF SECURITY TOOLS / MECHANISMS / SUPPORT COMPONENTS
+    description: 'The organization isolates [Assignment: organization-defined information
+      security tools, mechanisms, and support components] from other internal information
+      system components by implementing physically separate subnetworks with managed
+      interfaces to other components of the system.'
+  nist_800_53:rev4:SC-7:14:
+    standard:
+      name: nist_800_53:rev4
+    family: SC
+    title: PROTECTS AGAINST UNAUTHORIZED PHYSICAL CONNECTIONS
+    description: 'The organization protects against unauthorized physical connections
+      at [Assignment: organization-defined managed interfaces].'
+  nist_800_53:rev4:SC-7:15:
+    standard:
+      name: nist_800_53:rev4
+    family: SC
+    title: ROUTE PRIVILEGED NETWORK ACCESSES
+    description: The information system routes all networked, privileged accesses
+      through a dedicated, managed interface for purposes of access control and auditing.
+  nist_800_53:rev4:SC-7:16:
+    standard:
+      name: nist_800_53:rev4
+    family: SC
+    title: PREVENT DISCOVERY OF COMPONENTS / DEVICES
+    description: The information system prevents discovery of specific system components
+      composing a managed interface.
+  nist_800_53:rev4:SC-7:17:
+    standard:
+      name: nist_800_53:rev4
+    family: SC
+    title: AUTOMATED ENFORCEMENT OF PROTOCOL FORMATS
+    description: The information system enforces adherence to protocol formats.
+  nist_800_53:rev4:SC-7:18:
+    standard:
+      name: nist_800_53:rev4
+    family: SC
+    title: FAIL SECURE
+    description: The information system fails securely in the event of an operational
+      failure of a boundary protection device.
+  nist_800_53:rev4:SC-7:19:
+    standard:
+      name: nist_800_53:rev4
+    family: SC
+    title: BLOCKS COMMUNICATION FROM NON-ORGANIZATIONALLY CONFIGURED HOSTS
+    description: 'The information system blocks both inbound and outbound communications
+      traffic between [Assignment: organization-defined communication clients] that
+      are independently configured by end users and external service providers.'
+  nist_800_53:rev4:SC-7:20:
+    standard:
+      name: nist_800_53:rev4
+    family: SC
+    title: DYNAMIC ISOLATION / SEGREGATION
+    description: 'The information system provides the capability to dynamically isolate/segregate
+      [Assignment: organization-defined information system components] from other
+      components of the system.'
+  nist_800_53:rev4:SC-7:21:
+    standard:
+      name: nist_800_53:rev4
+    family: SC
+    title: ISOLATION OF INFORMATION SYSTEM COMPONENTS
+    description: 'The organization employs boundary protection mechanisms to separate
+      [Assignment: organization-defined information system components] supporting
+      [Assignment: organization-defined missions and/or business functions].'
+  nist_800_53:rev4:SC-7:22:
+    standard:
+      name: nist_800_53:rev4
+    family: SC
+    title: SEPARATE SUBNETS FOR CONNECTING TO DIFFERENT SECURITY DOMAINS
+    description: The information system implements separate network addresses (i.e.,
+      different subnets) to connect to systems in different security domains.
+  nist_800_53:rev4:SC-7:23:
+    standard:
+      name: nist_800_53:rev4
+    family: SC
+    title: DISABLE SENDER FEEDBACK ON PROTOCOL VALIDATION FAILURE
+    description: The information system disables feedback to senders on protocol format
+      validation failure.
+  nist_800_53:rev4:SC-8:1:
+    standard:
+      name: nist_800_53:rev4
+    family: SC
+    title: CRYPTOGRAPHIC OR ALTERNATE PHYSICAL PROTECTION
+    description: 'The information system implements cryptographic mechanisms to [Selection
+      (one or more): prevent unauthorized disclosure of information; detect changes
+      to information] during transmission unless otherwise protected by [Assignment:
+      organization-defined alternative physical safeguards].'
+  nist_800_53:rev4:SC-8:2:
+    standard:
+      name: nist_800_53:rev4
+    family: SC
+    title: PRE / POST TRANSMISSION HANDLING
+    description: 'The information system maintains the [Selection (one or more): confidentiality;
+      integrity] of information during preparation for transmission and during reception.'
+  nist_800_53:rev4:SC-8:3:
+    standard:
+      name: nist_800_53:rev4
+    family: SC
+    title: CRYPTOGRAPHIC PROTECTION FOR MESSAGE EXTERNALS
+    description: 'The information system implements cryptographic mechanisms to protect
+      message externals unless otherwise protected by [Assignment: organization-defined
+      alternative physical safeguards].'
+  nist_800_53:rev4:SC-8:4:
+    standard:
+      name: nist_800_53:rev4
+    family: SC
+    title: CONCEAL / RANDOMIZE COMMUNICATIONS
+    description: 'The information system implements cryptographic mechanisms to conceal
+      or randomize communication patterns unless otherwise protected by [Assignment:
+      organization-defined alternative physical safeguards].'
+  nist_800_53:rev4:SC-11:1:
+    standard:
+      name: nist_800_53:rev4
+    family: SC
+    title: LOGICAL ISOLATION
+    description: The information system provides a trusted communications path that
+      is logically isolated and distinguishable from other paths.
+  nist_800_53:rev4:SC-12:1:
+    standard:
+      name: nist_800_53:rev4
+    family: SC
+    title: AVAILABILITY
+    description: The organization maintains availability of information in the event
+      of the loss of cryptographic keys by users.
+  nist_800_53:rev4:SC-12:2:
+    standard:
+      name: nist_800_53:rev4
+    family: SC
+    title: SYMMETRIC KEYS
+    description: 'The organization produces, controls, and distributes symmetric cryptographic
+      keys using [Selection: NIST FIPS-compliant; NSA-approved] key management technology
+      and processes.'
+  nist_800_53:rev4:SC-12:3:
+    standard:
+      name: nist_800_53:rev4
+    family: SC
+    title: ASYMMETRIC KEYS
+    description: 'The organization produces, controls, and distributes asymmetric
+      cryptographic keys using [Selection: NSA-approved key management technology
+      and processes; approved PKI Class 3 certificates or prepositioned keying material;
+      approved PKI Class 3 or Class 4 certificates and hardware security tokens that
+      protect the user�s private key].'
+  nist_800_53:rev4:SC-12:4:
+    standard:
+      name: nist_800_53:rev4
+    family: SC
+    title: PKI CERTIFICATES
+    description: "[Withdrawn: Incorporated into SC-12]."
+  nist_800_53:rev4:SC-12:5:
+    standard:
+      name: nist_800_53:rev4
+    family: SC
+    title: PKI CERTIFICATES / HARDWARE TOKENS
+    description: "[Withdrawn: Incorporated into SC-12]."
+  nist_800_53:rev4:SC-13:1:
+    standard:
+      name: nist_800_53:rev4
+    family: SC
+    title: FIPS-VALIDATED CRYPTOGRAPHY
+    description: "[Withdrawn: Incorporated into SC-13]."
+  nist_800_53:rev4:SC-13:2:
+    standard:
+      name: nist_800_53:rev4
+    family: SC
+    title: NSA-APPROVED CRYPTOGRAPHY
+    description: "[Withdrawn: Incorporated into SC-13]."
+  nist_800_53:rev4:SC-13:3:
+    standard:
+      name: nist_800_53:rev4
+    family: SC
+    title: INDIVIDUALS WITHOUT FORMAL ACCESS  APPROVALS
+    description: "[Withdrawn: Incorporated into SC-13]."
+  nist_800_53:rev4:SC-13:4:
+    standard:
+      name: nist_800_53:rev4
+    family: SC
+    title: DIGITAL SIGNATURES
+    description: "[Withdrawn: Incorporated into SC-13]."
+  nist_800_53:rev4:SC-15:a:
+    standard:
+      name: nist_800_53:rev4
+    family: SC
+    title: SC-15a.
+    description: 'Prohibits remote activation of collaborative computing devices with
+      the following exceptions: [Assignment: organization-defined exceptions where
+      remote activation is to be allowed]; and'
+  nist_800_53:rev4:SC-15:b:
+    standard:
+      name: nist_800_53:rev4
+    family: SC
+    title: SC-15b.
+    description: Provides an explicit indication of use to users physically present
+      at the devices.
+  nist_800_53:rev4:SC-15:1:
+    standard:
+      name: nist_800_53:rev4
+    family: SC
+    title: PHYSICAL DISCONNECT
+    description: The information system provides physical disconnect of collaborative
+      computing devices in a manner that supports ease of use.
+  nist_800_53:rev4:SC-15:2:
+    standard:
+      name: nist_800_53:rev4
+    family: SC
+    title: BLOCKING INBOUND / OUTBOUND COMMUNICATIONS TRAFFIC
+    description: "[Withdrawn: Incorporated into SC-7]."
+  nist_800_53:rev4:SC-15:3:
+    standard:
+      name: nist_800_53:rev4
+    family: SC
+    title: DISABLING / REMOVAL IN SECURE WORK AREAS
+    description: 'The organization disables or removes collaborative computing devices
+      from [Assignment: organization-defined information systems or information system
+      components] in [Assignment: organization-defined secure work areas].'
+  nist_800_53:rev4:SC-15:4:
+    standard:
+      name: nist_800_53:rev4
+    family: SC
+    title: EXPLICITLY INDICATE CURRENT PARTICIPANTS
+    description: 'The information system provides an explicit indication of current
+      participants in [Assignment: organization-defined online meetings and teleconferences].'
+  nist_800_53:rev4:SC-16:1:
+    standard:
+      name: nist_800_53:rev4
+    family: SC
+    title: INTEGRITY VALIDATION
+    description: The information system validates the integrity of transmitted security
+      attributes.
+  nist_800_53:rev4:SC-18:a:
+    standard:
+      name: nist_800_53:rev4
+    family: SC
+    title: SC-18a.
+    description: Defines acceptable and unacceptable mobile code and mobile code technologies;
+  nist_800_53:rev4:SC-18:b:
+    standard:
+      name: nist_800_53:rev4
+    family: SC
+    title: SC-18b.
+    description: Establishes usage restrictions and implementation guidance for acceptable
+      mobile code and mobile code technologies; and
+  nist_800_53:rev4:SC-18:c:
+    standard:
+      name: nist_800_53:rev4
+    family: SC
+    title: SC-18c.
+    description: Authorizes, monitors, and controls the use of mobile code within
+      the information system.
+  nist_800_53:rev4:SC-18:1:
+    standard:
+      name: nist_800_53:rev4
+    family: SC
+    title: IDENTIFY UNACCEPTABLE CODE / TAKE CORRECTIVE ACTIONS
+    description: 'The information system identifies [Assignment: organization-defined
+      unacceptable mobile code] and takes [Assignment: organization-defined corrective
+      actions].'
+  nist_800_53:rev4:SC-18:2:
+    standard:
+      name: nist_800_53:rev4
+    family: SC
+    title: ACQUISITION / DEVELOPMENT / USE
+    description: 'The organization ensures that the acquisition, development, and
+      use of mobile code to be deployed in the information system meets [Assignment:
+      organization-defined mobile code requirements].'
+  nist_800_53:rev4:SC-18:3:
+    standard:
+      name: nist_800_53:rev4
+    family: SC
+    title: PREVENT DOWNLOADING / EXECUTION
+    description: 'The information system prevents the download and execution of [Assignment:
+      organization-defined unacceptable mobile code].'
+  nist_800_53:rev4:SC-18:4:
+    standard:
+      name: nist_800_53:rev4
+    family: SC
+    title: PREVENT AUTOMATIC EXECUTION
+    description: 'The information system prevents the automatic execution of mobile
+      code in [Assignment: organization-defined software applications] and enforces
+      [Assignment: organization-defined actions] prior to executing the code.'
+  nist_800_53:rev4:SC-18:5:
+    standard:
+      name: nist_800_53:rev4
+    family: SC
+    title: ALLOW EXECUTION ONLY IN CONFINED ENVIRONMENTS
+    description: The organization allows execution of permitted mobile code only in
+      confined virtual machine environments.
+  nist_800_53:rev4:SC-19:a:
+    standard:
+      name: nist_800_53:rev4
+    family: SC
+    title: SC-19a.
+    description: Establishes usage restrictions and implementation guidance for Voice
+      over Internet Protocol (VoIP) technologies based on the potential to cause damage
+      to the information system if used maliciously; and
+  nist_800_53:rev4:SC-19:b:
+    standard:
+      name: nist_800_53:rev4
+    family: SC
+    title: SC-19b.
+    description: Authorizes, monitors, and controls the use of VoIP within the information
+      system.
+  nist_800_53:rev4:SC-20:a:
+    standard:
+      name: nist_800_53:rev4
+    family: SC
+    title: SC-20a.
+    description: Provides additional data origin authentication and integrity verification
+      artifacts along with the authoritative name resolution data the system returns
+      in response to external name/address resolution queries; and
+  nist_800_53:rev4:SC-20:b:
+    standard:
+      name: nist_800_53:rev4
+    family: SC
+    title: SC-20b.
+    description: Provides the means to indicate the security status of child zones
+      and (if the child supports secure resolution services) to enable verification
+      of a chain of trust among parent and child domains, when operating as part of
+      a distributed, hierarchical namespace.
+  nist_800_53:rev4:SC-20:1:
+    standard:
+      name: nist_800_53:rev4
+    family: SC
+    title: CHILD SUBSPACES
+    description: "[Withdrawn: Incorporated into SC-20]."
+  nist_800_53:rev4:SC-20:2:
+    standard:
+      name: nist_800_53:rev4
+    family: SC
+    title: DATA ORIGIN / INTEGRITY
+    description: The information system provides data origin and integrity protection
+      artifacts for internal name/address resolution queries.
+  nist_800_53:rev4:SC-21:1:
+    standard:
+      name: nist_800_53:rev4
+    family: SC
+    title: DATA ORIGIN / INTEGRITY
+    description: "[Withdrawn: Incorporated into SC-21]."
+  nist_800_53:rev4:SC-23:1:
+    standard:
+      name: nist_800_53:rev4
+    family: SC
+    title: INVALIDATE SESSION IDENTIFIERS AT LOGOUT
+    description: The information system invalidates session identifiers upon user
+      logout or other session termination.
+  nist_800_53:rev4:SC-23:2:
+    standard:
+      name: nist_800_53:rev4
+    family: SC
+    title: USER-INITIATED LOGOUTS / MESSAGE DISPLAYS
+    description: "[Withdrawn: Incorporated into AC-12 (1)]."
+  nist_800_53:rev4:SC-23:3:
+    standard:
+      name: nist_800_53:rev4
+    family: SC
+    title: UNIQUE SESSION IDENTIFIERS WITH RANDOMIZATION
+    description: 'The information system generates a unique session identifier for
+      each session with [Assignment: organization-defined randomness requirements]
+      and recognizes only session identifiers that are system-generated.'
+  nist_800_53:rev4:SC-23:4:
+    standard:
+      name: nist_800_53:rev4
+    family: SC
+    title: UNIQUE SESSION IDENTIFIERS WITH RANDOMIZATION
+    description: "[Withdrawn: Incorporated into SC-23 (3)]."
+  nist_800_53:rev4:SC-23:5:
+    standard:
+      name: nist_800_53:rev4
+    family: SC
+    title: ALLOWED CERTIFICATE AUTHORITIES
+    description: 'The information system only allows the use of [Assignment: organization-defined
+      certificate authorities] for verification of the establishment of protected
+      sessions.'
+  nist_800_53:rev4:SC-26:1:
+    standard:
+      name: nist_800_53:rev4
+    family: SC
+    title: DETECTION OF MALICIOUS CODE
+    description: "[Withdrawn: Incorporated into SC-35]."
+  nist_800_53:rev4:SC-28:1:
+    standard:
+      name: nist_800_53:rev4
+    family: SC
+    title: CRYPTOGRAPHIC PROTECTION
+    description: 'The information system implements cryptographic mechanisms to prevent
+      unauthorized disclosure and modification of [Assignment: organization-defined
+      information] on [Assignment: organization-defined information system components].'
+  nist_800_53:rev4:SC-28:2:
+    standard:
+      name: nist_800_53:rev4
+    family: SC
+    title: OFF-LINE STORAGE
+    description: 'The organization removes from online storage and stores off-line
+      in a secure location [Assignment: organization-defined information].'
+  nist_800_53:rev4:SC-29:1:
+    standard:
+      name: nist_800_53:rev4
+    family: SC
+    title: VIRTUALIZATION TECHNIQUES
+    description: 'The organization employs virtualization techniques to support the
+      deployment of a diversity of operating systems and applications that are changed
+      [Assignment: organization-defined frequency].'
+  nist_800_53:rev4:SC-30:1:
+    standard:
+      name: nist_800_53:rev4
+    family: SC
+    title: VIRTUALIZATION TECHNIQUES
+    description: "[Withdrawn: Incorporated into SC-29 (1)]."
+  nist_800_53:rev4:SC-30:2:
+    standard:
+      name: nist_800_53:rev4
+    family: SC
+    title: RANDOMNESS
+    description: 'The organization employs [Assignment: organization-defined techniques]
+      to introduce randomness into organizational operations and assets.'
+  nist_800_53:rev4:SC-30:3:
+    standard:
+      name: nist_800_53:rev4
+    family: SC
+    title: CHANGE PROCESSING / STORAGE LOCATIONS
+    description: 'The organization changes the location of [Assignment: organization-defined
+      processing and/or storage] [Selection: [Assignment: organization-defined time
+      frequency]; at random time intervals]].'
+  nist_800_53:rev4:SC-30:4:
+    standard:
+      name: nist_800_53:rev4
+    family: SC
+    title: MISLEADING INFORMATION
+    description: 'The organization employs realistic, but misleading information in
+      [Assignment: organization-defined information system components] with regard
+      to its security state or posture.'
+  nist_800_53:rev4:SC-30:5:
+    standard:
+      name: nist_800_53:rev4
+    family: SC
+    title: CONCEALMENT OF SYSTEM COMPONENTS
+    description: 'The organization employs [Assignment: organization-defined techniques]
+      to hide or conceal [Assignment: organization-defined information system components].'
+  nist_800_53:rev4:SC-31:a:
+    standard:
+      name: nist_800_53:rev4
+    family: SC
+    title: SC-31a.
+    description: 'Performs a covert channel analysis to identify those aspects of
+      communications within the information system that are potential avenues for
+      covert [Selection (one or more): storage; timing] channels; and'
+  nist_800_53:rev4:SC-31:b:
+    standard:
+      name: nist_800_53:rev4
+    family: SC
+    title: SC-31b.
+    description: Estimates the maximum bandwidth of those channels.
+  nist_800_53:rev4:SC-31:1:
+    standard:
+      name: nist_800_53:rev4
+    family: SC
+    title: TEST COVERT CHANNELS FOR EXPLOITABILITY
+    description: The organization tests a subset of the identified covert channels
+      to determine which channels are exploitable.
+  nist_800_53:rev4:SC-31:2:
+    standard:
+      name: nist_800_53:rev4
+    family: SC
+    title: MAXIMUM BANDWIDTH
+    description: 'The organization reduces the maximum bandwidth for identified covert
+      [Selection (one or more); storage; timing] channels to [Assignment: organization-defined
+      values].'
+  nist_800_53:rev4:SC-31:3:
+    standard:
+      name: nist_800_53:rev4
+    family: SC
+    title: MEASURE BANDWIDTH IN OPERATIONAL ENVIRONMENTS
+    description: 'The organization measures the bandwidth of [Assignment: organization-defined
+      subset of identified covert channels] in the operational environment of the
+      information system.'
+  nist_800_53:rev4:SC-34:a:
+    standard:
+      name: nist_800_53:rev4
+    family: SC
+    title: SC-34a.
+    description: Loads and executes the operating environment from hardware-enforced,
+      read-only media; and
+  nist_800_53:rev4:SC-34:b:
+    standard:
+      name: nist_800_53:rev4
+    family: SC
+    title: SC-34b.
+    description: 'Loads and executes [Assignment: organization-defined applications]
+      from hardware-enforced, read-only media.'
+  nist_800_53:rev4:SC-34:1:
+    standard:
+      name: nist_800_53:rev4
+    family: SC
+    title: NO WRITABLE STORAGE
+    description: 'The organization employs [Assignment: organization-defined information
+      system components] with no writeable storage that is persistent across component
+      restart or power on/off.'
+  nist_800_53:rev4:SC-34:2:
+    standard:
+      name: nist_800_53:rev4
+    family: SC
+    title: INTEGRITY PROTECTION / READ-ONLY MEDIA
+    description: The organization protects the integrity of information prior to storage
+      on read-only media and controls the media after such information has been recorded
+      onto the media.
+  nist_800_53:rev4:SC-34:3:
+    standard:
+      name: nist_800_53:rev4
+    family: SC
+    title: HARDWARE-BASED PROTECTION
+    description: 'The organization:'
+  nist_800_53:rev4:SC-34:3:a:
+    standard:
+      name: nist_800_53:rev4
+    family: SC
+    title: SC-34 (3)(a)
+    description: 'Employs hardware-based, write-protect for [Assignment: organization-defined
+      information system firmware components]; and'
+  nist_800_53:rev4:SC-34:3:b:
+    standard:
+      name: nist_800_53:rev4
+    family: SC
+    title: SC-34 (3)(b)
+    description: 'Implements specific procedures for [Assignment: organization-defined
+      authorized individuals] to manually disable hardware write-protect for firmware
+      modifications and re-enable the write-protect prior to returning to operational
+      mode.'
+  nist_800_53:rev4:SC-36:1:
+    standard:
+      name: nist_800_53:rev4
+    family: SC
+    title: POLLING TECHNIQUES
+    description: 'The organization employs polling techniques to identify potential
+      faults, errors, or compromises to [Assignment: organization-defined distributed
+      processing and storage components].'
+  nist_800_53:rev4:SC-37:1:
+    standard:
+      name: nist_800_53:rev4
+    family: SC
+    title: ENSURE DELIVERY / TRANSMISSION
+    description: 'The organization employs [Assignment: organization-defined security
+      safeguards] to ensure that only [Assignment: organization-defined individuals
+      or information systems] receive the [Assignment: organization-defined information,
+      information system components, or devices].'
+  nist_800_53:rev4:SC-39:1:
+    standard:
+      name: nist_800_53:rev4
+    family: SC
+    title: HARDWARE SEPARATION
+    description: The information system implements underlying hardware separation
+      mechanisms to facilitate process separation.
+  nist_800_53:rev4:SC-39:2:
+    standard:
+      name: nist_800_53:rev4
+    family: SC
+    title: THREAD ISOLATION
+    description: 'The information system maintains a separate execution domain for
+      each thread in [Assignment: organization-defined multi-threaded processing].'
+  nist_800_53:rev4:SC-40:1:
+    standard:
+      name: nist_800_53:rev4
+    family: SC
+    title: ELECTROMAGNETIC INTERFERENCE
+    description: 'The information system implements cryptographic mechanisms that
+      achieve [Assignment: organization-defined level of protection] against the effects
+      of intentional electromagnetic interference.'
+  nist_800_53:rev4:SC-40:2:
+    standard:
+      name: nist_800_53:rev4
+    family: SC
+    title: REDUCE DETECTION POTENTIAL
+    description: 'The information system implements cryptographic mechanisms to reduce
+      the detection potential of wireless links to [Assignment: organization-defined
+      level of reduction].'
+  nist_800_53:rev4:SC-40:3:
+    standard:
+      name: nist_800_53:rev4
+    family: SC
+    title: IMITATIVE OR MANIPULATIVE COMMUNICATIONS DECEPTION
+    description: The information system implements cryptographic mechanisms to identify
+      and reject wireless transmissions that are deliberate attempts to achieve imitative
+      or manipulative communications deception based on signal parameters.
+  nist_800_53:rev4:SC-40:4:
+    standard:
+      name: nist_800_53:rev4
+    family: SC
+    title: SIGNAL PARAMETER IDENTIFICATION
+    description: 'The information system implements cryptographic mechanisms to prevent
+      the identification of [Assignment: organization-defined wireless transmitters]
+      by using the transmitter signal parameters.'
+  nist_800_53:rev4:SC-42:a:
+    standard:
+      name: nist_800_53:rev4
+    family: SC
+    title: SC-42a.
+    description: 'Prohibits the remote activation of environmental sensing capabilities
+      with the following exceptions: [Assignment: organization-defined exceptions
+      where remote activation of sensors is allowed]; and'
+  nist_800_53:rev4:SC-42:b:
+    standard:
+      name: nist_800_53:rev4
+    family: SC
+    title: SC-42b.
+    description: 'Provides an explicit indication of sensor use to [Assignment: organization-defined
+      class of users].'
+  nist_800_53:rev4:SC-42:1:
+    standard:
+      name: nist_800_53:rev4
+    family: SC
+    title: REPORTING TO AUTHORIZED INDIVIDUALS OR ROLES
+    description: 'The organization ensures that the information system is configured
+      so that data or information collected by the [Assignment: organization-defined
+      sensors] is only reported to authorized individuals or roles.'
+  nist_800_53:rev4:SC-42:2:
+    standard:
+      name: nist_800_53:rev4
+    family: SC
+    title: AUTHORIZED USE
+    description: 'The organization employs the following measures: [Assignment: organization-defined
+      measures], so that data or information collected by [Assignment: organization-defined
+      sensors] is only used for authorized purposes.'
+  nist_800_53:rev4:SC-42:3:
+    standard:
+      name: nist_800_53:rev4
+    family: SC
+    title: PROHIBIT USE OF DEVICES
+    description: 'The organization prohibits the use of devices possessing [Assignment:
+      organization-defined environmental sensing capabilities] in [Assignment: organization-defined
+      facilities, areas, or systems].'
+  nist_800_53:rev4:SC-43:a:
+    standard:
+      name: nist_800_53:rev4
+    family: SC
+    title: SC-43a.
+    description: 'Establishes usage restrictions and implementation guidance for [Assignment:
+      organization-defined information system components] based on the potential to
+      cause damage to the information system if used maliciously; and'
+  nist_800_53:rev4:SC-43:b:
+    standard:
+      name: nist_800_53:rev4
+    family: SC
+    title: SC-43b.
+    description: Authorizes, monitors, and controls the use of such components within
+      the information system.
+  nist_800_53:rev4:SI-1:a:
+    standard:
+      name: nist_800_53:rev4
+    family: SI
+    title: SI-1a.
+    description: 'Develops, documents, and disseminates to [Assignment: organization-defined
+      personnel or roles]:'
+  nist_800_53:rev4:SI-1:a:1:
+    standard:
+      name: nist_800_53:rev4
+    family: SI
+    title: SI-1a.1.
+    description: A system and information integrity policy that addresses purpose,
+      scope, roles, responsibilities, management commitment, coordination among organizational
+      entities, and compliance; and
+  nist_800_53:rev4:SI-1:a:2:
+    standard:
+      name: nist_800_53:rev4
+    family: SI
+    title: SI-1a.2.
+    description: Procedures to facilitate the implementation of the system and information
+      integrity policy and associated system and information integrity controls; and
+  nist_800_53:rev4:SI-1:b:
+    standard:
+      name: nist_800_53:rev4
+    family: SI
+    title: SI-1b.
+    description: 'Reviews and updates the current:'
+  nist_800_53:rev4:SI-1:b:1:
+    standard:
+      name: nist_800_53:rev4
+    family: SI
+    title: SI-1b.1.
+    description: 'System and information integrity policy [Assignment: organization-defined
+      frequency]; and'
+  nist_800_53:rev4:SI-1:b:2:
+    standard:
+      name: nist_800_53:rev4
+    family: SI
+    title: SI-1b.2.
+    description: 'System and information integrity procedures [Assignment: organization-defined
+      frequency].'
+  nist_800_53:rev4:SI-2:a:
+    standard:
+      name: nist_800_53:rev4
+    family: SI
+    title: SI-2a.
+    description: Identifies, reports, and corrects information system flaws;
+  nist_800_53:rev4:SI-2:b:
+    standard:
+      name: nist_800_53:rev4
+    family: SI
+    title: SI-2b.
+    description: Tests software and firmware updates related to flaw remediation for
+      effectiveness and potential side effects before installation;
+  nist_800_53:rev4:SI-2:c:
+    standard:
+      name: nist_800_53:rev4
+    family: SI
+    title: SI-2c.
+    description: 'Installs security-relevant software and firmware updates within
+      [Assignment: organization-defined time period] of the release of the updates;
+      and'
+  nist_800_53:rev4:SI-2:d:
+    standard:
+      name: nist_800_53:rev4
+    family: SI
+    title: SI-2d.
+    description: Incorporates flaw remediation into the organizational configuration
+      management process.
+  nist_800_53:rev4:SI-2:1:
+    standard:
+      name: nist_800_53:rev4
+    family: SI
+    title: CENTRAL MANAGEMENT
+    description: The organization centrally manages the flaw remediation process.
+  nist_800_53:rev4:SI-2:2:
+    standard:
+      name: nist_800_53:rev4
+    family: SI
+    title: AUTOMATED FLAW REMEDIATION STATUS
+    description: 'The organization employs automated mechanisms [Assignment: organization-defined
+      frequency] to determine the state of information system components with regard
+      to flaw remediation.'
+  nist_800_53:rev4:SI-2:3:
+    standard:
+      name: nist_800_53:rev4
+    family: SI
+    title: TIME TO REMEDIATE FLAWS / BENCHMARKS FOR CORRECTIVE ACTIONS
+    description: 'The organization:'
+  nist_800_53:rev4:SI-2:3:a:
+    standard:
+      name: nist_800_53:rev4
+    family: SI
+    title: SI-2 (3)(a)
+    description: Measures the time between flaw identification and flaw remediation;
+      and
+  nist_800_53:rev4:SI-2:3:b:
+    standard:
+      name: nist_800_53:rev4
+    family: SI
+    title: SI-2 (3)(b)
+    description: 'Establishes [Assignment: organization-defined benchmarks] for taking
+      corrective actions.'
+  nist_800_53:rev4:SI-2:4:
+    standard:
+      name: nist_800_53:rev4
+    family: SI
+    title: AUTOMATED PATCH MANAGEMENT TOOLS
+    description: "[Withdrawn: Incorporated into SI-2]."
+  nist_800_53:rev4:SI-2:5:
+    standard:
+      name: nist_800_53:rev4
+    family: SI
+    title: AUTOMATIC SOFTWARE / FIRMWARE UPDATES
+    description: 'The organization installs [Assignment: organization-defined security-relevant
+      software and firmware updates] automatically to [Assignment: organization-defined
+      information system components].'
+  nist_800_53:rev4:SI-2:6:
+    standard:
+      name: nist_800_53:rev4
+    family: SI
+    title: REMOVAL OF PREVIOUS VERSIONS OF SOFTWARE / FIRMWARE
+    description: 'The organization removes [Assignment: organization-defined software
+      and firmware components] after updated versions have been installed.'
+  nist_800_53:rev4:SI-3:a:
+    standard:
+      name: nist_800_53:rev4
+    family: SI
+    title: SI-3a.
+    description: Employs malicious code protection mechanisms at information system
+      entry and exit points to detect and eradicate malicious code;
+  nist_800_53:rev4:SI-3:b:
+    standard:
+      name: nist_800_53:rev4
+    family: SI
+    title: SI-3b.
+    description: Updates malicious code protection mechanisms whenever new releases
+      are available in accordance with organizational configuration management policy
+      and procedures;
+  nist_800_53:rev4:SI-3:c:
+    standard:
+      name: nist_800_53:rev4
+    family: SI
+    title: SI-3c.
+    description: 'Configures malicious code protection mechanisms to:'
+  nist_800_53:rev4:SI-3:c:1:
+    standard:
+      name: nist_800_53:rev4
+    family: SI
+    title: SI-3c.1.
+    description: 'Perform periodic scans of the information system [Assignment: organization-defined
+      frequency] and real-time scans of files from external sources at [Selection
+      (one or more); endpoint; network entry/exit points] as the files are downloaded,
+      opened, or executed in accordance with organizational security policy; and'
+  nist_800_53:rev4:SI-3:c:2:
+    standard:
+      name: nist_800_53:rev4
+    family: SI
+    title: SI-3c.2.
+    description: "[Selection (one or more): block malicious code; quarantine malicious
+      code;  send alert to administrator; [Assignment: organization-defined action]]
+      in response to malicious code detection; and"
+  nist_800_53:rev4:SI-3:d:
+    standard:
+      name: nist_800_53:rev4
+    family: SI
+    title: SI-3d.
+    description: Addresses the receipt of false positives during malicious code detection
+      and eradication and the resulting potential impact on the availability of the
+      information system.
+  nist_800_53:rev4:SI-3:1:
+    standard:
+      name: nist_800_53:rev4
+    family: SI
+    title: CENTRAL MANAGEMENT
+    description: The organization centrally manages malicious code protection mechanisms.
+  nist_800_53:rev4:SI-3:2:
+    standard:
+      name: nist_800_53:rev4
+    family: SI
+    title: AUTOMATIC UPDATES
+    description: The information system automatically updates malicious code protection
+      mechanisms.
+  nist_800_53:rev4:SI-3:3:
+    standard:
+      name: nist_800_53:rev4
+    family: SI
+    title: NON-PRIVILEGED USERS
+    description: "[Withdrawn: Incorporated into AC-6 (10)]."
+  nist_800_53:rev4:SI-3:4:
+    standard:
+      name: nist_800_53:rev4
+    family: SI
+    title: UPDATES ONLY BY PRIVILEGED USERS
+    description: The information system updates malicious code protection mechanisms
+      only when directed by a privileged user.
+  nist_800_53:rev4:SI-3:5:
+    standard:
+      name: nist_800_53:rev4
+    family: SI
+    title: PORTABLE STORAGE DEVICES
+    description: "[Withdrawn: Incorporated into MP-7]."
+  nist_800_53:rev4:SI-3:6:
+    standard:
+      name: nist_800_53:rev4
+    family: SI
+    title: TESTING / VERIFICATION
+    description: 'The organization:'
+  nist_800_53:rev4:SI-3:6:a:
+    standard:
+      name: nist_800_53:rev4
+    family: SI
+    title: SI-3 (6)(a)
+    description: 'Tests malicious code protection mechanisms [Assignment: organization-defined
+      frequency] by introducing a known benign, non-spreading test case into the information
+      system; and'
+  nist_800_53:rev4:SI-3:6:b:
+    standard:
+      name: nist_800_53:rev4
+    family: SI
+    title: SI-3 (6)(b)
+    description: Verifies that both detection of the test case and associated incident
+      reporting occur.
+  nist_800_53:rev4:SI-3:7:
+    standard:
+      name: nist_800_53:rev4
+    family: SI
+    title: NONSIGNATURE-BASED DETECTION
+    description: The information system implements nonsignature-based malicious code
+      detection mechanisms.
+  nist_800_53:rev4:SI-3:8:
+    standard:
+      name: nist_800_53:rev4
+    family: SI
+    title: DETECT UNAUTHORIZED COMMANDS
+    description: 'The information system detects [Assignment: organization-defined
+      unauthorized operating system commands] through the kernel application programming
+      interface at [Assignment: organization-defined information system hardware components]
+      and [Selection (one or more): issues a warning; audits the command execution;
+      prevents the execution of the command].'
+  nist_800_53:rev4:SI-3:9:
+    standard:
+      name: nist_800_53:rev4
+    family: SI
+    title: AUTHENTICATE REMOTE COMMANDS
+    description: 'The information system implements [Assignment: organization-defined
+      security safeguards] to authenticate [Assignment: organization-defined remote
+      commands].'
+  nist_800_53:rev4:SI-3:10:
+    standard:
+      name: nist_800_53:rev4
+    family: SI
+    title: MALICIOUS CODE ANALYSIS
+    description: 'The organization:'
+  nist_800_53:rev4:SI-3:10:a:
+    standard:
+      name: nist_800_53:rev4
+    family: SI
+    title: SI-3 (10)(a)
+    description: 'Employs [Assignment: organization-defined tools and techniques]
+      to analyze the characteristics and behavior of malicious code; and'
+  nist_800_53:rev4:SI-3:10:b:
+    standard:
+      name: nist_800_53:rev4
+    family: SI
+    title: SI-3 (10)(b)
+    description: Incorporates the results from malicious code analysis into organizational
+      incident response and flaw remediation processes.
+  nist_800_53:rev4:SI-4:a:
+    standard:
+      name: nist_800_53:rev4
+    family: SI
+    title: SI-4a.
+    description: 'Monitors the information system to detect:'
+  nist_800_53:rev4:SI-4:a:1:
+    standard:
+      name: nist_800_53:rev4
+    family: SI
+    title: SI-4a.1.
+    description: 'Attacks and indicators of potential attacks in accordance with [Assignment:
+      organization-defined monitoring objectives]; and'
+  nist_800_53:rev4:SI-4:a:2:
+    standard:
+      name: nist_800_53:rev4
+    family: SI
+    title: SI-4a.2.
+    description: Unauthorized local, network, and remote connections;
+  nist_800_53:rev4:SI-4:b:
+    standard:
+      name: nist_800_53:rev4
+    family: SI
+    title: SI-4b.
+    description: 'Identifies unauthorized use of the information system through [Assignment:
+      organization-defined techniques and methods];'
+  nist_800_53:rev4:SI-4:c:
+    standard:
+      name: nist_800_53:rev4
+    family: SI
+    title: SI-4c.
+    description: 'Deploys monitoring devices:'
+  nist_800_53:rev4:SI-4:c:1:
+    standard:
+      name: nist_800_53:rev4
+    family: SI
+    title: SI-4c.1.
+    description: Strategically within the information system to collect organization-determined
+      essential information; and
+  nist_800_53:rev4:SI-4:c:2:
+    standard:
+      name: nist_800_53:rev4
+    family: SI
+    title: SI-4c.2.
+    description: At ad hoc locations within the system to track specific types of
+      transactions of interest to the organization;
+  nist_800_53:rev4:SI-4:d:
+    standard:
+      name: nist_800_53:rev4
+    family: SI
+    title: SI-4d.
+    description: Protects information obtained from intrusion-monitoring tools from
+      unauthorized access, modification, and deletion;
+  nist_800_53:rev4:SI-4:e:
+    standard:
+      name: nist_800_53:rev4
+    family: SI
+    title: SI-4e.
+    description: Heightens the level of information system monitoring activity whenever
+      there is an indication of increased risk to organizational operations and assets,
+      individuals, other organizations, or the Nation based on law enforcement information,
+      intelligence information, or other credible sources of information;
+  nist_800_53:rev4:SI-4:f:
+    standard:
+      name: nist_800_53:rev4
+    family: SI
+    title: SI-4f.
+    description: Obtains legal opinion with regard to information system monitoring
+      activities in accordance with applicable federal laws, Executive Orders, directives,
+      policies, or regulations; and
+  nist_800_53:rev4:SI-4:g:
+    standard:
+      name: nist_800_53:rev4
+    family: SI
+    title: SI-4g.
+    description: 'Provides [Assignment: organization-defined information system monitoring
+      information] to [Assignment: organization-defined personnel or roles] [Selection
+      (one or more): as needed; [Assignment: organization-defined frequency]].'
+  nist_800_53:rev4:SI-4:1:
+    standard:
+      name: nist_800_53:rev4
+    family: SI
+    title: SYSTEM-WIDE INTRUSION DETECTION SYSTEM
+    description: The organization connects and configures individual intrusion detection
+      tools into an information system-wide intrusion detection system.
+  nist_800_53:rev4:SI-4:2:
+    standard:
+      name: nist_800_53:rev4
+    family: SI
+    title: AUTOMATED TOOLS FOR REAL-TIME ANALYSIS
+    description: The organization employs automated tools to support near real-time
+      analysis of events.
+  nist_800_53:rev4:SI-4:3:
+    standard:
+      name: nist_800_53:rev4
+    family: SI
+    title: AUTOMATED TOOL INTEGRATION
+    description: The organization employs automated tools to integrate intrusion detection
+      tools into access control and flow control mechanisms for rapid response to
+      attacks by enabling reconfiguration of these mechanisms in support of attack
+      isolation and elimination.
+  nist_800_53:rev4:SI-4:4:
+    standard:
+      name: nist_800_53:rev4
+    family: SI
+    title: INBOUND AND OUTBOUND COMMUNICATIONS TRAFFIC
+    description: 'The information system monitors inbound and outbound communications
+      traffic [Assignment: organization-defined frequency] for unusual or unauthorized
+      activities or conditions.'
+  nist_800_53:rev4:SI-4:5:
+    standard:
+      name: nist_800_53:rev4
+    family: SI
+    title: SYSTEM-GENERATED ALERTS
+    description: 'The information system alerts [Assignment: organization-defined
+      personnel or roles] when the following indications of compromise or potential
+      compromise occur: [Assignment: organization-defined compromise indicators].'
+  nist_800_53:rev4:SI-4:6:
+    standard:
+      name: nist_800_53:rev4
+    family: SI
+    title: RESTRICT NON-PRIVILEGED USERS
+    description: "[Withdrawn: Incorporated into AC-6 (10)]."
+  nist_800_53:rev4:SI-4:7:
+    standard:
+      name: nist_800_53:rev4
+    family: SI
+    title: AUTOMATED RESPONSE TO SUSPICIOUS EVENTS
+    description: 'The information system notifies [Assignment: organization-defined
+      incident response personnel (identified by name and/or by role)] of detected
+      suspicious events and takes [Assignment: organization-defined least-disruptive
+      actions to terminate suspicious events].'
+  nist_800_53:rev4:SI-4:8:
+    standard:
+      name: nist_800_53:rev4
+    family: SI
+    title: PROTECTION OF MONITORING INFORMATION
+    description: "[Withdrawn: Incorporated into SI-4]."
+  nist_800_53:rev4:SI-4:9:
+    standard:
+      name: nist_800_53:rev4
+    family: SI
+    title: TESTING OF MONITORING TOOLS
+    description: 'The organization tests intrusion-monitoring tools [Assignment: organization-defined
+      frequency].'
+  nist_800_53:rev4:SI-4:10:
+    standard:
+      name: nist_800_53:rev4
+    family: SI
+    title: VISIBILITY OF ENCRYPTED COMMUNICATIONS
+    description: 'The organization makes provisions so that [Assignment: organization-defined
+      encrypted communications traffic] is visible to [Assignment: organization-defined
+      information system monitoring tools].'
+  nist_800_53:rev4:SI-4:11:
+    standard:
+      name: nist_800_53:rev4
+    family: SI
+    title: ANALYZE COMMUNICATIONS TRAFFIC ANOMALIES
+    description: 'The organization analyzes outbound communications traffic at the
+      external boundary of the information system and selected [Assignment: organization-defined
+      interior points within the system (e.g., subnetworks, subsystems)] to discover
+      anomalies.'
+  nist_800_53:rev4:SI-4:12:
+    standard:
+      name: nist_800_53:rev4
+    family: SI
+    title: AUTOMATED ALERTS
+    description: 'The organization employs automated mechanisms to alert security
+      personnel of the following inappropriate or unusual activities with security
+      implications: [Assignment: organization-defined activities that trigger alerts].'
+  nist_800_53:rev4:SI-4:13:
+    standard:
+      name: nist_800_53:rev4
+    family: SI
+    title: ANALYZE TRAFFIC / EVENT PATTERNS
+    description: 'The organization:'
+  nist_800_53:rev4:SI-4:13:a:
+    standard:
+      name: nist_800_53:rev4
+    family: SI
+    title: SI-4 (13)(a)
+    description: Analyzes communications traffic/event patterns for the information
+      system;
+  nist_800_53:rev4:SI-4:13:b:
+    standard:
+      name: nist_800_53:rev4
+    family: SI
+    title: SI-4 (13)(b)
+    description: Develops profiles representing common traffic patterns and/or events;
+      and
+  nist_800_53:rev4:SI-4:13:c:
+    standard:
+      name: nist_800_53:rev4
+    family: SI
+    title: SI-4 (13)(c)
+    description: Uses the traffic/event profiles in tuning system-monitoring devices
+      to reduce the number of false positives and the number of false negatives.
+  nist_800_53:rev4:SI-4:14:
+    standard:
+      name: nist_800_53:rev4
+    family: SI
+    title: WIRELESS INTRUSION DETECTION
+    description: The organization employs a wireless intrusion detection system to
+      identify rogue wireless devices and to detect attack attempts and potential
+      compromises/breaches to the information system.
+  nist_800_53:rev4:SI-4:15:
+    standard:
+      name: nist_800_53:rev4
+    family: SI
+    title: WIRELESS TO WIRELINE COMMUNICATIONS
+    description: The organization employs an intrusion detection system to monitor
+      wireless communications traffic as the traffic passes from wireless to wireline
+      networks.
+  nist_800_53:rev4:SI-4:16:
+    standard:
+      name: nist_800_53:rev4
+    family: SI
+    title: CORRELATE MONITORING INFORMATION
+    description: The organization correlates information from monitoring tools employed
+      throughout the information system.
+  nist_800_53:rev4:SI-4:17:
+    standard:
+      name: nist_800_53:rev4
+    family: SI
+    title: INTEGRATED SITUATIONAL AWARENESS
+    description: The organization correlates information from monitoring physical,
+      cyber, and supply chain activities to achieve integrated, organization-wide
+      situational awareness.
+  nist_800_53:rev4:SI-4:18:
+    standard:
+      name: nist_800_53:rev4
+    family: SI
+    title: ANALYZE TRAFFIC / COVERT EXFILTRATION
+    description: 'The organization analyzes outbound communications traffic at the
+      external boundary of the information system (i.e., system perimeter) and at
+      [Assignment: organization-defined interior points within the system (e.g., subsystems,
+      subnetworks)] to detect covert exfiltration of information.'
+  nist_800_53:rev4:SI-4:19:
+    standard:
+      name: nist_800_53:rev4
+    family: SI
+    title: INDIVIDUALS POSING GREATER RISK
+    description: 'The organization implements [Assignment: organization-defined additional
+      monitoring] of individuals who have been identified by [Assignment: organization-defined
+      sources] as posing an increased level of risk.'
+  nist_800_53:rev4:SI-4:20:
+    standard:
+      name: nist_800_53:rev4
+    family: SI
+    title: PRIVILEGED USERS
+    description: 'The organization implements [Assignment: organization-defined additional
+      monitoring] of privileged users.'
+  nist_800_53:rev4:SI-4:21:
+    standard:
+      name: nist_800_53:rev4
+    family: SI
+    title: PROBATIONARY PERIODS
+    description: 'The organization implements [Assignment: organization-defined additional
+      monitoring] of individuals during [Assignment: organization-defined probationary
+      period].'
+  nist_800_53:rev4:SI-4:22:
+    standard:
+      name: nist_800_53:rev4
+    family: SI
+    title: UNAUTHORIZED NETWORK SERVICES
+    description: 'The information system detects network services that have not been
+      authorized or approved by [Assignment: organization-defined authorization or
+      approval processes] and [Selection (one or more): audits; alerts [Assignment:
+      organization-defined personnel or roles]].'
+  nist_800_53:rev4:SI-4:23:
+    standard:
+      name: nist_800_53:rev4
+    family: SI
+    title: HOST-BASED DEVICES
+    description: 'The organization implements [Assignment: organization-defined host-based
+      monitoring mechanisms] at [Assignment: organization-defined information system
+      components].'
+  nist_800_53:rev4:SI-4:24:
+    standard:
+      name: nist_800_53:rev4
+    family: SI
+    title: INDICATORS OF COMPROMISE
+    description: The information system discovers, collects, distributes, and uses
+      indicators of compromise.
+  nist_800_53:rev4:SI-5:a:
+    standard:
+      name: nist_800_53:rev4
+    family: SI
+    title: SI-5a.
+    description: 'Receives information system security alerts, advisories, and directives
+      from [Assignment: organization-defined external organizations] on an ongoing
+      basis;'
+  nist_800_53:rev4:SI-5:b:
+    standard:
+      name: nist_800_53:rev4
+    family: SI
+    title: SI-5b.
+    description: Generates internal security alerts, advisories, and directives as
+      deemed necessary;
+  nist_800_53:rev4:SI-5:c:
+    standard:
+      name: nist_800_53:rev4
+    family: SI
+    title: SI-5c.
+    description: 'Disseminates security alerts, advisories, and directives to: [Selection
+      (one or more): [Assignment: organization-defined personnel or roles]; [Assignment:
+      organization-defined elements within the organization]; [Assignment: organization-defined
+      external organizations]]; and'
+  nist_800_53:rev4:SI-5:d:
+    standard:
+      name: nist_800_53:rev4
+    family: SI
+    title: SI-5d.
+    description: Implements security directives in accordance with established time
+      frames, or notifies the issuing organization of the degree of noncompliance.
+  nist_800_53:rev4:SI-5:1:
+    standard:
+      name: nist_800_53:rev4
+    family: SI
+    title: AUTOMATED ALERTS AND ADVISORIES
+    description: The organization employs automated mechanisms to make security alert
+      and advisory information available throughout the organization.
+  nist_800_53:rev4:SI-6:a:
+    standard:
+      name: nist_800_53:rev4
+    family: SI
+    title: SI-6a.
+    description: 'Verifies the correct operation of [Assignment: organization-defined
+      security functions];'
+  nist_800_53:rev4:SI-6:b:
+    standard:
+      name: nist_800_53:rev4
+    family: SI
+    title: SI-6b.
+    description: 'Performs this verification [Selection (one or more): [Assignment:
+      organization-defined system transitional states]; upon command by user with
+      appropriate privilege; [Assignment: organization-defined frequency]];'
+  nist_800_53:rev4:SI-6:c:
+    standard:
+      name: nist_800_53:rev4
+    family: SI
+    title: SI-6c.
+    description: 'Notifies [Assignment: organization-defined personnel or roles] of
+      failed security verification tests; and'
+  nist_800_53:rev4:SI-6:d:
+    standard:
+      name: nist_800_53:rev4
+    family: SI
+    title: SI-6d.
+    description: "[Selection (one or more): shuts the information system down; restarts
+      the information system; [Assignment: organization-defined alternative action(s)]]
+      when anomalies are discovered."
+  nist_800_53:rev4:SI-6:1:
+    standard:
+      name: nist_800_53:rev4
+    family: SI
+    title: NOTIFICATION OF FAILED SECURITY TESTS
+    description: "[Withdrawn: Incorporated into SI-6]."
+  nist_800_53:rev4:SI-6:2:
+    standard:
+      name: nist_800_53:rev4
+    family: SI
+    title: AUTOMATION SUPPORT FOR DISTRIBUTED TESTING
+    description: The information system implements automated mechanisms to support
+      the management of distributed security testing.
+  nist_800_53:rev4:SI-6:3:
+    standard:
+      name: nist_800_53:rev4
+    family: SI
+    title: REPORT VERIFICATION RESULTS
+    description: 'The organization reports the results of security function verification
+      to [Assignment: organization-defined personnel or roles].'
+  nist_800_53:rev4:SI-7:1:
+    standard:
+      name: nist_800_53:rev4
+    family: SI
+    title: INTEGRITY CHECKS
+    description: 'The information system performs an integrity check of [Assignment:
+      organization-defined software, firmware, and information] [Selection (one or
+      more): at startup; at [Assignment: organization-defined transitional states
+      or security-relevant events]; [Assignment: organization-defined frequency]].'
+  nist_800_53:rev4:SI-7:2:
+    standard:
+      name: nist_800_53:rev4
+    family: SI
+    title: AUTOMATED NOTIFICATIONS OF INTEGRITY VIOLATIONS
+    description: 'The organization employs automated tools that provide notification
+      to [Assignment: organization-defined personnel or roles] upon discovering discrepancies
+      during integrity verification.'
+  nist_800_53:rev4:SI-7:3:
+    standard:
+      name: nist_800_53:rev4
+    family: SI
+    title: CENTRALLY-MANAGED INTEGRITY TOOLS
+    description: The organization employs centrally managed integrity verification
+      tools.
+  nist_800_53:rev4:SI-7:4:
+    standard:
+      name: nist_800_53:rev4
+    family: SI
+    title: TAMPER-EVIDENT PACKAGING
+    description: "[Withdrawn: Incorporated into SA-12]."
+  nist_800_53:rev4:SI-7:5:
+    standard:
+      name: nist_800_53:rev4
+    family: SI
+    title: AUTOMATED RESPONSE TO INTEGRITY VIOLATIONS
+    description: 'The information system automatically [Selection (one or more): shuts
+      the information system down; restarts the information system; implements [Assignment:
+      organization-defined security safeguards]] when integrity violations are discovered.'
+  nist_800_53:rev4:SI-7:6:
+    standard:
+      name: nist_800_53:rev4
+    family: SI
+    title: CRYPTOGRAPHIC PROTECTION
+    description: The information system implements cryptographic mechanisms to detect
+      unauthorized changes to software, firmware, and information.
+  nist_800_53:rev4:SI-7:7:
+    standard:
+      name: nist_800_53:rev4
+    family: SI
+    title: INTEGRATION OF DETECTION AND RESPONSE
+    description: 'The organization incorporates the detection of unauthorized [Assignment:
+      organization-defined security-relevant changes to the information system] into
+      the organizational incident response capability.'
+  nist_800_53:rev4:SI-7:8:
+    standard:
+      name: nist_800_53:rev4
+    family: SI
+    title: AUDITING CAPABILITY FOR SIGNIFICANT EVENTS
+    description: 'The information system, upon detection of a potential integrity
+      violation, provides the capability to audit the event and initiates the following
+      actions: [Selection (one or more): generates an audit record; alerts current
+      user; alerts [Assignment: organization-defined personnel or roles]; [Assignment:
+      organization-defined other actions]].'
+  nist_800_53:rev4:SI-7:9:
+    standard:
+      name: nist_800_53:rev4
+    family: SI
+    title: VERIFY BOOT PROCESS
+    description: 'The information system verifies the integrity of the boot process
+      of [Assignment: organization-defined devices].'
+  nist_800_53:rev4:SI-7:10:
+    standard:
+      name: nist_800_53:rev4
+    family: SI
+    title: PROTECTION OF BOOT FIRMWARE
+    description: 'The information system implements [Assignment: organization-defined
+      security safeguards] to protect the integrity of boot firmware in [Assignment:
+      organization-defined devices].'
+  nist_800_53:rev4:SI-7:11:
+    standard:
+      name: nist_800_53:rev4
+    family: SI
+    title: CONFINED ENVIRONMENTS WITH LIMITED PRIVILEGES
+    description: 'The organization requires that [Assignment: organization-defined
+      user-installed software] execute in a confined physical or virtual machine environment
+      with limited privileges.'
+  nist_800_53:rev4:SI-7:12:
+    standard:
+      name: nist_800_53:rev4
+    family: SI
+    title: INTEGRITY VERIFICATION
+    description: 'The organization requires that the integrity of [Assignment: organization-defined
+      user-installed software] be verified prior to execution.'
+  nist_800_53:rev4:SI-7:13:
+    standard:
+      name: nist_800_53:rev4
+    family: SI
+    title: CODE EXECUTION IN PROTECTED ENVIRONMENTS
+    description: 'The organization allows execution of binary or machine-executable
+      code obtained from sources with limited or no warranty and without the provision
+      of source code only in confined physical or virtual machine environments and
+      with the explicit approval of [Assignment: organization-defined personnel or
+      roles].'
+  nist_800_53:rev4:SI-7:14:
+    standard:
+      name: nist_800_53:rev4
+    family: SI
+    title: BINARY OR MACHINE EXECUTABLE CODE
+    description: 'The organization:'
+  nist_800_53:rev4:SI-7:14:a:
+    standard:
+      name: nist_800_53:rev4
+    family: SI
+    title: SI-7 (14)(a)
+    description: Prohibits the use of binary or machine-executable code from sources
+      with limited or no warranty and without the provision of source code; and
+  nist_800_53:rev4:SI-7:14:b:
+    standard:
+      name: nist_800_53:rev4
+    family: SI
+    title: SI-7 (14)(b)
+    description: Provides exceptions to the source code requirement only for compelling
+      mission/operational requirements and with the approval of the authorizing official.
+  nist_800_53:rev4:SI-7:15:
+    standard:
+      name: nist_800_53:rev4
+    family: SI
+    title: CODE AUTHENTICATION
+    description: 'The information system implements cryptographic mechanisms to authenticate
+      [Assignment: organization-defined software or firmware components] prior to
+      installation.'
+  nist_800_53:rev4:SI-7:16:
+    standard:
+      name: nist_800_53:rev4
+    family: SI
+    title: TIME LIMIT ON PROCESS EXECUTION W/O SUPERVISION
+    description: 'The organization does not allow processes to execute without supervision
+      for more than [Assignment: organization-defined time period].'
+  nist_800_53:rev4:SI-8:a:
+    standard:
+      name: nist_800_53:rev4
+    family: SI
+    title: SI-8a.
+    description: Employs spam protection mechanisms at information system entry and
+      exit points to detect and take action on unsolicited messages; and
+  nist_800_53:rev4:SI-8:b:
+    standard:
+      name: nist_800_53:rev4
+    family: SI
+    title: SI-8b.
+    description: Updates spam protection mechanisms when new releases are available
+      in accordance with organizational configuration management policy and procedures.
+  nist_800_53:rev4:SI-8:1:
+    standard:
+      name: nist_800_53:rev4
+    family: SI
+    title: CENTRAL MANAGEMENT
+    description: The organization centrally manages spam protection mechanisms.
+  nist_800_53:rev4:SI-8:2:
+    standard:
+      name: nist_800_53:rev4
+    family: SI
+    title: AUTOMATIC UPDATES
+    description: The information system automatically updates spam protection mechanisms.
+  nist_800_53:rev4:SI-8:3:
+    standard:
+      name: nist_800_53:rev4
+    family: SI
+    title: CONTINUOUS LEARNING CAPABILITY
+    description: The information system implements spam protection mechanisms with
+      a learning capability to more effectively identify legitimate communications
+      traffic.
+  nist_800_53:rev4:SI-10:1:
+    standard:
+      name: nist_800_53:rev4
+    family: SI
+    title: MANUAL OVERRIDE CAPABILITY
+    description: 'The information system:'
+  nist_800_53:rev4:SI-10:1:a:
+    standard:
+      name: nist_800_53:rev4
+    family: SI
+    title: SI-10 (1)(a)
+    description: 'Provides a manual override capability for input validation of [Assignment:
+      organization-defined inputs];'
+  nist_800_53:rev4:SI-10:1:b:
+    standard:
+      name: nist_800_53:rev4
+    family: SI
+    title: SI-10 (1)(b)
+    description: 'Restricts the use of the manual override capability to only [Assignment:
+      organization-defined authorized individuals]; and'
+  nist_800_53:rev4:SI-10:1:c:
+    standard:
+      name: nist_800_53:rev4
+    family: SI
+    title: SI-10 (1)(c)
+    description: Audits the use of the manual override capability.
+  nist_800_53:rev4:SI-10:2:
+    standard:
+      name: nist_800_53:rev4
+    family: SI
+    title: REVIEW / RESOLUTION OF ERRORS
+    description: 'The organization ensures that input validation errors are reviewed
+      and resolved within [Assignment: organization-defined time period].'
+  nist_800_53:rev4:SI-10:3:
+    standard:
+      name: nist_800_53:rev4
+    family: SI
+    title: PREDICTABLE BEHAVIOR
+    description: The information system behaves in a predictable and documented manner
+      that reflects organizational and system objectives when invalid inputs are received.
+  nist_800_53:rev4:SI-10:4:
+    standard:
+      name: nist_800_53:rev4
+    family: SI
+    title: REVIEW / TIMING INTERACTIONS
+    description: The organization accounts for timing interactions among information
+      system components in determining appropriate responses for invalid inputs.
+  nist_800_53:rev4:SI-10:5:
+    standard:
+      name: nist_800_53:rev4
+    family: SI
+    title: RESTRICT INPUTS TO TRUSTED SOURCES AND APPROVED FORMATS
+    description: 'The organization restricts the use of information inputs to [Assignment:
+      organization-defined trusted sources] and/or [Assignment: organization-defined
+      formats].'
+  nist_800_53:rev4:SI-11:a:
+    standard:
+      name: nist_800_53:rev4
+    family: SI
+    title: SI-11a.
+    description: Generates error messages that provide information necessary for corrective
+      actions without revealing information that could be exploited by adversaries;
+      and
+  nist_800_53:rev4:SI-11:b:
+    standard:
+      name: nist_800_53:rev4
+    family: SI
+    title: SI-11b.
+    description: 'Reveals error messages only to [Assignment: organization-defined
+      personnel or roles].'
+  nist_800_53:rev4:SI-13:a:
+    standard:
+      name: nist_800_53:rev4
+    family: SI
+    title: SI-13a.
+    description: 'Determines mean time to failure (MTTF) for [Assignment: organization-defined
+      information system components] in specific environments of operation; and'
+  nist_800_53:rev4:SI-13:b:
+    standard:
+      name: nist_800_53:rev4
+    family: SI
+    title: SI-13b.
+    description: 'Provides substitute information system components and a means to
+      exchange active and standby components at [Assignment: organization-defined
+      MTTF substitution criteria].'
+  nist_800_53:rev4:SI-13:1:
+    standard:
+      name: nist_800_53:rev4
+    family: SI
+    title: TRANSFERRING COMPONENT RESPONSIBILITIES
+    description: 'The organization takes information system components out of service
+      by transferring component responsibilities to substitute components no later
+      than [Assignment: organization-defined fraction or percentage] of mean time
+      to failure.'
+  nist_800_53:rev4:SI-13:2:
+    standard:
+      name: nist_800_53:rev4
+    family: SI
+    title: TIME LIMIT ON PROCESS EXECUTION WITHOUT SUPERVISION
+    description: "[Withdrawn: Incorporated into SI-7 (16)]."
+  nist_800_53:rev4:SI-13:3:
+    standard:
+      name: nist_800_53:rev4
+    family: SI
+    title: MANUAL TRANSFER BETWEEN COMPONENTS
+    description: 'The organization manually initiates transfers between active and
+      standby information system components [Assignment: organization-defined frequency]
+      if the mean time to failure exceeds [Assignment: organization-defined time period].'
+  nist_800_53:rev4:SI-13:4:
+    standard:
+      name: nist_800_53:rev4
+    family: SI
+    title: STANDBY COMPONENT INSTALLATION / NOTIFICATION
+    description: 'The organization, if information system component failures are detected:'
+  nist_800_53:rev4:SI-13:4:a:
+    standard:
+      name: nist_800_53:rev4
+    family: SI
+    title: SI-13 (4)(a)
+    description: 'Ensures that the standby components are successfully and transparently
+      installed within [Assignment: organization-defined time period]; and'
+  nist_800_53:rev4:SI-13:4:b:
+    standard:
+      name: nist_800_53:rev4
+    family: SI
+    title: SI-13 (4)(b)
+    description: "[Selection (one or more): activates [Assignment: organization-defined
+      alarm]; automatically shuts down the information system]."
+  nist_800_53:rev4:SI-13:5:
+    standard:
+      name: nist_800_53:rev4
+    family: SI
+    title: FAILOVER CAPABILITY
+    description: 'The organization provides [Selection: real-time; near real-time]
+      [Assignment: organization-defined failover capability] for the information system.'
+  nist_800_53:rev4:SI-14:1:
+    standard:
+      name: nist_800_53:rev4
+    family: SI
+    title: REFRESH FROM TRUSTED SOURCES
+    description: 'The organization ensures that software and data employed during
+      information system component and service refreshes are obtained from [Assignment:
+      organization-defined trusted sources].'
+  nist_800_53:rev4:PM-1:a:
+    standard:
+      name: nist_800_53:rev4
+    family: PM
+    title: PM-1a.
+    description: 'Develops and disseminates an organization-wide information security
+      program plan that:'
+  nist_800_53:rev4:PM-1:a:1:
+    standard:
+      name: nist_800_53:rev4
+    family: PM
+    title: PM-1a.1.
+    description: Provides an overview of the requirements for the security program
+      and a description of the security program management controls and common controls
+      in place or planned for meeting those requirements;
+  nist_800_53:rev4:PM-1:a:2:
+    standard:
+      name: nist_800_53:rev4
+    family: PM
+    title: PM-1a.2.
+    description: Includes the identification and assignment of roles, responsibilities,
+      management commitment, coordination among organizational entities, and compliance;
+  nist_800_53:rev4:PM-1:a:3:
+    standard:
+      name: nist_800_53:rev4
+    family: PM
+    title: PM-1a.3.
+    description: Reflects coordination among organizational entities responsible for
+      the different aspects of information security (i.e., technical, physical, personnel,
+      cyber-physical); and
+  nist_800_53:rev4:PM-1:a:4:
+    standard:
+      name: nist_800_53:rev4
+    family: PM
+    title: PM-1a.4.
+    description: Is approved by a senior official with responsibility and accountability
+      for the risk being incurred to organizational operations (including mission,
+      functions, image, and reputation), organizational assets, individuals, other
+      organizations, and the Nation;
+  nist_800_53:rev4:PM-1:b:
+    standard:
+      name: nist_800_53:rev4
+    family: PM
+    title: PM-1b.
+    description: 'Reviews the organization-wide information security program plan
+      [Assignment: organization-defined frequency];'
+  nist_800_53:rev4:PM-1:c:
+    standard:
+      name: nist_800_53:rev4
+    family: PM
+    title: PM-1c.
+    description: Updates the plan to address organizational changes and problems identified
+      during plan implementation or security control assessments; and
+  nist_800_53:rev4:PM-1:d:
+    standard:
+      name: nist_800_53:rev4
+    family: PM
+    title: PM-1d.
+    description: Protects the information security program plan from unauthorized
+      disclosure and modification.
+  nist_800_53:rev4:PM-3:a:
+    standard:
+      name: nist_800_53:rev4
+    family: PM
+    title: PM-3a.
+    description: Ensures that all capital planning and investment requests include
+      the resources needed to implement the information security program and documents
+      all exceptions to this requirement;
+  nist_800_53:rev4:PM-3:b:
+    standard:
+      name: nist_800_53:rev4
+    family: PM
+    title: PM-3b.
+    description: Employs a business case/Exhibit 300/Exhibit 53 to record the resources
+      required; and
+  nist_800_53:rev4:PM-3:c:
+    standard:
+      name: nist_800_53:rev4
+    family: PM
+    title: PM-3c.
+    description: Ensures that information security resources are available for expenditure
+      as planned.
+  nist_800_53:rev4:PM-4:a:
+    standard:
+      name: nist_800_53:rev4
+    family: PM
+    title: PM-4a.
+    description: 'Implements a process for ensuring that plans of action and milestones
+      for the security program and associated organizational information systems:'
+  nist_800_53:rev4:PM-4:a:1:
+    standard:
+      name: nist_800_53:rev4
+    family: PM
+    title: PM-4a.1.
+    description: Are developed and maintained;
+  nist_800_53:rev4:PM-4:a:2:
+    standard:
+      name: nist_800_53:rev4
+    family: PM
+    title: PM-4a.2.
+    description: Document the remedial information security actions to adequately
+      respond to risk to organizational operations and assets, individuals, other
+      organizations, and the Nation; and
+  nist_800_53:rev4:PM-4:a:3:
+    standard:
+      name: nist_800_53:rev4
+    family: PM
+    title: PM-4a.3.
+    description: Are reported in accordance with OMB FISMA reporting requirements.
+  nist_800_53:rev4:PM-4:b:
+    standard:
+      name: nist_800_53:rev4
+    family: PM
+    title: PM-4b.
+    description: Reviews plans of action and milestones for consistency with the organizational
+      risk management strategy and organization-wide priorities for risk response
+      actions.
+  nist_800_53:rev4:PM-9:a:
+    standard:
+      name: nist_800_53:rev4
+    family: PM
+    title: PM-9a.
+    description: Develops a comprehensive strategy to manage risk to organizational
+      operations and assets, individuals, other organizations, and the Nation associated
+      with the operation and use of information systems;
+  nist_800_53:rev4:PM-9:b:
+    standard:
+      name: nist_800_53:rev4
+    family: PM
+    title: PM-9b.
+    description: Implements the risk management strategy consistently across the organization;
+      and
+  nist_800_53:rev4:PM-9:c:
+    standard:
+      name: nist_800_53:rev4
+    family: PM
+    title: PM-9c.
+    description: 'Reviews and updates the risk management strategy [Assignment: organization-defined
+      frequency] or as required, to address organizational changes.'
+  nist_800_53:rev4:PM-10:a:
+    standard:
+      name: nist_800_53:rev4
+    family: PM
+    title: PM-10a.
+    description: Manages (i.e., documents, tracks, and reports) the security state
+      of organizational information systems and the environments in which those systems
+      operate through security authorization processes;
+  nist_800_53:rev4:PM-10:b:
+    standard:
+      name: nist_800_53:rev4
+    family: PM
+    title: PM-10b.
+    description: Designates individuals to fulfill specific roles and responsibilities
+      within the organizational risk management process; and
+  nist_800_53:rev4:PM-10:c:
+    standard:
+      name: nist_800_53:rev4
+    family: PM
+    title: PM-10c.
+    description: Fully integrates the security authorization processes into an organization-wide
+      risk management program.
+  nist_800_53:rev4:PM-11:a:
+    standard:
+      name: nist_800_53:rev4
+    family: PM
+    title: PM-11a.
+    description: Defines mission/business processes with consideration for information
+      security and the resulting risk to organizational operations, organizational
+      assets, individuals, other organizations, and the Nation; and
+  nist_800_53:rev4:PM-11:b:
+    standard:
+      name: nist_800_53:rev4
+    family: PM
+    title: PM-11b.
+    description: Determines information protection needs arising from the defined
+      mission/business processes and revises the processes as necessary, until achievable
+      protection needs are obtained.
+  nist_800_53:rev4:PM-14:a:
+    standard:
+      name: nist_800_53:rev4
+    family: PM
+    title: PM-14a.
+    description: 'Implements a process for ensuring that organizational plans for
+      conducting security testing, training, and monitoring activities associated
+      with organizational information systems:'
+  nist_800_53:rev4:PM-14:a:1:
+    standard:
+      name: nist_800_53:rev4
+    family: PM
+    title: PM-14a.1.
+    description: Are developed and maintained; and
+  nist_800_53:rev4:PM-14:a:2:
+    standard:
+      name: nist_800_53:rev4
+    family: PM
+    title: PM-14a.2.
+    description: Continue to be executed in a timely manner;
+  nist_800_53:rev4:PM-14:b:
+    standard:
+      name: nist_800_53:rev4
+    family: PM
+    title: PM-14b.
+    description: Reviews testing, training, and monitoring plans for consistency with
+      the organizational risk management strategy and organization-wide priorities
+      for risk response actions.
+  nist_800_53:rev4:PM-15:
+    standard:
+      name: nist_800_53:rev4
+    family: PM
+    title: CONTACTS WITH SECURITY GROUPS AND ASSOCIATIONS
+    description: 'The organization establishes and institutionalizes contact with
+      selected groups and associations within the security community:'
+  nist_800_53:rev4:PM-15:a:
+    standard:
+      name: nist_800_53:rev4
+    family: PM
+    title: PM-15a.
+    description: To facilitate ongoing security education and training for organizational
+      personnel;
+  nist_800_53:rev4:PM-15:b:
+    standard:
+      name: nist_800_53:rev4
+    family: PM
+    title: PM-15b.
+    description: To maintain currency with recommended security practices, techniques,
+      and technologies; and
+  nist_800_53:rev4:PM-15:c:
+    standard:
+      name: nist_800_53:rev4
+    family: PM
+    title: PM-15c.
+    description: To share current security-related information including threats,
+      vulnerabilities, and incidents.
+  nist_800_53:rev4:PM-16:
+    standard:
+      name: nist_800_53:rev4
+    family: PM
+    title: THREAT AWARENESS PROGRAM
+    description: The organization implements a threat awareness program that includes
+      a cross-organization information-sharing capability.


### PR DESCRIPTION
Add NIST 800.53 rev4 sub-controls to the control list. These are
controls that are 'tailored' in specifically by security engineers
to match the site specific policies, and therefore they aren't in the
default nist_800_53_rev4 profile, but are mapped to checks in compliance
engine.

SIMP-5526 #comment pupmod-simp-compliance_markup