### PR TITLE
(SIMP-7813) Allow confine on data other than checks

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+* Fri May 29 2020 Steven Pritchard <steven.pritchard@onyxpoint.com> - 3.1.0-0
+- Support confinement in profiles, controls, and ces (as well as checks)
+- Add rspec tests for compliance_markup::enforcement
+
 * Fri Apr 10 2020 Steven Pritchard <steven.pritchard@onyxpoint.com> - 3.1.0-0
 - Support arrays of potential matches in confinement blocks
 - Support structured facts in confinement

--- a/Gemfile
+++ b/Gemfile
@@ -20,6 +20,7 @@ end
 group :development do
   gem 'pry'
   gem 'pry-doc'
+  gem 'pry-byebug'
 end
 
 group :system_tests do

--- a/spec/functions/compliance_markup/enforcement_spec.rb
+++ b/spec/functions/compliance_markup/enforcement_spec.rb
@@ -3,161 +3,180 @@
 require 'spec_helper'
 require 'semantic_puppet'
 require 'puppet/pops/lookup/context'
+require 'yaml'
+require 'fileutils'
+
 puppetver = SemanticPuppet::Version.parse(Puppet.version)
 requiredver = SemanticPuppet::Version.parse("4.10.0")
 
-describe 'compliance_markup::hiera_backend' do
-  skip 'requires function and test changes to handle incomplete LookupContext in rspec' do
-    if (puppetver > requiredver)
-      context "when key doesn't exist in the compliance map" do
-        let(:hieradata) {"test_spec"}
-        it 'should throw an error' do
-          errored = false
-          ex = nil
-          begin
-            result = subject.execute("compliance_markup::test::nonexistent", {}, Puppet::LookupContext.new('rp_env', 'compliance_markup'))
-          rescue Exception => e
-            ex = e
-            errored = true
-          end
-          expect(errored).to eql(true)
-        end
-        it 'should throw a :no_such_key error' do
-          errored = false
-          ex = nil
-          begin
-            result = subject.execute("compliance_markup::test::nonexistent", {}, Puppet::LookupContext.new('rp_env', 'compliance_markup'))
-          rescue Exception => e
-            ex = e
-            errored = true
-          end
-          expect(ex.to_s).to match(/no_such_key/)
-        end
-      end
-      context "when key does exist in the compliance map" do
-        let(:hieradata) {"test_spec"}
-        it 'should not throw an error' do
-          errored = false
-          ex = nil
-          begin
-            result = subject.execute("compliance_markup::test::testvariable", {}, Puppet::LookupContext.new('rp_env', 'compliance_markup'))
-          rescue Exception => e
-            ex = e
-            errored = true
-          end
-          expect(errored).to eql(false)
-        end
-        it 'should not throw a :no_such_key error' do
-          errored = false
-          ex = nil
-          begin
-            result = subject.execute("compliance_markup::test::testvariable", {}, Puppet::LookupContext.new('rp_env', 'compliance_markup'))
-          rescue Exception => e
-            ex = e
-            errored = true
-          end
-          expect(ex.to_s).to_not match(/no_such_key/)
-        end
-        it 'should return "disa"' do
-          errored = false
-          ex = nil
-          begin
-            result = subject.execute("compliance_markup::test::testvariable", {}, Puppet::LookupContext.new('m'))
-          rescue Exception => e
-            ex = e
-            errored = true
-          end
-          expect(ex.to_s).to_not match(/no_such_key/)
-        end
+describe 'lookup' do
+  # Generate a fake module with dummy data for lookup().
+  profile_yaml = {
+    'version' => '2.0.0',
+    'profiles' => {
+      'profile_test' => {
+        'controls' => {
+          'control1' => true,
+          'os_control' => true,
+        },
+        # Future
+        # 'confine' => {
+        #   # Test for module name
+        #   # Test for module version
+        #   # Test for single fact
+        #   # Test for multiple facts
+        #   # Test for array of facts
+        # },
+      },
+    },
+  }.to_yaml
 
-        context "when key == compliance_markup::debug::hiera_backend_compile_time" do
-          let(:hieradata) {"test_spec"}
-          it 'should return an number' do
-            errored = false
-            ex = nil
-            begin
-              result = subject.execute("compliance_markup::debug::hiera_backend_compile_time", {}, nil)
-            rescue Exception => e
-              ex = e
-              errored = true
-            end
-            puts "    completed in #{result} seconds"
-            expect(result).to be_a(Float)
-          end
-        end
+  ces_yaml = {
+    'version' => '2.0.0',
+    'ce' => {
+      'ce1' => {
+        'controls' => {
+          'control1' => true,
+        },
+      },
+      'ce2' => {
+        'controls' => {
+          'os_control' => true,
+        },
+      },
+      'ce3' => {
+        'controls' => {
+          'control1' => true,
+        },
+        'confine' => {
+          'module_name' => 'simp-compliance_markup',
+          'module_version' => '< 3.1.0',
+        },
+      },
+    },
+  }.to_yaml
+
+  checks_yaml = {
+    'version' => '2.0.0',
+    'checks' => {
+      'check1' => {
+        'type' => 'puppet-class-parameter',
+        'settings' => {
+          'parameter' => 'test_module::test_param',
+          'value' => 'a string',
+        },
+        'ces' => [
+          'ce1',
+        ],
+      },
+      'check2' => {
+        'type' => 'puppet-class-parameter',
+        'settings' => {
+          'parameter' => 'test_module::test_param2',
+          'value' => 'another string',
+        },
+        'ces' => [
+          'ce1',
+        ],
+      },
+      'el_check' => {
+        'type' => 'puppet-class-parameter',
+        'settings' => {
+          'parameter' => 'test_module::is_el',
+          'value' => true,
+        },
+        'ces' => [
+          'ce2',
+        ],
+        'confine' => {
+          'os.family' => 'RedHat',
+        },
+      },
+      'el7_check' => {
+        'type' => 'puppet-class-parameter',
+        'settings' => {
+          'parameter' => 'test_module::el_version',
+          'value' => '7',
+        },
+        'ces' => [
+          'ce2',
+        ],
+        'confine' => {
+          'os.name' => [
+            'RedHat',
+            'CentOS',
+          ],
+          'os.release.major' => '7',
+        },
+      },
+      'confine_in_ces' => {
+        'type' => 'puppet-class-parameter',
+        'settings' => {
+          'parameter' => 'test_module::fixed_confines',
+          'value' => false,
+        },
+        'ces' => [
+          'ce3',
+        ],
+      },
+    },
+  }.to_yaml
+
+  fixtures = File.expand_path('../../fixtures', __dir__)
+
+  compliance_dir = File.join(fixtures, 'modules', 'test_module', 'SIMP', 'compliance_profiles')
+  FileUtils.mkdir_p(compliance_dir)
+
+  File.open(File.join(compliance_dir, 'profile.yaml'), 'w') do |fh|
+    fh.puts profile_yaml
+  end
+
+  File.open(File.join(compliance_dir, 'ces.yaml'), 'w') do |fh|
+    fh.puts ces_yaml
+  end
+
+  File.open(File.join(compliance_dir, 'checks.yaml'), 'w') do |fh|
+    fh.puts checks_yaml
+  end
+
+  on_supported_os.each do |os, os_facts|
+    context "on #{os} with compliance_markup::enforcement and a non-existent profile" do
+      let(:facts) do
+        os_facts.merge('target_compliance_profile' => 'not_a_profile')
       end
+
+      let(:hieradata) { 'compliance-engine' }
+
+      it { is_expected.to run.with_params('test_module::test_param').and_raise_error(Puppet::DataBinding::LookupError, "Function lookup() did not find a value for the name 'test_module::test_param'") }
     end
-    context "when key == compliance_markup::test::confined_by_module" do
-      let(:hieradata){ "test_spec" }
-      it 'should return "confined"' do
-        errored = false
-        ex = nil
-        begin
-          result = subject.execute("compliance_markup::test::confined_by_module", {}, nil)
-        rescue Exception => e
-          ex = e
-          errored = true
-        end
-        expect(result).to eql("confined")
+
+    context "on #{os} with compliance_markup::enforcement and an existing profile" do
+      let(:facts) do
+        os_facts.merge('target_compliance_profile' => 'profile_test')
       end
-    end
-    context "when key == compliance_markup::test::unconfined" do
-      let(:hieradata){ "test_spec" }
-      it 'should return "confined"' do
-        errored = false
-        ex = nil
-        begin
-          result = subject.execute("compliance_markup::test::unconfined", {}, nil)
-        rescue Exception => e
-          ex = e
-          errored = true
-        end
-        expect(result).to eql("confined")
+
+      let(:hieradata) { 'compliance-engine' }
+
+      # Test unconfined data.
+      it { is_expected.to run.with_params('test_module::test_param').and_return('a string') }
+      it { is_expected.to run.with_params('test_module::test_param2').and_return('another string') }
+
+      # Test for confine on a single fact in checks.
+      if os_facts[:osfamily] == 'RedHat'
+        it { is_expected.to run.with_params('test_module::is_el').and_return(true) }
+      else
+        it { is_expected.to run.with_params('test_module::is_el').and_raise_error(Puppet::DataBinding::LookupError, "Function lookup() did not find a value for the name 'test_module::is_el'") }
       end
-    end
-    context "when key == compliance_markup::test::confined_with_matching_fact" do
-      let(:hieradata){ "test_spec" }
-      it 'should return "confined"' do
-        errored = false
-        ex = nil
-        begin
-          result = subject.execute("compliance_markup::test::confined_with_matching_fact", {}, nil)
-        rescue Exception => e
-          ex = e
-          errored = true
-        end
-        expect(result).to eql("confined")
+
+      # Test for confine on multiple facts and an array of facts in checks.
+      if (os_facts[:os][:name] == 'RedHat' || os_facts[:os][:name] == 'CentOS') && os_facts[:operatingsystemmajrelease] == '7'
+        it { is_expected.to run.with_params('test_module::el_version').and_return('7') }
+      else
+        it { is_expected.to run.with_params('test_module::el_version').and_raise_error(Puppet::DataBinding::LookupError, "Function lookup() did not find a value for the name 'test_module::el_version'") }
       end
-    end
-    context "when key == compliance_markup::test::confined_with_not_matching_fact" do
-      let(:hieradata){ "test_spec" }
-      it 'should return "confined"' do
-        errored = false
-        ex = nil
-        begin
-          result = subject.execute("compliance_markup::test::confined_with_not_matching_fact", {}, nil)
-        rescue Exception => e
-          ex = e
-          errored = true
-        end
-        expect(result).to_not eql("confined")
-      end
-    end
-    context "when key == compliance_markup::test::confined_with_wrong_module_version" do
-      let(:hieradata){ "test_spec" }
-      it 'should not return "confined"' do
-        errored = false
-        ex = nil
-        begin
-          $pry_debug = true
-          result = subject.execute("compliance_markup::test::confined_with_wrong_module_version", {}, nil)
-        rescue Exception => e
-          ex = e
-          errored = true
-        end
-        expect(result).to_not eql("confined")
-      end
+
+      # Test for confine on module name & module version in ce.
+      it { is_expected.to run.with_params('test_module::fixed_confines').and_raise_error(Puppet::DataBinding::LookupError, "Function lookup() did not find a value for the name 'test_module::fixed_confines'") }
     end
   end
 end
-


### PR DESCRIPTION
Currently, `confine` is only used in `checks` specifications, and is applied late in the compile process.  This moves it to a function that is applied early in the data compilation process, and also applies it to all relevant data (`profiles`, `controls`, `checks`, and `ce`).

In addition, this adds missing tests for `compliance_markup::enforcement`.