### PR TITLE
(SIMP-5663) Fix errors in v1 compliance_markup data

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,11 @@
+* Fri Nov 02 2018 Steven Pritchard <steven.pritchard@onyxpoint.com> - 2.4.1-0
+- Fix the following keys:
+  - simp::mountpoints::tmp::secure
+  - simp::root_user::manage_group
+  - simp::root_user::manage_perms
+  - simp::root_user::manage_user
+  - ssh::server::conf::pki
+
 * Wed Oct 31 2018 Steven Pritchard <steven.pritchard@onyxpoint.com> - 2.4.1-0
 - Fix the output of utils/compliance_map_migrate
 

--- a/data/compliance_profiles/CentOS/6/nist_800_53_rev4.json
+++ b/data/compliance_profiles/CentOS/6/nist_800_53_rev4.json
@@ -1278,7 +1278,7 @@
           "nosuid"
         ]
       },
-      "simp::mountpoints:tmp::secure": {
+      "simp::mountpoints::tmp::secure": {
         "identifiers": [
           "AC-3",
           "CM-7"
@@ -1305,21 +1305,21 @@
         "notes": "Setting this number higher than 10 should be justified",
         "value": 10
       },
-      "simp:root_user::manage_group": {
+      "simp::root_user::manage_group": {
         "identifiers": [
           "AC-3",
           "CM-7"
         ],
         "value": true
       },
-      "simp:root_user::manage_perms": {
+      "simp::root_user::manage_perms": {
         "identifiers": [
           "AC-3",
           "CM-7"
         ],
         "value": true
       },
-      "simp:root_user::manage_user": {
+      "simp::root_user::manage_user": {
         "identifiers": [
           "AC-3",
           "CM-7"
@@ -2304,7 +2304,7 @@
         ],
         "value": false
       },
-      "ssh::server:conf::pki": {
+      "ssh::server::conf::pki": {
         "identifiers": [
           "SC-8(1)",
           "SC-8(2)",

--- a/data/compliance_profiles/CentOS/7/nist_800_53_rev4.json
+++ b/data/compliance_profiles/CentOS/7/nist_800_53_rev4.json
@@ -1278,7 +1278,7 @@
           "nosuid"
         ]
       },
-      "simp::mountpoints:tmp::secure": {
+      "simp::mountpoints::tmp::secure": {
         "identifiers": [
           "AC-3",
           "CM-7"
@@ -1305,21 +1305,21 @@
         "notes": "Setting this number higher than 10 should be justified",
         "value": 10
       },
-      "simp:root_user::manage_group": {
+      "simp::root_user::manage_group": {
         "identifiers": [
           "AC-3",
           "CM-7"
         ],
         "value": true
       },
-      "simp:root_user::manage_perms": {
+      "simp::root_user::manage_perms": {
         "identifiers": [
           "AC-3",
           "CM-7"
         ],
         "value": true
       },
-      "simp:root_user::manage_user": {
+      "simp::root_user::manage_user": {
         "identifiers": [
           "AC-3",
           "CM-7"
@@ -2304,7 +2304,7 @@
         ],
         "value": false
       },
-      "ssh::server:conf::pki": {
+      "ssh::server::conf::pki": {
         "identifiers": [
           "SC-8(1)",
           "SC-8(2)",

--- a/data/compliance_profiles/OracleLinux/6/nist_800_53_rev4.json
+++ b/data/compliance_profiles/OracleLinux/6/nist_800_53_rev4.json
@@ -1287,7 +1287,7 @@
           "nosuid"
         ]
       },
-      "simp::mountpoints:tmp::secure": {
+      "simp::mountpoints::tmp::secure": {
         "identifiers": [
           "AC-3",
           "CM-7"
@@ -1314,21 +1314,21 @@
         "notes": "Setting this number higher than 10 should be justified",
         "value": 10
       },
-      "simp:root_user::manage_group": {
+      "simp::root_user::manage_group": {
         "identifiers": [
           "AC-3",
           "CM-7"
         ],
         "value": true
       },
-      "simp:root_user::manage_perms": {
+      "simp::root_user::manage_perms": {
         "identifiers": [
           "AC-3",
           "CM-7"
         ],
         "value": true
       },
-      "simp:root_user::manage_user": {
+      "simp::root_user::manage_user": {
         "identifiers": [
           "AC-3",
           "CM-7"
@@ -2313,7 +2313,7 @@
         ],
         "value": false
       },
-      "ssh::server:conf::pki": {
+      "ssh::server::conf::pki": {
         "identifiers": [
           "SC-8(1)",
           "SC-8(2)",

--- a/data/compliance_profiles/OracleLinux/7/nist_800_53_rev4.json
+++ b/data/compliance_profiles/OracleLinux/7/nist_800_53_rev4.json
@@ -1287,7 +1287,7 @@
           "nosuid"
         ]
       },
-      "simp::mountpoints:tmp::secure": {
+      "simp::mountpoints::tmp::secure": {
         "identifiers": [
           "AC-3",
           "CM-7"
@@ -1314,21 +1314,21 @@
         "notes": "Setting this number higher than 10 should be justified",
         "value": 10
       },
-      "simp:root_user::manage_group": {
+      "simp::root_user::manage_group": {
         "identifiers": [
           "AC-3",
           "CM-7"
         ],
         "value": true
       },
-      "simp:root_user::manage_perms": {
+      "simp::root_user::manage_perms": {
         "identifiers": [
           "AC-3",
           "CM-7"
         ],
         "value": true
       },
-      "simp:root_user::manage_user": {
+      "simp::root_user::manage_user": {
         "identifiers": [
           "AC-3",
           "CM-7"
@@ -2313,7 +2313,7 @@
         ],
         "value": false
       },
-      "ssh::server:conf::pki": {
+      "ssh::server::conf::pki": {
         "identifiers": [
           "SC-8(1)",
           "SC-8(2)",

--- a/data/compliance_profiles/RedHat/6/nist_800_53_rev4.json
+++ b/data/compliance_profiles/RedHat/6/nist_800_53_rev4.json
@@ -1287,7 +1287,7 @@
           "nosuid"
         ]
       },
-      "simp::mountpoints:tmp::secure": {
+      "simp::mountpoints::tmp::secure": {
         "identifiers": [
           "AC-3",
           "CM-7"
@@ -1314,21 +1314,21 @@
         "notes": "Setting this number higher than 10 should be justified",
         "value": 10
       },
-      "simp:root_user::manage_group": {
+      "simp::root_user::manage_group": {
         "identifiers": [
           "AC-3",
           "CM-7"
         ],
         "value": true
       },
-      "simp:root_user::manage_perms": {
+      "simp::root_user::manage_perms": {
         "identifiers": [
           "AC-3",
           "CM-7"
         ],
         "value": true
       },
-      "simp:root_user::manage_user": {
+      "simp::root_user::manage_user": {
         "identifiers": [
           "AC-3",
           "CM-7"
@@ -2313,7 +2313,7 @@
         ],
         "value": false
       },
-      "ssh::server:conf::pki": {
+      "ssh::server::conf::pki": {
         "identifiers": [
           "SC-8(1)",
           "SC-8(2)",

--- a/data/compliance_profiles/RedHat/7/nist_800_53_rev4.json
+++ b/data/compliance_profiles/RedHat/7/nist_800_53_rev4.json
@@ -1287,7 +1287,7 @@
           "nosuid"
         ]
       },
-      "simp::mountpoints:tmp::secure": {
+      "simp::mountpoints::tmp::secure": {
         "identifiers": [
           "AC-3",
           "CM-7"
@@ -1314,21 +1314,21 @@
         "notes": "Setting this number higher than 10 should be justified",
         "value": 10
       },
-      "simp:root_user::manage_group": {
+      "simp::root_user::manage_group": {
         "identifiers": [
           "AC-3",
           "CM-7"
         ],
         "value": true
       },
-      "simp:root_user::manage_perms": {
+      "simp::root_user::manage_perms": {
         "identifiers": [
           "AC-3",
           "CM-7"
         ],
         "value": true
       },
-      "simp:root_user::manage_user": {
+      "simp::root_user::manage_user": {
         "identifiers": [
           "AC-3",
           "CM-7"
@@ -2313,7 +2313,7 @@
         ],
         "value": false
       },
-      "ssh::server:conf::pki": {
+      "ssh::server::conf::pki": {
         "identifiers": [
           "SC-8(1)",
           "SC-8(2)",


### PR DESCRIPTION
Several keys in the v1 compliance_markup data were missing a ':'
separator.  They are corrected with this change.

SIMP-5663 #close