### PR TITLE
[SIMP-7823] Work around Ruby 1.7 issue

### DIFF
--- a/lib/puppet/functions/compliance_markup/enforcement.rb
+++ b/lib/puppet/functions/compliance_markup/enforcement.rb
@@ -132,7 +132,7 @@ Puppet::Functions.create_function(:'compliance_markup::enforcement') do
 
   def lookup_fact(fact)
     begin
-      call_function(:dig, closure_scope.lookupvar('facts'), *fact.split('.'))
+      call_function('dig', closure_scope.lookupvar('facts'), *fact.split('.'))
     rescue ArgumentError
       nil
     end

--- a/lib/puppet/functions/compliance_markup/enforcement.rb
+++ b/lib/puppet/functions/compliance_markup/enforcement.rb
@@ -131,7 +131,11 @@ Puppet::Functions.create_function(:'compliance_markup::enforcement') do
   end
 
   def lookup_fact(fact)
-    closure_scope.lookupvar('facts')[fact]
+    begin
+      call_function(:dig, closure_scope.lookupvar('facts'), *fact.split('.'))
+    rescue ArgumentError
+      nil
+    end
   end
 
   def module_list

--- a/lib/puppet/functions/compliance_markup/enforcement.rb
+++ b/lib/puppet/functions/compliance_markup/enforcement.rb
@@ -131,7 +131,7 @@ Puppet::Functions.create_function(:'compliance_markup::enforcement') do
   end
 
   def lookup_fact(fact)
-    closure_scope.lookupvar("facts").dig(*fact.split('.'))
+    closure_scope.lookupvar('facts')[fact]
   end
 
   def module_list

--- a/lib/puppetx/simp/compliance_map.rb
+++ b/lib/puppetx/simp/compliance_map.rb
@@ -485,7 +485,11 @@ def environment
 end
 
 def lookup_fact(fact)
-  @context.lookupvar('facts')[fact]
+  begin
+    @context.call_function(:dig, @context.lookupvar('facts'), *fact.split('.'))
+  rescue ArgumentError
+    nil
+  end
 end
 
 def module_list

--- a/lib/puppetx/simp/compliance_map.rb
+++ b/lib/puppetx/simp/compliance_map.rb
@@ -486,7 +486,7 @@ end
 
 def lookup_fact(fact)
   begin
-    @context.call_function(:dig, [@context.lookupvar('facts'), *fact.split('.')])
+    @context.call_function('dig', [@context.lookupvar('facts'), *fact.split('.')])
   rescue ArgumentError
     nil
   end

--- a/lib/puppetx/simp/compliance_map.rb
+++ b/lib/puppetx/simp/compliance_map.rb
@@ -486,7 +486,7 @@ end
 
 def lookup_fact(fact)
   begin
-    @context.call_function(:dig, @context.lookupvar('facts'), *fact.split('.'))
+    @context.call_function(:dig, [@context.lookupvar('facts'), *fact.split('.')])
   rescue ArgumentError
     nil
   end

--- a/lib/puppetx/simp/compliance_map.rb
+++ b/lib/puppetx/simp/compliance_map.rb
@@ -485,7 +485,7 @@ def environment
 end
 
 def lookup_fact(fact)
-  @context.lookupvar("facts").dig(*fact.split('.'))
+  @context.lookupvar('facts')[fact]
 end
 
 def module_list


### PR DESCRIPTION
This code is loaded by default and is causing issues with the default
puppetserver 5.X load since it starts out with Ruby 1.7, it needs to be
compatible.

SIMP-7823 #close