### PR TITLE
(SIMP-5525) Fix compliance_map_migrate output

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+* Wed Oct 31 2018 Steven Pritchard <steven.pritchard@onyxpoint.com> - 2.4.1-0
+- Fix the output of utils/compliance_map_migrate
+
 * Fri Oct 19 2018 Liz Nemsick <lnemsick.simp@gmail.com> - 2.4.1-0
 - Fixed the following incorrect parameter types
   - simp::yum::schedule::minute

--- a/utils/compliance_map_migrate
+++ b/utils/compliance_map_migrate
@@ -273,7 +273,7 @@ class HieraXlat
     if options.target_module
       to_ret = self.send(xlat_name.to_sym, options.input, options.target_module)
     else
-      to_ret = self.send(xlat_name.to_sym, options.input).to_yaml
+      to_ret = self.send(xlat_name.to_sym, options.input)
     end
 
     if options.output_format == 'yaml'


### PR DESCRIPTION
`utils/compliance_map_migrate` contained an errant `to_yaml` which
caused incorrect output.

SIMP-5525 #comment utils/compliance_map_migrate should be usable with this change.