### PR TITLE
(SIMP-7709) Improve confinement support

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -6,6 +6,7 @@ fixtures:
       puppet_version: ">= 6.0.0"
     simplib: https://github.com/simp/pupmod-simp-simplib
     stdlib: https://github.com/simp/puppetlabs-stdlib
+    systemd: https://github.com/simp/puppet-systemd
     useradd: https://github.com/simp/pupmod-simp-useradd
     yum: https://github.com/simp/voxpupuli-yum
     yumrepo_core:

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+* Fri Apr 10 2020 Steven Pritchard <steven.pritchard@onyxpoint.com> - 3.1.0-0
+- Support arrays of potential matches in confinement blocks
+- Support structured facts in confinement
+
 * Wed Feb 26 2020 Trevor Vaughan <tvaughan@onyxpoint.com> - 3.1.0-0
 - Ensure that the Hiera backend recurses as little as possible to improve
   performance.

--- a/lib/puppet/functions/compliance_markup/enforcement.rb
+++ b/lib/puppet/functions/compliance_markup/enforcement.rb
@@ -95,7 +95,7 @@ Puppet::Functions.create_function(:'compliance_markup::enforcement', Puppet::Fun
     end
   end
   def lookup_fact(fact)
-    closure_scope.lookupvar("facts")[fact]
+    closure_scope.lookupvar("facts").dig(*fact.split('.'))
   end
   def module_list
     closure_scope.environment.modules.map { |obj| { "name" => obj.metadata["name"], "version" => obj.metadata["version"] } }

--- a/lib/puppetx/simp/compliance_map.rb
+++ b/lib/puppetx/simp/compliance_map.rb
@@ -484,7 +484,7 @@ def environment
 end
 
 def lookup_fact(fact)
-  @context.lookupvar("facts")[fact]
+  @context.lookupvar("facts").dig(*fact.split('.'))
 end
 
 def module_list

--- a/lib/puppetx/simp/compliance_mapper.rb
+++ b/lib/puppetx/simp/compliance_mapper.rb
@@ -521,7 +521,7 @@ def compiler_class()
                     end
 
                     fact_value = @callback.lookup_fact(confinement_setting)
-                    unless fact_value == confinement_value
+                    unless confinement_value.is_a?(Array) ? confinement_value.include?(fact_value) : (fact_value == confinement_value)
                       delete_item = true
                       throw :confine_end
                     end


### PR DESCRIPTION
This adds two additional features to `confine` blocks:

1. Structured facts (as dotted names, such as `os.family`)
2. Multiple options for facts as an array

For example, to confine a check to EL7 and EL8, with this change we can add a block like this:
```
confine:
  os.family: RedHat
  os.release.major:
    - 7
    - 8
```