### PR TITLE
(SIMP-8345) Apply confinement before merging values

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,8 @@
 * Fri Sep 11 2020 Steven Pritchard <steven.pritchard@onyxpoint.com> - 3.1.1-0
 - Add controls, identifiers, and oval-ids
 - Work around rspec failure
+- Apply confinement before merging values
+- Ignore undefined ces when correlating checks and profiles
 
 * Mon Jun 22 2020 Steven Pritchard <steven.pritchard@onyxpoint.com> - 3.1.0-0
 - Deep merge hash values in the Hiera backend

--- a/lib/puppetx/simp/compliance_mapper.rb
+++ b/lib/puppetx/simp/compliance_mapper.rb
@@ -380,21 +380,19 @@ def compiler_class()
 
         def import(filename, data)
           data.each do |key, value|
+            apply_confinement(value) if value.is_a?(Hash)
+
             case key
             when "profiles"
               value.each do |profile, map|
                 @profile_list[profile] ||= {}
                 @profile_list[profile] = DeepMerge.deep_merge!(@profile_list[profile], map, {:knockout_prefix => '--'})
               end
-
-              apply_confinement(@profile_list)
             when "controls"
               value.each do |profile, map|
                 @control_list[profile] ||= {}
                 @control_list[profile] = DeepMerge.deep_merge!(@control_list[profile], map, {:knockout_prefix => '--'})
               end
-
-              apply_confinement(@control_list)
             when "checks"
               value.each do |profile, map|
                 @check_list[profile] ||= {}
@@ -408,23 +406,17 @@ def compiler_class()
                 }
 
                 @check_list[profile]['telemetry'] = [check_telemetry]
-
               end
-
-              apply_confinement(@check_list)
             when "ce"
               value.each do |profile, map|
                 @configuration_element_list[profile] ||= {}
                 @configuration_element_list[profile] = DeepMerge.deep_merge!(@configuration_element_list[profile], map, {:knockout_prefix => '--'})
               end
-
-              apply_confinement(@configuration_element_list)
             end
           end
         end
 
         def list_puppet_params(profile_list)
-          # Potential matches prior to confinement
           specifications = []
 
           profile_list.reverse.each do |profile_name|
@@ -483,7 +475,7 @@ def compiler_class()
               if specification.key?('ces')
                 specification['ces'].each do |ce_name|
                   if (info.key?('ces')) && (info['ces'].key?(ce_name)) && (info['ces'][ce_name] == true)
-                    specifications << specification
+                    specifications << specification if @configuration_element_list.key?(ce_name)
                     next
                   elsif @configuration_element_list.key?(ce_name)
                     if @configuration_element_list[ce_name].key?('controls')


### PR DESCRIPTION
Filtering data that would be confined away earlier prevents data that is
unconfined or already passed through confinement from being unexpectedly
confined away.

Also, ignore undefined ces when correlating checks and profiles.

SIMP-8345 #close