### PR TITLE
(SIMP-4923) Convert rsync::server settings

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+* Fri Jan 11 2019 Adam Yohrling <adam.yohrling@onyxpoint.com> - 2.4.2-0
+- Converted all `rsync::server::global` settings to updated `rsync::server`
+  settings
+
 * Fri Nov 02 2018 Steven Pritchard <steven.pritchard@onyxpoint.com> - 2.4.1-0
 - Fix the following keys:
   - simp::mountpoints::tmp::secure

--- a/data/compliance_profiles/CentOS/6/nist_800_53_rev4.json
+++ b/data/compliance_profiles/CentOS/6/nist_800_53_rev4.json
@@ -1038,7 +1038,7 @@
         "notes": "This only helps with \"Secure Name/Address Resolution\" but does not alone meet that control",
         "value": "warn"
       },
-      "rsync::server::global::address": {
+      "rsync::server::listen_address": {
         "identifiers": [
           "CM-7"
         ],

--- a/data/compliance_profiles/CentOS/7/nist_800_53_rev4.json
+++ b/data/compliance_profiles/CentOS/7/nist_800_53_rev4.json
@@ -1038,7 +1038,7 @@
         "notes": "This only helps with \"Secure Name/Address Resolution\" but does not alone meet that control",
         "value": "warn"
       },
-      "rsync::server::global::address": {
+      "rsync::server::listen_address": {
         "identifiers": [
           "CM-7"
         ],

--- a/data/compliance_profiles/OracleLinux/6/nist_800_53_rev4.json
+++ b/data/compliance_profiles/OracleLinux/6/nist_800_53_rev4.json
@@ -1047,7 +1047,7 @@
         "notes": "This only helps with \"Secure Name/Address Resolution\" but does not alone meet that control",
         "value": "warn"
       },
-      "rsync::server::global::address": {
+      "rsync::server::listen_address": {
         "identifiers": [
           "CM-7"
         ],

--- a/data/compliance_profiles/OracleLinux/7/nist_800_53_rev4.json
+++ b/data/compliance_profiles/OracleLinux/7/nist_800_53_rev4.json
@@ -1047,7 +1047,7 @@
         "notes": "This only helps with \"Secure Name/Address Resolution\" but does not alone meet that control",
         "value": "warn"
       },
-      "rsync::server::global::address": {
+      "rsync::server::listen_address": {
         "identifiers": [
           "CM-7"
         ],

--- a/data/compliance_profiles/RedHat/6/nist_800_53_rev4.json
+++ b/data/compliance_profiles/RedHat/6/nist_800_53_rev4.json
@@ -1047,7 +1047,7 @@
         "notes": "This only helps with \"Secure Name/Address Resolution\" but does not alone meet that control",
         "value": "warn"
       },
-      "rsync::server::global::address": {
+      "rsync::server::listen_address": {
         "identifiers": [
           "CM-7"
         ],

--- a/data/compliance_profiles/RedHat/7/nist_800_53_rev4.json
+++ b/data/compliance_profiles/RedHat/7/nist_800_53_rev4.json
@@ -1047,7 +1047,7 @@
         "notes": "This only helps with \"Secure Name/Address Resolution\" but does not alone meet that control",
         "value": "warn"
       },
-      "rsync::server::global::address": {
+      "rsync::server::listen_address": {
         "identifiers": [
           "CM-7"
         ],

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-compliance_markup",
-  "version": "2.4.1",
+  "version": "2.4.2",
   "author": "SIMP Team",
   "summary": "Compliance-mapping annotation for Puppet code",
   "license": "Apache-2.0",


### PR DESCRIPTION
This change updates the `rsync::server::global` settings in profiles to 
the updated `rsync::server` settings from pupmod-simp-rsync version 
6.1.1

SIMP-4923 #comment updated compliance_markup profile settings

This should not be merged until after https://github.com/simp/pupmod-simp-rsync/pull/51 is merged through