### PR TITLE
(SIMP-6921) Allow puppetlabs/stdlib 6.x.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+* Mon Aug 12 2019 Robert Vincent <pillarsdotnet@gmail.com> - 3.0.2-0
+- Support puppetlabs/stdlib 6.x.
+
 * Fri Aug 09 2019 Dylan Cochran <dylan.cochran@onyxpoint.com> - 3.0.1-0
 - Add confinement on modules and facts to SIMP Compliance Engine.
 

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-compliance_markup",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "author": "SIMP Team",
   "summary": "Compliance-mapping annotation for Puppet code",
   "license": "Apache-2.0",
@@ -16,7 +16,7 @@
   "dependencies": [
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 4.13.1 < 6.0.0"
+      "version_requirement": ">= 4.13.1 < 7.0.0"
     },
     {
       "name": "simp/simplib",

--- a/spec/acceptance/nodesets/docker_centos.yml
+++ b/spec/acceptance/nodesets/docker_centos.yml
@@ -18,11 +18,6 @@ HOSTS:
     docker_image_commands:
       # Puppet Deps
       - 'yum install -y ntpdate rsync openssl openssh-server'
-    yum_repos:
-      epel:
-        mirrorlist: 'https://mirrors.fedoraproject.org/metalink?repo=epel-7&arch=$basearch'
-        gpgkeys:
-          - https://getfedora.org/static/352C64E5.txt
 
   el6-compliance-map:
     roles:
@@ -35,11 +30,6 @@ HOSTS:
     docker_image_commands:
       # Puppet Deps
       - 'yum install -y ntpdate rsync openssl'
-    yum_repos:
-      epel:
-        mirrorlist: 'https://mirrors.fedoraproject.org/metalink?repo=epel-6&arch=$basearch'
-        gpgkeys:
-          - https://getfedora.org/static/0608B895.txt
 
 CONFIG:
   log_level: verbose

--- a/spec/acceptance/nodesets/docker_oel.yml
+++ b/spec/acceptance/nodesets/docker_oel.yml
@@ -18,11 +18,6 @@ HOSTS:
     docker_image_commands:
       # Puppet Deps
       - 'yum install -y ntpdate rsync openssl openssh-server'
-    yum_repos:
-      epel:
-        mirrorlist: 'https://mirrors.fedoraproject.org/metalink?repo=epel-7&arch=$basearch'
-        gpgkeys:
-          - https://getfedora.org/static/352C64E5.txt
 
   el6-compliance-map:
     roles:
@@ -35,11 +30,6 @@ HOSTS:
     docker_image_commands:
       # Puppet Deps
       - 'yum install -y ntpdate rsync openssl'
-    yum_repos:
-      epel:
-        mirrorlist: 'https://mirrors.fedoraproject.org/metalink?repo=epel-6&arch=$basearch'
-        gpgkeys:
-          - https://getfedora.org/static/0608B895.txt
 
 CONFIG:
   log_level: verbose


### PR DESCRIPTION
I'm getting an "unsatisfied dependencies" warning with the `compliance_markup` module.  I'm hoping this will resolve it.