### PR TITLE
(SIMP-6869) No timestamps in client reports

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,6 @@
-* Sun Jul 07 2019 Trevor Vaughan <tvaughan@onyxpoint.com> - 3.0.0-0
+* Mon Jul 29 2019 Trevor Vaughan <tvaughan@onyxpoint.com> - 3.0.0-0
+- Make the 'timestamp' in the client-side report optional to prevent puppet
+  from triggering file resource changes every time
 - Remove the experimental v1 data since it is no longer used
 - Remove partial v2 data sets
 - Add v2 data for the non-SIMP `yum` module

--- a/lib/puppet/parser/functions/compliance_map.rb
+++ b/lib/puppet/parser/functions/compliance_map.rb
@@ -105,6 +105,17 @@ module Puppet::Parser::Functions
           client itself. This will ensure that PuppetDB will have a copy of the
           report for later processing.
 
+        **:client_report_timestamp**
+
+          Default: false
+
+          A Boolean which, if set, will add a ``timestamp`` field to the
+          client-side report.
+
+          This used to be enabled by default but users did not want to see
+          updates in their catalogs unless something of substance had been
+          modified.
+
         **:server_report**
 
           Default: true

--- a/lib/puppetx/simp/compliance_map.rb
+++ b/lib/puppetx/simp/compliance_map.rb
@@ -42,17 +42,18 @@ end
 
 def process_options(args)
   config = {
-    :custom_call              => false,
-    :report_types             => [
+    :custom_call               => false,
+    :report_types              => [
       'non_compliant',
       'unknown_parameters',
       'custom_entries'
     ],
-    :format                   => 'json',
-    :client_report            => false,
-    :server_report            => true,
-    :server_report_dir        => File.join(Puppet[:vardir], 'simp', 'compliance_reports'),
-    :default_map              => {},
+    :format                    => 'json',
+    :client_report             => false,
+    :client_report_timestamp   => false,
+    :server_report             => true,
+    :server_report_dir         => File.join(Puppet[:vardir], 'simp', 'compliance_reports'),
+    :default_map               => {},
     :catalog_to_compliance_map => false
   }
 
@@ -196,6 +197,10 @@ def add_file_to_client(config, compliance_map)
       compliance_resource.set_parameter('owner',Process.uid)
       compliance_resource.set_parameter('group',Process.gid)
       compliance_resource.set_parameter('mode','0600')
+    end
+
+    unless (config[:client_report_timestamp].nil? || config[:client_report_timestamp])
+      compliance_map.delete('timestamp') if compliance_map['timestamp']
     end
 
     if config[:format] == 'json'

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -98,7 +98,7 @@ describe 'compliance_markup' do
                 }
 
                 let(:params){
-                  _params = @default_params.dup
+                  _params = Marshal.load(Marshal.dump(@default_params))
                   _params['options']['catalog_to_compliance_map'] = true
                   _params
                 }
@@ -307,16 +307,28 @@ describe 'compliance_markup' do
               let(:hieradata) { 'passing_checks' }
 
               let(:params) {
-                _params = @default_params.dup
+                _params = Marshal.load(Marshal.dump(@default_params))
 
                 _params['options'].merge!(
                   {
                     'client_report' => true,
-                    'report_types'  => 'full'
+                    'report_types'  => ['full']
                   }
                 )
 
                 _params
+              }
+
+              let(:client_report) {
+                report_content = compliance_file_resource[:content]
+
+                if report_format == 'yaml'
+                  @report ||= YAML.load(report_content)
+                elsif report_format == 'json'
+                  @report ||= JSON.load(report_content)
+                end
+
+                @report
               }
 
               it { is_expected.to(create_class('compliance_markup')) }
@@ -326,16 +338,35 @@ describe 'compliance_markup' do
               end
 
               it "should have a valid #{report_format} report" do
-                file = nil;
-                if report_format == 'yaml'
-                  file = YAML.load(compliance_file_resource[:content]);
-                elsif report_format == 'json'
-                  file = JSON.load(compliance_file_resource[:content]);
-                else
-                  fail("Invalid report type '#{report_format}' specified")
+                expect(client_report['version']).to eq(report_version)
+              end
+
+              it 'should NOT have a timestamp' do
+                expect(client_report['timestamp']).to be_nil
+              end
+
+              context 'with client_report_timestamp = true' do
+                let(:params) {
+                  _params = Marshal.load(Marshal.dump(@default_params))
+
+                  _params['options'].merge!(
+                    {
+                      'client_report'           => true,
+                      'client_report_timestamp' => true,
+                      'report_types'            => ['full']
+                    }
+                  )
+
+                  _params
+                }
+
+                it "should have a valid #{report_format} report" do
+                  expect(client_report['version']).to eq(report_version)
                 end
-                version = file['version'];
-                expect(version).to eq(report_version)
+
+                it 'should have a timestamp' do
+                  expect(client_report['timestamp']).to_not be_nil
+                end
               end
             end
 
@@ -343,11 +374,11 @@ describe 'compliance_markup' do
               let(:hieradata) { 'passing_checks' }
 
               let(:params) {
-                _params = @default_params.dup
+                _params = Marshal.load(Marshal.dump(@default_params))
 
                 _params['options'].merge!(
                   {
-                    'report_types' => 'full'
+                    'report_types' => ['full']
                   }
                 )
 
@@ -363,6 +394,10 @@ describe 'compliance_markup' do
 
               it 'should have a valid version number' do
                 expect( report['version'] ).to eq(report_version)
+              end
+
+              it 'should have a timestamp' do
+                expect( report['timestamp'] ).to_not be_nil
               end
 
               it 'should have a valid compliance profile' do
@@ -540,12 +575,12 @@ describe 'compliance_markup' do
               }
 
               let(:params) {
-                _params = @default_params.dup
+                _params = Marshal.load(Marshal.dump(@default_params))
 
                 _params['options'].merge!(
                   {
                     'client_report' => true,
-                    'report_types'  => 'full'
+                    'report_types'  => ['full']
                   }
                 )
 


### PR DESCRIPTION
- Make the 'timestamp' in the client-side report optional to prevent puppet
  from triggering file resource changes every time

SIMP-6869 #close