### PR TITLE
(SIMP-5599) use context.cached_file_data in the hiera backend

### DIFF
--- a/lib/puppet/functions/compliance_markup/enforcement.rb
+++ b/lib/puppet/functions/compliance_markup/enforcement.rb
@@ -34,8 +34,33 @@ Puppet::Functions.create_function(:'compliance_markup::enforcement') do
   def debug(message)
     @context.explain() { "#{message}" }
   end
+  def cache?
+    if (!@context.nil?)
+      true
+    else
+      false
+    end
+  end
   def cache(key, value)
     @context.cache(key, value)
+  end
+  def cache_has_key(key)
+    if (!@context.nil?)
+      @context.cache_has_key(key)
+    else
+      false
+    end
+  end
+  def cached_file_data(path)
+    data = nil
+    if (!@context.nil?)
+      @context.cached_file_data(path) do |contents|
+        data = contents
+      end
+    else
+      data = File.read(path)
+    end
+    data
   end
   def cached_value(key)
     @context.cached_value(key)

--- a/lib/puppetx/simp/compliance_map.rb
+++ b/lib/puppetx/simp/compliance_map.rb
@@ -450,23 +450,31 @@ def cache(key, value)
   end
   @hash[key] = value
 end
+
 def cached_value(key)
   if @hash == nil
     @hash = {}
   end
   @hash[key]
 end
+
 def cache_has_key(key)
   if @hash == nil
     @hash = {}
   end
   @hash.key?(key)
 end
+
 def debug(message)
   return
 end
+
 def codebase
   "compliance_map"
+end
+
+def cached_file_data(path)
+  File.read(path)
 end
 
 def environment

--- a/lib/puppetx/simp/compliance_mapper.rb
+++ b/lib/puppetx/simp/compliance_mapper.rb
@@ -224,12 +224,13 @@ def compiler_class()
             ]
             interp_pathspecs.each do |interp_pathspec|
               Dir.glob(interp_pathspec) do |filename|
+                filedata = @callback.cached_file_data(filename)
                 begin
                   case type
-                    when 'yaml'
-                      @compliance_data[filename] = YAML.load(File.read(filename))
+                  when 'yaml'
+                      @compliance_data[filename] = YAML.load(filedata)
                     when 'json'
-                      @compliance_data[filename] = JSON.parse(File.read(filename))
+                      @compliance_data[filename] = JSON.parse(filedata)
                   end
                 rescue
                 end


### PR DESCRIPTION
Use context.cached_file_data if it's available to cache file reads
in memory between catalog compiles. Has no effect on non-puppetserver
catalog compiles.

SIMP-5599 #comment pupmod-simp-compliance_markup