### PR TITLE
(SIMP-5711) compliance_markup acceptance tests fail

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,180 +1,240 @@
 # The testing matrix considers ruby/puppet versions supported by SIMP and PE:
 #
-# https://puppet.com/docs/pe/2017.3/overview/component_versions_in_recent_pe_releases.html
+# https://puppet.com/docs/pe/2018.1/component_versions_in_recent_pe_releases.html
 # https://puppet.com/misc/puppet-enterprise-lifecycle
-# https://puppet.com/docs/pe/2017.3/overview/getting_support_for_pe.html#standard-releases-and-long-term-support-releases
+# https://puppet.com/docs/pe/2018.1/overview/getting_support_for_pe.html
 # ------------------------------------------------------------------------------
-#  release    pup   ruby      eol
-# PE 2017.2   4.10  2.1.9  2018-02-21
-# PE 2017.3   5.3   2.4.1  2018-07
-# PE 2018.1   ???   ?????  ????-??  (LTS)
+# Release       Puppet   Ruby   EOL
+# SIMP 6.1      4.10.6   2.1.9  TBD
+# SIMP 6.2      4.10.12  2.1.9  TBD
+# PE 2016.4.15  4.10.12  2.1.9  2018-12 (LTS)
+# PE 2017.3.10  5.3.8    2.4.4  2018-12 (STS)
+# SIMP 6.3      5.5.7    2.4.4  TBD***
+# PE 2018.1     5.5.6    2.4.4  2020-05 (LTS)***
+# PE 2019.0     6.0      2.5.1  2019-08-31^^^
+#
+# *** = Modules created for SIMP 6.3+ are not required to support Puppet < 5.5
+# ^^^ = SIMP doesn't support 6 yet; tests are info-only and allowed to fail
 ---
-.cache_bundler: &cache_bundler
+stages:
+  - 'sanity'
+  - 'validation'
+  - 'acceptance'
+  - 'compliance'
+  - 'deployment'
+
+image: 'ruby:2.4'
+
+variables:
+  PUPPET_VERSION:    'UNDEFINED' # <- Matrixed jobs MUST override this (or fail)
+  BUNDLER_VERSION:   '1.17.1'
+
+  # Force dependencies into a path the gitlab-runner user can write to.
+  # (This avoids some failures on Runners with misconfigured ruby environments.)
+  GEM_HOME:          .vendor/gem_install
+  BUNDLE_CACHE_PATH: .vendor/bundle
+  BUNDLE_PATH:       .vendor/bundle
+  BUNDLE_BIN:        .vendor/gem_install/bin
+  BUNDLE_NO_PRUNE:   'true'
+
+
+# bundler dependencies and caching
+#
+# - Cache bundler gems between pipelines foreach Ruby version
+# - Try to use cached and local resources before downloading dependencies
+# --------------------------------------
+.setup_bundler_env: &setup_bundler_env
   cache:
     untracked: true
-    # A broad attempt at caching between runs (ala Travis CI)
-    key: "${CI_PROJECT_NAMESPACE}__bundler"
+    key: "${CI_PROJECT_NAMESPACE}_ruby-${MATRIX_RUBY_VERSION}_bundler"
     paths:
       - '.vendor'
-      - 'vendor'
-
-.setup_bundler_env: &setup_bundler_env
   before_script:
-    - 'echo Files in cache: $(find .vendor | wc -l) || :'
-    - 'export GEM_HOME=.vendor/gem_install'
-    - 'export BUNDLE_CACHE_PATH=.vendor/bundler'
-    - 'declare GEM_BUNDLER_VER=(-v ''~> ${BUNDLER_VERSION:-1.16.0}'')'
-    - declare GEM_INSTALL=(gem install --no-document)
-    - declare BUNDLER_INSTALL=(bundle install --no-binstubs --jobs $(nproc) --path=.vendor "${FLAGS[@]}")
-    - gem list -ie "${GEM_BUNDLE_VER[@]}" --silent bundler || "${GEM_INSTALL[@]}" --local "${GEM_BUNDLE_VER[@]}" bundler || "${GEM_INSTALL[@]}" "${GEM_BUNDLE_VER[@]}" bundler
+    - 'ruby -e "puts %(Environment Variables:\n  * #{ENV.keys.grep(/PUPPET|SIMP|BEAKER|MATRIX/).map{|v| %(#{v} = #{ENV[v]})}.join(%(\n  * ))})"'
+    - 'declare GEM_BUNDLER_VER=(-v "~> ${BUNDLER_VERSION:-1.17.0}")'
+    - 'declare GEM_INSTALL_CMD=(gem install --no-document)'
+    - 'declare BUNDLER_INSTALL_CMD=(bundle install --no-binstubs --jobs $(nproc) "${FLAGS[@]}")'
+    - 'mkdir -p ${GEM_HOME} ${BUNDLER_BIN}'
+    - 'gem list -ie "${GEM_BUNDLER_VER[@]}" --silent bundler || "${GEM_INSTALL_CMD[@]}" --local "${GEM_BUNDLER_VER[@]}" bundler || "${GEM_INSTALL_CMD[@]}" "${GEM_BUNDLER_VER[@]}" bundler'
     - 'rm -rf pkg/ || :'
-    - bundle check || rm -f Gemfile.lock && ("${BUNDLER_INSTALL[@]}" --local || "${BUNDLER_INSTALL[@]}")
-
-
-.validation_checks: &validation_checks
-  script:
-    - bundle exec rake syntax
-    - bundle exec rake check:dot_underscore
-    - bundle exec rake check:test_file
-    - bundle exec rake pkg:check_version
-    - bundle exec rake pkg:compare_latest_tag
-    - bundle exec rake lint
-    - bundle exec rake clean
-    - ruby -r json -e 'Dir.glob("data/**/*.json").map{|j| puts "Attempting to load "+j;JSON.load(File.new(j))}'
-    - ruby -r yaml -e 'Dir.glob("data/**/*.y{,a}ml").map{|y| puts "Attempting to load "+y;YAML.load(File.new(y))}'
-    - bundle exec puppet module build
-
-.spec_tests: &spec_tests
-  script:
-    - bundle exec rake spec
+    - 'bundle check || rm -f Gemfile.lock && ("${BUNDLER_INSTALL_CMD[@]}" --local || "${BUNDLER_INSTALL_CMD[@]}" || bundle pristine ||  "${BUNDLER_INSTALL_CMD[@]}") || { echo "PIPELINE: Bundler could not install everything (see log output above)" && exit 99 ; }'
 
 # To avoid running a prohibitive number of tests every commit,
 # don't set this env var in your gitlab instance
 .only_with_SIMP_FULL_MATRIX: &only_with_SIMP_FULL_MATRIX
   only:
     variables:
-      - $SIMP_FULL_MATRIX
+      - $SIMP_FULL_MATRIX == "yes"
 
-stages:
-  - validation
-  - unit
-  - acceptance
-  - deploy
+# Puppet Versions
+#-----------------------------------------------------------------------
 
-# Puppet 4.10 for PE 2017.2 support (EOL:2018-02-21)
-# See: https://puppet.com/misc/puppet-enterprise-lifecycle
-# --------------------------------------
-pup4_10-validation:
-  stage: validation
-  tags:
-    - docker
-  image: ruby:2.1
+.pup_4: &pup_4
+  image: 'ruby:2.4'
   variables:
-    PUPPET_VERSION: '~> 4.10.0'
-  <<: *cache_bundler
-  <<: *setup_bundler_env
-  <<: *validation_checks
+    PUPPET_VERSION: '~> 4.0'
+    MATRIX_RUBY_VERSION: '2.1'
 
-pup4_10-unit:
-  stage: unit
-  tags:
-    - docker
-  image: ruby:2.1
+.pup_4_10: &pup_4_10
+  image: 'ruby:2.1'
   variables:
-    PUPPET_VERSION: '~> 4.10.0'
-  <<: *cache_bundler
-  <<: *setup_bundler_env
-  <<: *spec_tests
+    PUPPET_VERSION: '~> 4.10.4'
+    MATRIX_RUBY_VERSION: '2.1'
 
-
-# Puppet 5.3 for PE 2017.3 support (EOL: 2018-07)
-# See: https://puppet.com/misc/puppet-enterprise-lifecycle
-# --------------------------------------
-pup5_3-validation:
-  stage: validation
-  tags:
-    - docker
-  image: ruby:2.4
-  variables:
-    PUPPET_VERSION: '~> 5.3.0'
-  <<: *cache_bundler
-  <<: *setup_bundler_env
-  <<: *validation_checks
-
-pup5_3-unit:
-  stage: unit
-  tags:
-    - docker
-  image: ruby:2.4
-  variables:
-    PUPPET_VERSION: '~> 5.3.0'
-  <<: *cache_bundler
-  <<: *setup_bundler_env
-  <<: *spec_tests
-
-
-# Keep an eye on the latest puppet 5
-# ----------------------------------
-pup5_latest-validation:
-  stage: validation
-  tags:
-    - docker
-  image: ruby:2.4
+.pup_5: &pup_5
+  image: 'ruby:2.4'
   variables:
     PUPPET_VERSION: '~> 5.0'
-  <<: *cache_bundler
-  <<: *setup_bundler_env
-  <<: *validation_checks
-
-pup5_latest-unit:
-  stage: unit
-  tags:
-    - docker
-  image: ruby:2.4
-  variables:
-    PUPPET_VERSION: '~> 5.0'
-  <<: *cache_bundler
-  <<: *setup_bundler_env
-  <<: *spec_tests
-
-
-
-# Acceptance tests
-# ==============================================================================
-default:
-  stage: acceptance
-  tags:
-    - beaker
-  <<: *cache_bundler
-  <<: *setup_bundler_env
-  variables:
-    PUPPET_VERSION: '~> 4.10.11'
-  script:
-    - bundle exec rake spec_clean
-    - bundle exec rake beaker:suites[default]
-
-default-oel:
-  stage: acceptance
-  tags:
-    - beaker
-  <<: *cache_bundler
-  <<: *setup_bundler_env
-  <<: *only_with_SIMP_FULL_MATRIX
-  variables:
-    PUPPET_VERSION: '~> 4.10.0'
-  script:
-    - bundle exec rake spec_clean
-    - bundle exec rake beaker:suites[default,oel]
-
-default-puppet5:
-  stage: acceptance
-  tags:
-    - beaker
-  <<: *cache_bundler
-  <<: *setup_bundler_env
-  variables:
-    PUPPET_VERSION: '~> 5.4.0'
     BEAKER_PUPPET_COLLECTION: 'puppet5'
+    MATRIX_RUBY_VERSION: '2.4'
+
+.pup_5_3: &pup_5_3
+  image: 'ruby:2.4'
+  variables:
+    PUPPET_VERSION: '~> 5.3.0'
+    BEAKER_PUPPET_COLLECTION: 'puppet5'
+    MATRIX_RUBY_VERSION: '2.4'
+
+.pup_5_5_7: &pup_5_5_7
+  image: 'ruby:2.4'
+  variables:
+    PUPPET_VERSION: '5.5.7'
+    BEAKER_PUPPET_COLLECTION: 'puppet5'
+    MATRIX_RUBY_VERSION: '2.4'
+
+.pup_6: &pup_6
+  allow_failure: true
+  image: 'ruby:2.5'
+  variables:
+    PUPPET_VERSION: '~> 6.0'
+    BEAKER_PUPPET_COLLECTION: 'puppet6'
+    MATRIX_RUBY_VERSION: '2.5'
+
+
+# Testing Environments
+#-----------------------------------------------------------------------
+
+.lint_tests: &lint_tests
+  stage: 'validation'
+  tags: ['docker']
+  <<: *setup_bundler_env
   script:
-    - bundle exec rake spec_clean
-    - bundle exec rake beaker:suites[default]
+    - 'bundle exec rake syntax'
+    - 'bundle exec rake lint'
+    - 'bundle exec rake metadata_lint'
+
+.unit_tests: &unit_tests
+  stage: 'validation'
+  tags: ['docker']
+  <<: *setup_bundler_env
+  script:
+    - 'bundle exec rake spec'
+
+.acceptance_tests: &acceptance_tests
+  stage: 'acceptance'
+  tags: ['beaker']
+  <<: *setup_bundler_env
+
+.compliance_tests: &compliance_tests
+  stage: 'compliance'
+  tags: ['beaker']
+  <<: *setup_bundler_env
+
+
+# Pipeline / testing matrix
+#=======================================================================
+
+sanity_checks:
+  <<: *pup_5
+  <<: *setup_bundler_env
+  stage: 'sanity'
+  tags: ['docker']
+  script:
+    - 'if `hash apt-get`; then apt-get update; fi'
+    - 'if `hash apt-get`; then apt-get install -y rpm; fi'
+    - 'bundle exec rake check:dot_underscore'
+    - 'bundle exec rake check:test_file'
+    - 'bundle exec rake pkg:check_version'
+    - 'bundle exec rake pkg:compare_latest_tag'
+    - 'bundle exec rake pkg:create_tag_changelog'
+    - 'bundle exec puppet module build'
+    - ruby -r json -e 'Dir.glob("data/**/*.json").map{|j| puts "Attempting to load "+j;JSON.load(File.new(j))}'
+    - ruby -r yaml -e 'Dir.glob("data/**/*.y{,a}ml").map{|y| puts "Attempting to load "+y;YAML.load(File.new(y))}'
+
+# Linting
+#-----------------------------------------------------------------------
+
+pup4-lint:
+  <<: *pup_4
+  <<: *lint_tests
+
+pup5-lint:
+  <<: *pup_5
+  <<: *lint_tests
+
+pup6-lint:
+  <<: *pup_6
+  <<: *lint_tests
+
+# Unit Tests
+#-----------------------------------------------------------------------
+
+pup4.10-unit:
+  <<: *pup_4_10
+  <<: *unit_tests
+
+pup5-unit:
+  <<: *pup_5
+  <<: *unit_tests
+
+pup5.3-unit:
+  <<: *pup_5_3
+  <<: *unit_tests
+
+pup5.5.7-unit:
+  <<: *pup_5_5_7
+  <<: *unit_tests
+
+pup6-unit:
+  <<: *pup_6
+  <<: *unit_tests
+
+# Acceptance Tests
+# ==============================================================================
+pup4.10:
+  <<: *pup_4_10
+  <<: *acceptance_tests
+  script:
+    - 'bundle exec rake beaker:suites'
+
+pup4.10-fips:
+  <<: *pup_4_10
+  <<: *acceptance_tests
+  <<: *only_with_SIMP_FULL_MATRIX
+  script:
+    - 'BEAKER_fips=yes bundle exec rake beaker:suites'
+
+pup5.5.7:
+  <<: *pup_5_5_7
+  <<: *acceptance_tests
+  script:
+    - 'bundle exec rake beaker:suites'
+
+pup5.5.7-fips:
+  <<: *pup_5_5_7
+  <<: *acceptance_tests
+  script:
+    - 'BEAKER_fips=yes bundle exec rake beaker:suites'
+
+pup5.5.7-oel:
+  <<: *pup_5_5_7
+  <<: *acceptance_tests
+  script:
+    - 'bundle exec rake beaker:suites[default,oel]'
+
+pup5.5.7-oel-fips:
+  <<: *pup_5_5_7
+  <<: *acceptance_tests
+  <<: *only_with_SIMP_FULL_MATRIX
+  script:
+    - 'BEAKER_fips=yes bundle exec rake beaker:suites[default,oel]'

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,32 @@
 # The testing matrix considers ruby/puppet versions supported by SIMP and PE:
+#
+# https://puppet.com/docs/pe/2018.1/component_versions_in_recent_pe_releases.html
+# https://puppet.com/misc/puppet-enterprise-lifecycle
+# https://puppet.com/docs/pe/2018.1/overview/getting_support_for_pe.html
 # ------------------------------------------------------------------------------
-#  release    pup   ruby      eol
-# PE 2017.2   4.10  2.1.9  TBD
-# PE 2017.3   5.3   2.4.1  2018-07
-# PE 2018.1   ???   ?????  ????-??  (LTS)
+# Release       Puppet   Ruby   EOL
+# SIMP 6.2      4.10     2.1.9  TBD
+# PE 2016.4     4.10     2.1.9  2018-12-31 (LTS)
+# PE 2017.3     5.3      2.4.4  2018-12-31
+# SIMP 6.3      5.5      2.4.4  TBD***
+# PE 2018.1     5.5      2.4.4  2020-05 (LTS)***
+# PE 2019.0     6.0      2.5.1  2019-08-31^^^
+#
+# *** = Modules created for SIMP 6.3+ are not required to support Puppet < 5.5
+# ^^^ = SIMP doesn't support 6 yet; tests are info-only and allowed to fail
+
 ---
 language: ruby
 cache: bundler
 sudo: false
 
-bundler_args: --without development system_tests --path .vendor
+stages:
+  - check
+  - spec
+  - name: deploy
+    if: 'fork = false AND tag = true'
 
+bundler_args: --without development system_tests --path .vendor
 
 notifications:
   email: false
@@ -23,62 +39,91 @@ addons:
 before_install:
   - rm -f Gemfile.lock
 
+global:
+  - STRICT_VARIABLES=yes
+
 jobs:
+  allow_failures:
+    - name: 'Latest Puppet 6.x (allowed to fail)'
+
   include:
     - stage: check
-      rvm: 2.4.1
-      env: STRICT_VARIABLES=yes TRUSTED_NODE_DATA=yes PUPPET_VERSION="~> 5"
+      name: 'Syntax, style, and validation checks'
+      rvm: 2.4.4
+      env: PUPPET_VERSION="~> 5.5"
       script:
         - bundle exec rake check:dot_underscore
         - bundle exec rake check:test_file
-        - bundle exec rake lint
-        - bundle exec rake metadata_lint
         - bundle exec rake pkg:check_version
+        - bundle exec rake metadata_lint
         - bundle exec rake pkg:compare_latest_tag
         - bundle exec rake pkg:create_tag_changelog
+        - bundle exec rake lint
+        - bundle exec puppet module build
         - ruby -r json -e 'Dir.glob("data/**/*.json").map{|j| puts "Attempting to load "+j;JSON.load(File.new(j))}'
         - ruby -r yaml -e 'Dir.glob("data/**/*.y{,a}ml").map{|y| puts "Attempting to load "+y;YAML.load(File.new(y))}'
-        - bundle exec puppet module build
 
     - stage: spec
-      rvm: 2.4.1
-      env: STRICT_VARIABLES=yes TRUSTED_NODE_DATA=yes PUPPET_VERSION="~> 5.0"
+      name: 'Puppet 4.10 (SIMP 6.2, PE 2016.4)'
+      rvm: 2.1.9
+      env: PUPPET_VERSION="~> 4.10.0"
       script:
         - bundle exec rake spec
 
     - stage: spec
-      rvm: 2.1.9
-      env: STRICT_VARIABLES=yes TRUSTED_NODE_DATA=yes PUPPET_VERSION="~> 4.10.0"
+      name: 'Puppet 5.3 (PE 2017.3)'
+      rvm: 2.4.4
+      env: PUPPET_VERSION="~> 5.3.0"
+      script:
+        - bundle exec rake spec
+
+    - stage: spec
+      rvm: 2.4.4
+      name: 'Puppet 5.5 (SIMP 6.3, PE 2018.1)'
+      env: PUPPET_VERSION="~> 5.5.0"
+      script:
+        - bundle exec rake spec
+
+    - stage: spec
+      name: 'Latest Puppet 5.x'
+      rvm: 2.4.4
+      env: PUPPET_VERSION="~> 5.0"
+      script:
+        - bundle exec rake spec
+
+    - stage: spec
+      name: 'Latest Puppet 6.x (allowed to fail)'
+      rvm: 2.5.1
+      env: PUPPET_VERSION="~> 6.0"
       script:
         - bundle exec rake spec
 
     - stage: acceptance
       sudo: required
       rvm: 2.1.9
+      name: 'Puppet 4.10 (SIMP 6.2, PE 2016.4)'
       bundler_args: --without development --path .vendor
       services:
         - docker
       script:
         - bundle exec rake spec_clean
         - bundle exec rake beaker:suites[default,docker_centos]
-      # PUPPET_VERSION can't handle a '~' here due to code in the test
-      env: PUPPET_VERSION="4.10.4"
+      env: PUPPET_VERSION="~> 4.10.4"
 
     - stage: acceptance
       sudo: required
-      rvm: 2.4.1
+      rvm: 2.4.4
+      name: 'Puppet 5.5 (SIMP 6.3, PE 2018.1)'
       bundler_args: --without development --path .vendor
       services:
         - docker
       script:
         - bundle exec rake spec_clean
         - bundle exec rake beaker:suites[default,docker_centos]
-      # PUPPET_VERSION can't handle a '~' here due to code in the test
-      env: PUPPET_VERSION="5.5.3" BEAKER_PUPPET_COLLECTION="puppet5"
+      env: PUPPET_VERSION="~> 5.5.7" BEAKER_PUPPET_COLLECTION="puppet5"
 
-    # This needs to be last since we have an acceptance test
     - stage: deploy
-      rvm: 2.4.1
+      rvm: 2.4.4
       script:
         - true
       before_deploy:
@@ -98,5 +143,4 @@ jobs:
               secure: "vL1MNFrE7aazh/rEsSaHugCYYWXrJmsBuhMIP27CQ/EpBQ6wfWZhukZdkikZrmkIiJHHLi1HaQycKdW2AzcqN932iXOdjYtEA9eE/hO1VtGMYVobZFS4sh2Wtt8saVOg0tMPq45hjFHUe8FmgyrsjHBB+kl/fdfLVr+TiFCmWGXtZkjMlJxqPp+fyZZDrMoKoB7eSm3edOtqX7gONP3MEJ/wcHgCUTyspxI8sSXGl8IPwWNxU4LSgCwbvr/JzmDmKiK2AbSc7Q2+g7NrvZV39CbcV0IH4Uy4A+3fBBli/nPaidm/dvIvcYDacWF0UiXZTMvqd8tL4Z3Sf4vvB6NZ328ml97w233fLSHdLGn8qaIjmkK5x1UN9BRmA/WZbmkSSLWqwr6Cz+c4unik1NeQF2shpNZw8cGyh6IFnpIUbBsXPgxiIbb1HfoQCRFocTgkqpsbH7n8WpJkEdPpVgtJh51xILlbZibsI9U1YsfDjpZWXxUUObsANbAK0Z0Ep0wkzv31+9fSD7FlGOJ//GjqFRjW4inekCeUNyRbXTGIlDMeZyRKs/JZVndKr9AFestwkiM7AWWNFUKfSX5RE0oRNwQDAKAa8HDPtErNhfoAtBCYEcBTB6GoXhnyX/1gwrDb8zeEtbc50PLBnJT6gJIp2M2IiAeXHgGuMLiDbNzgThQ="
           on:
             tags: true
-            rvm: 2.4.1
             condition: '($SKIP_FORGE_PUBLISH != true)'

--- a/Gemfile
+++ b/Gemfile
@@ -1,13 +1,10 @@
-# ------------------------------------------------------------------------------
-# NOTE: SIMP Puppet rake tasks support ruby 2.1.9
-# ------------------------------------------------------------------------------
 gem_sources = ENV.fetch('GEM_SERVERS','https://rubygems.org').split(/[, ]+/)
 
 gem_sources.each { |gem_source| source gem_source }
 
 group :test do
   gem 'rake'
-  gem 'puppet', ENV.fetch('PUPPET_VERSION',  '~> 5.5')
+  gem 'puppet', ENV.fetch('PUPPET_VERSION', '~> 5.5')
   gem 'rspec'
   gem 'rspec-puppet'
   gem 'hiera-puppet-helper'
@@ -16,13 +13,11 @@ group :test do
   gem 'puppet-strings'
   gem 'puppet-lint-empty_string-check',   :require => false
   gem 'puppet-lint-trailing_comma-check', :require => false
-  gem 'simp-rspec-puppet-facts', ENV.fetch('SIMP_RSPEC_PUPPET_FACTS_VERSION', '~> 2.0')
-  gem 'simp-rake-helpers', ENV.fetch('SIMP_RAKE_HELPERS_VERSION', ['>= 5.2', '< 6.0'])
-  gem 'semantic_puppet'
+  gem 'simp-rspec-puppet-facts', ENV.fetch('SIMP_RSPEC_PUPPET_FACTS_VERSION', '~> 2.2')
+  gem 'simp-rake-helpers', ENV.fetch('SIMP_RAKE_HELPERS_VERSION', '~> 5.6')
 end
 
 group :development do
-  gem 'puppet-blacksmith'
   gem 'pry'
   gem 'pry-byebug'
   gem 'pry-doc'
@@ -31,5 +26,5 @@ end
 group :system_tests do
   gem 'beaker'
   gem 'beaker-rspec'
-  gem 'simp-beaker-helpers', ENV.fetch('SIMP_BEAKER_HELPERS_VERSION', ['>= 1.12', '< 2.0'])
+  gem 'simp-beaker-helpers', ENV.fetch('SIMP_BEAKER_HELPERS_VERSION', '~> 1.12')
 end

--- a/spec/functions/compliance_markup/hiera_backend_spec.rb
+++ b/spec/functions/compliance_markup/hiera_backend_spec.rb
@@ -1,71 +1,69 @@
 #!/usr/bin/env ruby -S rspec
 
 require 'spec_helper'
-require 'semantic_puppet'
-puppetver = SemanticPuppet::Version.parse(Puppet.version)
-requiredver = SemanticPuppet::Version.parse("20.9.0")
-if (puppetver > requiredver)
-  describe 'compliance_markup::hiera_backend' do
-    context "when key doesn't exist in the compliance map" do
-      let(:hieradata){ "test_spec" }
-      it 'should throw an error' do
-        errored = false
-        ex = nil
-        begin
-          result = subject.execute("compliance_markup::test::nonexistent", {}, Puppet::LookupContext.new('rp_env', 'compliance_markup'))
-        rescue Exception => e
-          ex = e
-          errored = true
-        end
-        expect(errored).to eql(true)
+
+describe 'compliance_markup::hiera_backend' do
+skip 'requires function and test changes to handle incomplete LookupContext in rspec' do
+  context "when key doesn't exist in the compliance map" do
+    let(:hieradata){ "test_spec" }
+    it 'should throw an error' do
+      errored = false
+      ex = nil
+      begin
+        result = subject.execute("compliance_markup::test::nonexistent", {}, Puppet::LookupContext.new('rp_env', 'compliance_markup'))
+      rescue Exception => e
+        ex = e
+        errored = true
       end
-      it 'should throw a :no_such_key error' do
-        errored = false
-        ex = nil
-        begin
-          result = subject.execute("compliance_markup::test::nonexistent", {}, Puppet::LookupContext.new('rp_env', 'compliance_markup'))
-        rescue Exception => e
-          ex = e
-          errored = true
-        end
-        expect(ex.to_s).to match(/no_such_key/)
-      end
+      expect(errored).to eql(true)
     end
-    context "when key does exist in the compliance map" do
-      let(:hieradata){ "test_spec" }
-      it 'should not throw an error' do
-        errored = false
-        ex = nil
-        begin
-          result = subject.execute("compliance_markup::test::testvariable", {}, Puppet::LookupContext.new('rp_env', 'compliance_markup'))
-        rescue Exception => e
-          ex = e
-          errored = true
-        end
-        expect(errored).to eql(false)
+    it 'should throw a :no_such_key error' do
+      errored = false
+      ex = nil
+      begin
+        result = subject.execute("compliance_markup::test::nonexistent", {}, Puppet::LookupContext.new('rp_env', 'compliance_markup'))
+      rescue Exception => e
+        ex = e
+        errored = true
       end
-      it 'should not throw a :no_such_key error' do
-        errored = false
-        ex = nil
-        begin
-          result = subject.execute("compliance_markup::test::testvariable", {}, Puppet::LookupContext.new('rp_env', 'compliance_markup'))
-        rescue Exception => e
-          ex = e
-          errored = true
-        end
-        expect(ex.to_s).to_not match(/no_such_key/)
-      end
-      it 'should return "disa"' do
-        errored = false
-        ex = nil
-        begin
-          result = subject.execute("compliance_markup::test::testvariable", {}, Puppet::LookupContext.new('m'))
-        rescue Exception => e
-          ex = e
-          errored = true
-        end
-        expect(ex.to_s).to_not match(/no_such_key/)
-      end
+      expect(ex.to_s).to match(/no_such_key/)
     end
   end
+  context "when key does exist in the compliance map" do
+    let(:hieradata){ "test_spec" }
+    it 'should not throw an error' do
+      errored = false
+      ex = nil
+      begin
+        result = subject.execute("compliance_markup::test::testvariable", {}, Puppet::LookupContext.new('rp_env', 'compliance_markup'))
+      rescue Exception => e
+        ex = e
+        errored = true
+      end
+      expect(errored).to eql(false)
+    end
+    it 'should not throw a :no_such_key error' do
+      errored = false
+      ex = nil
+      begin
+        result = subject.execute("compliance_markup::test::testvariable", {}, Puppet::LookupContext.new('rp_env', 'compliance_markup'))
+      rescue Exception => e
+        ex = e
+        errored = true
+      end
+      expect(ex.to_s).to_not match(/no_such_key/)
+    end
+    it 'should return "disa"' do
+      errored = false
+      ex = nil
+      begin
+        result = subject.execute("compliance_markup::test::testvariable", {}, Puppet::LookupContext.new('m'))
+      rescue Exception => e
+        ex = e
+        errored = true
+      end
+      expect(ex.to_s).to_not match(/no_such_key/)
+    end
+  end
+end
 end


### PR DESCRIPTION
- Remove OBE test logic WRT to Puppet version.  The versions
  of Puppet allowed by the metadata.json satisfy the original
  constraints.
- Skip test that requires other work to handle the incomplete
  LookupContext available in rspec'
- Normalize static assets

SIMP-5711 #close