### PR TITLE
(SIMP-7824) deep merge hash values

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+* Mon Jun 22 2020 Steven Pritchard <steven.pritchard@onyxpoint.com> - 3.1.0-0
+- Deep merge hash values in the Hiera backend
+- Reduce the amount of data passed around in the Hiera backend
+
 * Fri May 29 2020 Steven Pritchard <steven.pritchard@onyxpoint.com> - 3.1.0-0
 - Support confinement in profiles, controls, and ces (as well as checks)
 - Add rspec tests for compliance_markup::enforcement

--- a/README.md
+++ b/README.md
@@ -383,6 +383,9 @@ Depending on the version of Puppet being used, the
 `compliance_markup::compliance_map()` function may not be able to precisely
 determine where the function has been called and a best guess may be provided.
 
+Hash values for Puppet parameters in compliance data will always be deep
+merged. Configurable merge behavior may be implemented in a future release.
+
 ## Development
 
 Patches are welcome to the code on the [SIMP Project Github](https://github.com/simp/pupmod-simp-compliance_markup) account. If you provide code, you are

--- a/spec/functions/compliance_markup/00_enforcement_spec.rb
+++ b/spec/functions/compliance_markup/00_enforcement_spec.rb
@@ -1,0 +1,102 @@
+#!/usr/bin/env ruby -S rspec
+
+require 'spec_helper'
+require 'semantic_puppet'
+require 'puppet/pops/lookup/context'
+require 'yaml'
+require 'fileutils'
+
+puppetver = SemanticPuppet::Version.parse(Puppet.version)
+requiredver = SemanticPuppet::Version.parse("4.10.0")
+
+describe 'lookup' do
+  # Generate a fake module with dummy data for lookup().
+  profile_yaml = {
+    'version' => '2.0.0',
+    'profiles' => {
+      'profile_test' => {
+        'controls' => {
+          'control1' => true,
+        },
+      },
+    },
+  }.to_yaml
+
+  ces_yaml = {
+    'version' => '2.0.0',
+    'ce' => {
+      'ce1' => {
+        'controls' => {
+          'control1' => true,
+        },
+      },
+    },
+  }.to_yaml
+
+  checks_yaml = {
+    'version' => '2.0.0',
+    'checks' => {
+      'check1' => {
+        'type' => 'puppet-class-parameter',
+        'settings' => {
+          'parameter' => 'test_module::test_param',
+          'value' => 'a string',
+        },
+        'ces' => [
+          'ce1',
+        ],
+      },
+      'check2' => {
+        'type' => 'puppet-class-parameter',
+        'settings' => {
+          'parameter' => 'test_module::test_param2',
+          'value' => 'another string',
+        },
+        'ces' => [
+          'ce1',
+        ],
+      },
+    },
+  }.to_yaml
+
+  fixtures = File.expand_path('../../fixtures', __dir__)
+
+  compliance_dir = File.join(fixtures, 'modules', 'test_module_00', 'SIMP', 'compliance_profiles')
+  FileUtils.mkdir_p(compliance_dir)
+
+  File.open(File.join(compliance_dir, 'profile.yaml'), 'w') do |fh|
+    fh.puts profile_yaml
+  end
+
+  File.open(File.join(compliance_dir, 'ces.yaml'), 'w') do |fh|
+    fh.puts ces_yaml
+  end
+
+  File.open(File.join(compliance_dir, 'checks.yaml'), 'w') do |fh|
+    fh.puts checks_yaml
+  end
+
+  on_supported_os.each do |os, os_facts|
+    context "on #{os} with compliance_markup::enforcement and a non-existent profile" do
+      let(:facts) do
+        os_facts.merge('target_compliance_profile' => 'not_a_profile')
+      end
+
+      let(:hieradata) { 'compliance-engine' }
+
+      it { is_expected.to run.with_params('test_module::test_param').and_raise_error(Puppet::DataBinding::LookupError, "Function lookup() did not find a value for the name 'test_module::test_param'") }
+    end
+
+    context "on #{os} with compliance_markup::enforcement and an existing profile" do
+      let(:facts) do
+        os_facts.merge('target_compliance_profile' => 'profile_test')
+      end
+
+      let(:hieradata) { 'compliance-engine' }
+
+      # Test unconfined data.
+      it { is_expected.to run.with_params('test_module::test_param').and_return('a string') }
+      it { is_expected.to run.with_params('test_module::test_param2').and_return('another string') }
+    end
+  end
+end

--- a/spec/functions/compliance_markup/01_enforcement_confine_spec.rb
+++ b/spec/functions/compliance_markup/01_enforcement_confine_spec.rb
@@ -5,7 +5,6 @@ require 'semantic_puppet'
 require 'puppet/pops/lookup/context'
 require 'yaml'
 require 'fileutils'
-require 'pry'
 
 puppetver = SemanticPuppet::Version.parse(Puppet.version)
 requiredver = SemanticPuppet::Version.parse("4.10.0")
@@ -60,26 +59,6 @@ describe 'lookup' do
   checks_yaml = {
     'version' => '2.0.0',
     'checks' => {
-      'check1' => {
-        'type' => 'puppet-class-parameter',
-        'settings' => {
-          'parameter' => 'test_module::test_param',
-          'value' => 'a string',
-        },
-        'ces' => [
-          'ce1',
-        ],
-      },
-      'check2' => {
-        'type' => 'puppet-class-parameter',
-        'settings' => {
-          'parameter' => 'test_module::test_param2',
-          'value' => 'another string',
-        },
-        'ces' => [
-          'ce1',
-        ],
-      },
       'el_check' => {
         'type' => 'puppet-class-parameter',
         'settings' => {
@@ -125,7 +104,7 @@ describe 'lookup' do
 
   fixtures = File.expand_path('../../fixtures', __dir__)
 
-  compliance_dir = File.join(fixtures, 'modules', 'test_module', 'SIMP', 'compliance_profiles')
+  compliance_dir = File.join(fixtures, 'modules', 'test_module_01', 'SIMP', 'compliance_profiles')
   FileUtils.mkdir_p(compliance_dir)
 
   File.open(File.join(compliance_dir, 'profile.yaml'), 'w') do |fh|
@@ -141,26 +120,12 @@ describe 'lookup' do
   end
 
   on_supported_os.each do |os, os_facts|
-    context "on #{os} with compliance_markup::enforcement and a non-existent profile" do
-      let(:facts) do
-        os_facts.merge('target_compliance_profile' => 'not_a_profile')
-      end
-
-      let(:hieradata) { 'compliance-engine' }
-
-      it { is_expected.to run.with_params('test_module::test_param').and_raise_error(Puppet::DataBinding::LookupError, "Function lookup() did not find a value for the name 'test_module::test_param'") }
-    end
-
     context "on #{os} with compliance_markup::enforcement and an existing profile" do
       let(:facts) do
         os_facts.merge('target_compliance_profile' => 'profile_test')
       end
 
       let(:hieradata) { 'compliance-engine' }
-
-      # Test unconfined data.
-      it { is_expected.to run.with_params('test_module::test_param').and_return('a string') }
-      it { is_expected.to run.with_params('test_module::test_param2').and_return('another string') }
 
       # Test for confine on a single fact in checks.
       if os_facts[:osfamily] == 'RedHat'

--- a/spec/functions/compliance_markup/02_enforcement_merge_spec.rb
+++ b/spec/functions/compliance_markup/02_enforcement_merge_spec.rb
@@ -1,0 +1,153 @@
+#!/usr/bin/env ruby -S rspec
+
+require 'spec_helper'
+require 'semantic_puppet'
+require 'puppet/pops/lookup/context'
+require 'yaml'
+require 'fileutils'
+
+puppetver = SemanticPuppet::Version.parse(Puppet.version)
+requiredver = SemanticPuppet::Version.parse("4.10.0")
+
+describe 'lookup' do
+  # Generate a fake module with dummy data for lookup().
+  profile_yaml = {
+    'version' => '2.0.0',
+    'profiles' => {
+      'profile_test' => {
+        'controls' => {
+          'control1' => true,
+        },
+      },
+    },
+  }.to_yaml
+
+  ces_yaml = {
+    'version' => '2.0.0',
+    'ce' => {
+      'ce1' => {
+        'controls' => {
+          'control1' => true,
+        },
+      },
+    },
+  }.to_yaml
+
+  checks_yaml = {
+    'version' => '2.0.0',
+    'checks' => {
+      'array check1' => {
+        'type' => 'puppet-class-parameter',
+        'settings' => {
+          'parameter' => 'test_module::array_param',
+          'value' => [
+            'array value 1',
+          ],
+        },
+        'ces' => [
+          'ce1',
+        ],
+      },
+      'array check2' => {
+        'type' => 'puppet-class-parameter',
+        'settings' => {
+          'parameter' => 'test_module::array_param',
+          'value' => [
+            'array value 2',
+          ],
+        },
+        'ces' => [
+          'ce1',
+        ],
+      },
+      'hash check1' => {
+        'type' => 'puppet-class-parameter',
+        'settings' => {
+          'parameter' => 'test_module::hash_param',
+          'value' => {
+            'hash key 1' => 'hash value 1',
+          },
+        },
+        'ces' => [
+          'ce1',
+        ],
+      },
+      'hash check2' => {
+        'type' => 'puppet-class-parameter',
+        'settings' => {
+          'parameter' => 'test_module::hash_param',
+          'value' => {
+            'hash key 2' => 'hash value 2',
+          },
+        },
+        'ces' => [
+          'ce1',
+        ],
+      },
+      'nested hash1' => {
+        'type' => 'puppet-class-parameter',
+        'settings' => {
+          'parameter' => 'test_module::nested_hash',
+          'value' => {
+            'key' => {
+              'key1' => 'value1',
+            },
+          },
+        },
+        'ces' => [
+          'ce1',
+        ],
+      },
+      'nested hash2' => {
+        'type' => 'puppet-class-parameter',
+        'settings' => {
+          'parameter' => 'test_module::nested_hash',
+          'value' => {
+            'key' => {
+              'key2' => 'value2',
+            },
+          },
+        },
+        'ces' => [
+          'ce1',
+        ],
+      },
+    },
+  }.to_yaml
+
+  fixtures = File.expand_path('../../fixtures', __dir__)
+
+  compliance_dir = File.join(fixtures, 'modules', 'test_module_02', 'SIMP', 'compliance_profiles')
+  FileUtils.mkdir_p(compliance_dir)
+
+  File.open(File.join(compliance_dir, 'profile.yaml'), 'w') do |fh|
+    fh.puts profile_yaml
+  end
+
+  File.open(File.join(compliance_dir, 'ces.yaml'), 'w') do |fh|
+    fh.puts ces_yaml
+  end
+
+  File.open(File.join(compliance_dir, 'checks.yaml'), 'w') do |fh|
+    fh.puts checks_yaml
+  end
+
+  on_supported_os.each do |os, os_facts|
+    context "on #{os} with compliance_markup::enforcement and an existing profile" do
+      let(:facts) do
+        os_facts.merge('target_compliance_profile' => 'profile_test')
+      end
+
+      let(:hieradata) { 'compliance-engine' }
+
+      # Test a simple array.
+      it { is_expected.to run.with_params('test_module::array_param').and_return(['array value 1', 'array value 2']) }
+
+      # Test a simple hash.
+      it { is_expected.to run.with_params('test_module::hash_param').and_return({'hash key 1' => 'hash value 1', 'hash key 2' => 'hash value 2'}) }
+
+      # Test a nested hash.
+      it { is_expected.to run.with_params('test_module::nested_hash').and_return({'key' => { 'key1' => 'value1', 'key2' => 'value2'}}) }
+    end
+  end
+end


### PR DESCRIPTION
Prior to this change, hash values were merged using `merge`, causing
unexpected behavior with nested hashes.  This change fixes that by using
`deep_merge!` for hash values.

In addition, this refactors the logic that handles merging to make it
more clear, calls `raise` if there is a type mismatch when merging
(where previously the behavior was undefined), returns less extraneous
data in the Hiera backend, breaks up the
`compliance_markup::enforcement` `lookup()` tests, and adds tests for
merge behavior.

SIMP-7824 #close
