### PR TITLE
(SIMP-5600) Add 'compliance_markup::debug::hiera_backend_compile_time'

### DIFF
--- a/lib/puppet/functions/compliance_markup/enforcement.rb
+++ b/lib/puppet/functions/compliance_markup/enforcement.rb
@@ -3,6 +3,11 @@ Puppet::Functions.create_function(:'compliance_markup::enforcement') do
     param "String", :key
     param "Hash", :options
     param "Puppet::LookupContext", :context
+    end
+  dispatch :hiera_enforcement do
+    param "String", :key
+    param "Hash", :options
+    param "Undef", :context
   end
   def initialize(closure_scope, loader)
     filename = File.expand_path('../../../../puppetx/simp/compliance_mapper.rb', __FILE__)
@@ -21,7 +26,7 @@ Puppet::Functions.create_function(:'compliance_markup::enforcement') do
       unless (e.class.to_s == 'ArgumentError')
         debug("Threw error #{e.to_s}")
       end
-      context.not_found
+      not_found
     end
     retval
   end
@@ -31,16 +36,33 @@ Puppet::Functions.create_function(:'compliance_markup::enforcement') do
   def environment()
     closure_scope.environment.name.to_s
   end
+  def not_found()
+    if (!@context.nil?)
+      @context.not_found
+    else
+      throw :no_such_key
+    end
+  end
   def debug(message)
-    @context.explain() { "#{message}" }
+    if (!@context.nil?)
+      @context.explain() { "#{message}" }
+    end
   end
   def cache(key, value)
-    @context.cache(key, value)
+    if (!@context.nil?)
+      @context.cache(key, value)
+    end
   end
   def cached_value(key)
-    @context.cached_value(key)
+    if (!@context.nil?)
+      @context.cached_value(key)
+    end
   end
   def cache_has_key(key)
-    @context.cache_has_key(key)
+    if (!@context.nil?)
+      @context.cache_has_key(key)
+    else
+      false
+    end
   end
 end

--- a/lib/puppetx/simp/compliance_mapper.rb
+++ b/lib/puppetx/simp/compliance_mapper.rb
@@ -45,7 +45,7 @@ def enforcement(key, options = {"mode" => "value"}, &block)
       throw :no_such_key
     when "compliance_markup::percent_sign"
       throw :no_such_key
-    else
+  else
       retval = :notfound
       if cache_has_key("lock")
         lock = cached_value("lock")
@@ -80,10 +80,11 @@ def enforcement(key, options = {"mode" => "value"}, &block)
               end
 
               cache("debug_output_#{profile}", debug_output)
-              cache("compliance_map_#{profile}", profile_map)
 
               compile_end_time = Time.now
 
+              profile_map["compliance_markup::debug::hiera_backend_compile_time"] = (compile_end_time - compile_start_time)
+              cache("compliance_map_#{profile}", profile_map)
               debug("debug: compiled compliance_map containing #{profile_map.size} keys in #{compile_end_time - compile_start_time} seconds")
             end
             if key == "compliance_markup::debug::dump"

--- a/spec/functions/compliance_markup/enforcement_spec.rb
+++ b/spec/functions/compliance_markup/enforcement_spec.rb
@@ -2,17 +2,18 @@
 
 require 'spec_helper'
 require 'semantic_puppet'
+require 'puppet/pops/lookup/context'
 puppetver = SemanticPuppet::Version.parse(Puppet.version)
-requiredver = SemanticPuppet::Version.parse("20.9.0")
+requiredver = SemanticPuppet::Version.parse("4.10.0")
 if (puppetver > requiredver)
-  describe 'compliance_markup::hiera_backend' do
+  describe 'compliance_markup::enforcement' do
     context "when key doesn't exist in the compliance map" do
       let(:hieradata){ "test_spec" }
       it 'should throw an error' do
         errored = false
         ex = nil
         begin
-          result = subject.execute("compliance_markup::test::nonexistent", {}, Puppet::LookupContext.new('rp_env', 'compliance_markup'))
+          result = subject.execute("compliance_markup::test::nonexistent", {}, nil)
         rescue Exception => e
           ex = e
           errored = true
@@ -23,7 +24,7 @@ if (puppetver > requiredver)
         errored = false
         ex = nil
         begin
-          result = subject.execute("compliance_markup::test::nonexistent", {}, Puppet::LookupContext.new('rp_env', 'compliance_markup'))
+          result = subject.execute("compliance_markup::test::nonexistent", {}, nil)
         rescue Exception => e
           ex = e
           errored = true
@@ -37,7 +38,7 @@ if (puppetver > requiredver)
         errored = false
         ex = nil
         begin
-          result = subject.execute("compliance_markup::test::testvariable", {}, Puppet::LookupContext.new('rp_env', 'compliance_markup'))
+          result = subject.execute("compliance_markup::test::testvariable", {}, nil)
         rescue Exception => e
           ex = e
           errored = true
@@ -48,7 +49,7 @@ if (puppetver > requiredver)
         errored = false
         ex = nil
         begin
-          result = subject.execute("compliance_markup::test::testvariable", {}, Puppet::LookupContext.new('rp_env', 'compliance_markup'))
+          result = subject.execute("compliance_markup::test::testvariable", {}, nil)
         rescue Exception => e
           ex = e
           errored = true
@@ -59,12 +60,28 @@ if (puppetver > requiredver)
         errored = false
         ex = nil
         begin
-          result = subject.execute("compliance_markup::test::testvariable", {}, Puppet::LookupContext.new('m'))
+          result = subject.execute("compliance_markup::test::testvariable", {}, nil)
         rescue Exception => e
           ex = e
           errored = true
         end
         expect(ex.to_s).to_not match(/no_such_key/)
+      end
+    end
+
+    context "when key == compliance_markup::debug::hiera_backend_compile_time" do
+      let(:hieradata){ "test_spec" }
+      it 'should return an number' do
+        errored = false
+        ex = nil
+        begin
+          result = subject.execute("compliance_markup::debug::hiera_backend_compile_time", {}, nil)
+        rescue Exception => e
+          ex = e
+          errored = true
+        end
+        puts "    completed in #{result} seconds"
+        expect(result).to be_a(Float)
       end
     end
   end


### PR DESCRIPTION
Add 'compliance_markup::debug::hiera_backend_compile_time' virtual
parameter for use in debugging performance in production environments.

This is accessible both through puppet lookup and puppet catalog compilations

SIMP-5600 #comment pupmod-simp-compliance_markup