### PR TITLE
(SIMP-6674) Remove simp::sssd::client::ldap_domain

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,10 @@
+* Mon Jun 24 2019 Trevor Vaughan <tvaughan@onyxpoint.com> - 2.4.4-0
+- Revert change from __dir__ to File.dirname(__FILE__) in compliance_map.rb due
+  to discovered incompatibility with some puppetserver configurations.
+- Add log statement if invalid JSON or YAML files are found when loading.
+- Remove management of simp::sssd::client::ldap_domain from the mappings since
+  use of LDAP is not guaranteed.
+
 * Tue Jun 11 2019 Trevor Vaughan <tvaughan@onyxpoint.com> - 2.4.3-0
 - Fix Puppet 6 support in the compliance_map function
 - Dropped Puppet 4 support

--- a/data/compliance_profiles/CentOS/6/nist_800_53_rev4.json
+++ b/data/compliance_profiles/CentOS/6/nist_800_53_rev4.json
@@ -1363,12 +1363,6 @@
         ],
         "value": false
       },
-      "simp::sssd::client::ldap_domain": {
-        "identifiers": [
-          "IA-2"
-        ],
-        "value": true
-      },
       "simp::sssd::client::min_id": {
         "identifiers": [
           "IA-2"

--- a/data/compliance_profiles/CentOS/7/disa_stig.json
+++ b/data/compliance_profiles/CentOS/7/disa_stig.json
@@ -1625,14 +1625,6 @@
         ],
         "value": false
       },
-      "simp::sssd::client::ldap_domain": {
-        "identifiers": [
-          "RHEL-07-010000",
-          "SRG-OS-000001-GPOS-00001",
-          "CCI-000015"
-        ],
-        "value": true
-      },
       "simp::sssd::client::min_id": {
         "identifiers": [
           "RHEL-07-010000",

--- a/data/compliance_profiles/CentOS/7/nist_800_53_rev4.json
+++ b/data/compliance_profiles/CentOS/7/nist_800_53_rev4.json
@@ -1363,12 +1363,6 @@
         ],
         "value": false
       },
-      "simp::sssd::client::ldap_domain": {
-        "identifiers": [
-          "IA-2"
-        ],
-        "value": true
-      },
       "simp::sssd::client::min_id": {
         "identifiers": [
           "IA-2"

--- a/data/compliance_profiles/OracleLinux/6/nist_800_53_rev4.json
+++ b/data/compliance_profiles/OracleLinux/6/nist_800_53_rev4.json
@@ -1372,12 +1372,6 @@
         ],
         "value": false
       },
-      "simp::sssd::client::ldap_domain": {
-        "identifiers": [
-          "IA-2"
-        ],
-        "value": true
-      },
       "simp::sssd::client::min_id": {
         "identifiers": [
           "IA-2"

--- a/data/compliance_profiles/OracleLinux/7/disa_stig.json
+++ b/data/compliance_profiles/OracleLinux/7/disa_stig.json
@@ -1625,14 +1625,6 @@
         ],
         "value": false
       },
-      "simp::sssd::client::ldap_domain": {
-        "identifiers": [
-          "RHEL-07-010000",
-          "SRG-OS-000001-GPOS-00001",
-          "CCI-000015"
-        ],
-        "value": true
-      },
       "simp::sssd::client::min_id": {
         "identifiers": [
           "RHEL-07-010000",

--- a/data/compliance_profiles/OracleLinux/7/nist_800_53_rev4.json
+++ b/data/compliance_profiles/OracleLinux/7/nist_800_53_rev4.json
@@ -1372,12 +1372,6 @@
         ],
         "value": false
       },
-      "simp::sssd::client::ldap_domain": {
-        "identifiers": [
-          "IA-2"
-        ],
-        "value": true
-      },
       "simp::sssd::client::min_id": {
         "identifiers": [
           "IA-2"

--- a/data/compliance_profiles/RedHat/6/nist_800_53_rev4.json
+++ b/data/compliance_profiles/RedHat/6/nist_800_53_rev4.json
@@ -1372,12 +1372,6 @@
         ],
         "value": false
       },
-      "simp::sssd::client::ldap_domain": {
-        "identifiers": [
-          "IA-2"
-        ],
-        "value": true
-      },
       "simp::sssd::client::min_id": {
         "identifiers": [
           "IA-2"

--- a/data/compliance_profiles/RedHat/7/disa_stig.json
+++ b/data/compliance_profiles/RedHat/7/disa_stig.json
@@ -1625,14 +1625,6 @@
         ],
         "value": false
       },
-      "simp::sssd::client::ldap_domain": {
-        "identifiers": [
-          "RHEL-07-010000",
-          "SRG-OS-000001-GPOS-00001",
-          "CCI-000015"
-        ],
-        "value": true
-      },
       "simp::sssd::client::min_id": {
         "identifiers": [
           "RHEL-07-010000",

--- a/data/compliance_profiles/RedHat/7/nist_800_53_rev4.json
+++ b/data/compliance_profiles/RedHat/7/nist_800_53_rev4.json
@@ -1372,12 +1372,6 @@
         ],
         "value": false
       },
-      "simp::sssd::client::ldap_domain": {
-        "identifiers": [
-          "IA-2"
-        ],
-        "value": true
-      },
       "simp::sssd::client::min_id": {
         "identifiers": [
           "IA-2"

--- a/lib/puppet/parser/functions/compliance_map.rb
+++ b/lib/puppet/parser/functions/compliance_map.rb
@@ -190,10 +190,10 @@ module Puppet::Parser::Functions
       unless compliance_report_generator
         object = Object.new()
 
-        filename = File.join(__dir__, '..', '..', '..', 'puppetx', 'simp', 'compliance_map.rb')
+        filename = File.join(File.dirname(__FILE__), '..', '..', '..', 'puppetx', 'simp', 'compliance_map.rb')
         object.instance_eval(File.read(filename), filename)
 
-        filename = File.join(__dir__, '..', '..', '..', 'puppetx', 'simp', 'compliance_mapper.rb')
+        filename = File.join(File.dirname(__FILE__), '..', '..', '..', 'puppetx', 'simp', 'compliance_mapper.rb')
         object.instance_eval(File.read(filename), filename)
 
         catalog.instance_variable_set(:@simp_compliance_report_generator, object)

--- a/lib/puppetx/simp/compliance_mapper.rb
+++ b/lib/puppetx/simp/compliance_mapper.rb
@@ -232,6 +232,7 @@ def compiler_class()
                       @compliance_data[filename] = JSON.parse(File.read(filename))
                   end
                 rescue
+                  Hiera.warn(%{compliance_engine: Invalid '#{type}' file found at '#{filename}'})
                 end
               end
             end

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-compliance_markup",
-  "version": "2.4.3",
+  "version": "2.4.4",
   "author": "SIMP Team",
   "summary": "Compliance-mapping annotation for Puppet code",
   "license": "Apache-2.0",


### PR DESCRIPTION
* simp::sssd::client::ldap_domain never should have been managed by the
  compliance enforcement data because there is no guarantee that the
  system will be connected to LDAP.
* Fixed a bug where `__dir__` was causing issues with some versions of
  the puppetserver
* Added a warning statement if the Hiera backend hits an invalid JSON or
  YAML file.

SIMP-6674 #close