### PR TITLE
(SIMP-8375) Fix profile merging

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,12 @@
+* Wed Sep 16 2020 Steven Pritchard <steven.pritchard@onyxpoint.com> - 3.1.1-0
+- Add tests for profile merging
+- Deduplicate profile, control, ce, and check names in enforcement tests to
+  avoid cross-contamination of test data
+- Remove useless loops in list_puppet_params function
+- Fix calls to deep_merge!
+- Fix logic for merging oval-ids, controls, and identifiers
+- Add begin/rescue blocks around merges to avoid problems with incorrect data
+
 * Fri Sep 11 2020 Steven Pritchard <steven.pritchard@onyxpoint.com> - 3.1.1-0
 - Add controls, identifiers, and oval-ids
 - Work around rspec failure

--- a/spec/acceptance/nodesets/centos.yml
+++ b/spec/acceptance/nodesets/centos.yml
@@ -12,19 +12,19 @@ HOSTS:
       - default
     platform:   el-7-x86_64
     box:        centos/7
-    hypervisor: vagrant
+    hypervisor: <%= hypervisor %>
   el6:
     roles:
       - client
     platform:   el-6-x86_64
     box:        centos/6
-    hypervisor: vagrant
+    hypervisor: <%= hypervisor %>
   el8:
     roles:
       - client
     platform:   el-8-x86_64
     box:        centos/8
-    hypervisor: vagrant
+    hypervisor: <%= hypervisor %>
 CONFIG:
   log_level: verbose
   type:      aio

--- a/spec/functions/compliance_markup/00_enforcement_spec.rb
+++ b/spec/functions/compliance_markup/00_enforcement_spec.rb
@@ -14,9 +14,9 @@ describe 'lookup' do
   profile_yaml = {
     'version' => '2.0.0',
     'profiles' => {
-      'profile_test' => {
+      '00_profile_test' => {
         'controls' => {
-          'control1' => true,
+          '00_control1' => true,
         },
       },
     },
@@ -25,9 +25,9 @@ describe 'lookup' do
   ces_yaml = {
     'version' => '2.0.0',
     'ce' => {
-      'ce1' => {
+      '00_ce1' => {
         'controls' => {
-          'control1' => true,
+          '00_control1' => true,
         },
       },
     },
@@ -36,24 +36,24 @@ describe 'lookup' do
   checks_yaml = {
     'version' => '2.0.0',
     'checks' => {
-      'check1' => {
-        'type' => 'puppet-class-parameter',
+      '00_check1' => {
+        'type'     => 'puppet-class-parameter',
         'settings' => {
-          'parameter' => 'test_module::test_param',
-          'value' => 'a string',
+          'parameter' => 'test_module_00::test_param',
+          'value'     => 'a string',
         },
-        'ces' => [
-          'ce1',
+        'ces'      => [
+          '00_ce1',
         ],
       },
-      'check2' => {
-        'type' => 'puppet-class-parameter',
+      '00_check2' => {
+        'type'     => 'puppet-class-parameter',
         'settings' => {
-          'parameter' => 'test_module::test_param2',
-          'value' => 'another string',
+          'parameter' => 'test_module_00::test_param2',
+          'value'     => 'another string',
         },
-        'ces' => [
-          'ce1',
+        'ces'      => [
+          '00_ce1',
         ],
       },
     },
@@ -84,19 +84,19 @@ describe 'lookup' do
 
       let(:hieradata) { 'compliance-engine' }
 
-      it { is_expected.to run.with_params('test_module::test_param').and_raise_error(Puppet::DataBinding::LookupError, "Function lookup() did not find a value for the name 'test_module::test_param'") }
+      it { is_expected.to run.with_params('test_module_00::test_param').and_raise_error(Puppet::DataBinding::LookupError, "Function lookup() did not find a value for the name 'test_module_00::test_param'") }
     end
 
     context "on #{os} with compliance_markup::enforcement and an existing profile" do
       let(:facts) do
-        os_facts.merge('target_compliance_profile' => 'profile_test')
+        os_facts.merge('target_compliance_profile' => '00_profile_test')
       end
 
       let(:hieradata) { 'compliance-engine' }
 
       # Test unconfined data.
-      it { is_expected.to run.with_params('test_module::test_param').and_return('a string') }
-      it { is_expected.to run.with_params('test_module::test_param2').and_return('another string') }
+      it { is_expected.to run.with_params('test_module_00::test_param').and_return('a string') }
+      it { is_expected.to run.with_params('test_module_00::test_param2').and_return('another string') }
     end
   end
 end

--- a/spec/functions/compliance_markup/01_enforcement_confine_spec.rb
+++ b/spec/functions/compliance_markup/01_enforcement_confine_spec.rb
@@ -12,44 +12,36 @@ requiredver = SemanticPuppet::Version.parse("4.10.0")
 describe 'lookup' do
   # Generate a fake module with dummy data for lookup().
   profile_yaml = {
-    'version' => '2.0.0',
+    'version'  => '2.0.0',
     'profiles' => {
-      'profile_test' => {
+      '01_profile_test' => {
         'controls' => {
-          'control1' => true,
-          'os_control' => true,
+          '01_control1'   => true,
+          '01_os_control' => true,
         },
-        # Future
-        # 'confine' => {
-        #   # Test for module name
-        #   # Test for module version
-        #   # Test for single fact
-        #   # Test for multiple facts
-        #   # Test for array of facts
-        # },
       },
     },
   }.to_yaml
 
   ces_yaml = {
     'version' => '2.0.0',
-    'ce' => {
-      'ce1' => {
+    'ce'      => {
+      '01_ce1' => {
         'controls' => {
-          'control1' => true,
+          '01_control1' => true,
         },
       },
-      'ce2' => {
+      '01_ce2' => {
         'controls' => {
-          'os_control' => true,
+          '01_os_control' => true,
         },
       },
-      'ce3' => {
+      '01_ce3' => {
         'controls' => {
-          'control1' => true,
+          '01_control1' => true,
         },
-        'confine' => {
-          'module_name' => 'simp-compliance_markup',
+        'confine'  => {
+          'module_name'    => 'simp-compliance_markup',
           'module_version' => '< 3.1.0',
         },
       },
@@ -58,45 +50,45 @@ describe 'lookup' do
 
   checks_yaml = {
     'version' => '2.0.0',
-    'checks' => {
-      'el_check' => {
-        'type' => 'puppet-class-parameter',
+    'checks'  => {
+      '01_el_check'       => {
+        'type'     => 'puppet-class-parameter',
         'settings' => {
-          'parameter' => 'test_module::is_el',
-          'value' => true,
+          'parameter' => 'test_module_01::is_el',
+          'value'     => true,
         },
-        'ces' => [
-          'ce2',
+        'ces'      => [
+          '01_ce2',
         ],
-        'confine' => {
+        'confine'  => {
           'os.family' => 'RedHat',
         },
       },
-      'el7_check' => {
-        'type' => 'puppet-class-parameter',
+      '01_el7_check'      => {
+        'type'     => 'puppet-class-parameter',
         'settings' => {
-          'parameter' => 'test_module::el_version',
-          'value' => '7',
+          'parameter' => 'test_module_01::el_version',
+          'value'     => '7',
         },
-        'ces' => [
-          'ce2',
+        'ces'      => [
+          '01_ce2',
         ],
-        'confine' => {
-          'os.name' => [
+        'confine'  => {
+          'os.name'          => [
             'RedHat',
             'CentOS',
           ],
           'os.release.major' => '7',
         },
       },
-      'confine_in_ces' => {
-        'type' => 'puppet-class-parameter',
+      '01_confine_in_ces' => {
+        'type'     => 'puppet-class-parameter',
         'settings' => {
-          'parameter' => 'test_module::fixed_confines',
-          'value' => false,
+          'parameter' => 'test_module_01::fixed_confines',
+          'value'     => false,
         },
-        'ces' => [
-          'ce3',
+        'ces'      => [
+          '01_ce3',
         ],
       },
     },
@@ -122,27 +114,27 @@ describe 'lookup' do
   on_supported_os.each do |os, os_facts|
     context "on #{os} with compliance_markup::enforcement and an existing profile" do
       let(:facts) do
-        os_facts.merge('target_compliance_profile' => 'profile_test')
+        os_facts.merge('target_compliance_profile' => '01_profile_test')
       end
 
       let(:hieradata) { 'compliance-engine' }
 
       # Test for confine on a single fact in checks.
       if os_facts[:osfamily] == 'RedHat'
-        it { is_expected.to run.with_params('test_module::is_el').and_return(true) }
+        it { is_expected.to run.with_params('test_module_01::is_el').and_return(true) }
       else
-        it { is_expected.to run.with_params('test_module::is_el').and_raise_error(Puppet::DataBinding::LookupError, "Function lookup() did not find a value for the name 'test_module::is_el'") }
+        it { is_expected.to run.with_params('test_module_01::is_el').and_raise_error(Puppet::DataBinding::LookupError, "Function lookup() did not find a value for the name 'test_module_01::is_el'") }
       end
 
       # Test for confine on multiple facts and an array of facts in checks.
       if (os_facts[:os][:name] == 'RedHat' || os_facts[:os][:name] == 'CentOS') && os_facts[:operatingsystemmajrelease] == '7'
-        it { is_expected.to run.with_params('test_module::el_version').and_return('7') }
+        it { is_expected.to run.with_params('test_module_01::el_version').and_return('7') }
       else
-        it { is_expected.to run.with_params('test_module::el_version').and_raise_error(Puppet::DataBinding::LookupError, "Function lookup() did not find a value for the name 'test_module::el_version'") }
+        it { is_expected.to run.with_params('test_module_01::el_version').and_raise_error(Puppet::DataBinding::LookupError, "Function lookup() did not find a value for the name 'test_module_01::el_version'") }
       end
 
       # Test for confine on module name & module version in ce.
-      it { is_expected.to run.with_params('test_module::fixed_confines').and_raise_error(Puppet::DataBinding::LookupError, "Function lookup() did not find a value for the name 'test_module::fixed_confines'") }
+      it { is_expected.to run.with_params('test_module_01::fixed_confines').and_raise_error(Puppet::DataBinding::LookupError, "Function lookup() did not find a value for the name 'test_module_01::fixed_confines'") }
     end
   end
 end

--- a/spec/functions/compliance_markup/02_enforcement_merge_spec.rb
+++ b/spec/functions/compliance_markup/02_enforcement_merge_spec.rb
@@ -14,9 +14,9 @@ describe 'lookup' do
   profile_yaml = {
     'version' => '2.0.0',
     'profiles' => {
-      'profile_test' => {
+      '02_profile_test' => {
         'controls' => {
-          'control1' => true,
+          '02_control1' => true,
         },
       },
     },
@@ -25,9 +25,9 @@ describe 'lookup' do
   ces_yaml = {
     'version' => '2.0.0',
     'ce' => {
-      'ce1' => {
+      '02_ce1' => {
         'controls' => {
-          'control1' => true,
+          '02_control1' => true,
         },
       },
     },
@@ -35,81 +35,81 @@ describe 'lookup' do
 
   checks_yaml = {
     'version' => '2.0.0',
-    'checks' => {
-      'array check1' => {
-        'type' => 'puppet-class-parameter',
+    'checks'  => {
+      '02_array check1' => {
+        'type'     => 'puppet-class-parameter',
         'settings' => {
-          'parameter' => 'test_module::array_param',
-          'value' => [
+          'parameter' => 'test_module_02::array_param',
+          'value'     => [
             'array value 1',
           ],
         },
-        'ces' => [
-          'ce1',
+        'ces'      => [
+          '02_ce1',
         ],
       },
-      'array check2' => {
-        'type' => 'puppet-class-parameter',
+      '02_array check2' => {
+        'type'     => 'puppet-class-parameter',
         'settings' => {
-          'parameter' => 'test_module::array_param',
-          'value' => [
+          'parameter' => 'test_module_02::array_param',
+          'value'     => [
             'array value 2',
           ],
         },
-        'ces' => [
-          'ce1',
+        'ces'      => [
+          '02_ce1',
         ],
       },
-      'hash check1' => {
-        'type' => 'puppet-class-parameter',
+      '02_hash check1'  => {
+        'type'     => 'puppet-class-parameter',
         'settings' => {
-          'parameter' => 'test_module::hash_param',
-          'value' => {
+          'parameter' => 'test_module_02::hash_param',
+          'value'     => {
             'hash key 1' => 'hash value 1',
           },
         },
-        'ces' => [
-          'ce1',
+        'ces'      => [
+          '02_ce1',
         ],
       },
-      'hash check2' => {
-        'type' => 'puppet-class-parameter',
+      '02_hash check2'  => {
+        'type'     => 'puppet-class-parameter',
         'settings' => {
-          'parameter' => 'test_module::hash_param',
-          'value' => {
+          'parameter' => 'test_module_02::hash_param',
+          'value'     => {
             'hash key 2' => 'hash value 2',
           },
         },
-        'ces' => [
-          'ce1',
+        'ces'      => [
+          '02_ce1',
         ],
       },
-      'nested hash1' => {
-        'type' => 'puppet-class-parameter',
+      '02_nested hash1' => {
+        'type'     => 'puppet-class-parameter',
         'settings' => {
-          'parameter' => 'test_module::nested_hash',
-          'value' => {
+          'parameter' => 'test_module_02::nested_hash',
+          'value'     => {
             'key' => {
               'key1' => 'value1',
             },
           },
         },
-        'ces' => [
-          'ce1',
+        'ces'      => [
+          '02_ce1',
         ],
       },
-      'nested hash2' => {
-        'type' => 'puppet-class-parameter',
+      '02_nested hash2' => {
+        'type'     => 'puppet-class-parameter',
         'settings' => {
-          'parameter' => 'test_module::nested_hash',
-          'value' => {
+          'parameter' => 'test_module_02::nested_hash',
+          'value'     => {
             'key' => {
               'key2' => 'value2',
             },
           },
         },
-        'ces' => [
-          'ce1',
+        'ces'      => [
+          '02_ce1',
         ],
       },
     },
@@ -135,19 +135,19 @@ describe 'lookup' do
   on_supported_os.each do |os, os_facts|
     context "on #{os} with compliance_markup::enforcement and an existing profile" do
       let(:facts) do
-        os_facts.merge('target_compliance_profile' => 'profile_test')
+        os_facts.merge('target_compliance_profile' => '02_profile_test')
       end
 
       let(:hieradata) { 'compliance-engine' }
 
       # Test a simple array.
-      it { is_expected.to run.with_params('test_module::array_param').and_return(['array value 1', 'array value 2']) }
+      it { is_expected.to run.with_params('test_module_02::array_param').and_return(['array value 1', 'array value 2']) }
 
       # Test a simple hash.
-      it { is_expected.to run.with_params('test_module::hash_param').and_return({'hash key 1' => 'hash value 1', 'hash key 2' => 'hash value 2'}) }
+      it { is_expected.to run.with_params('test_module_02::hash_param').and_return({'hash key 1' => 'hash value 1', 'hash key 2' => 'hash value 2'}) }
 
       # Test a nested hash.
-      it { is_expected.to run.with_params('test_module::nested_hash').and_return({'key' => { 'key1' => 'value1', 'key2' => 'value2'}}) }
+      it { is_expected.to run.with_params('test_module_02::nested_hash').and_return({'key' => { 'key1' => 'value1', 'key2' => 'value2'}}) }
     end
   end
 end

--- a/spec/functions/compliance_markup/03_enforcement_profile_merge_spec.rb
+++ b/spec/functions/compliance_markup/03_enforcement_profile_merge_spec.rb
@@ -1,0 +1,205 @@
+#!/usr/bin/env ruby -S rspec
+
+require 'spec_helper'
+require 'semantic_puppet'
+require 'puppet/pops/lookup/context'
+require 'yaml'
+require 'fileutils'
+
+puppetver = SemanticPuppet::Version.parse(Puppet.version)
+requiredver = SemanticPuppet::Version.parse("4.10.0")
+
+describe 'lookup' do
+  # Generate a fake module with dummy data for lookup().
+  profile_yaml = {
+    'version'  => '2.0.0',
+    'profiles' => {
+      'profile_test1' => {
+        'ces' => {
+          '03_profile_test1' => true,
+        },
+      },
+      'profile_test2' => {
+        'ces' => {
+          '03_profile_test2' => true,
+        },
+      },
+    },
+  }.to_yaml
+
+  ces_yaml = {
+    'version' => '2.0.0',
+    'ce'      => {
+      '03_profile_test1' => {},
+      '03_profile_test2' => {},
+    },
+  }.to_yaml
+
+  checks_yaml = {
+    'version' => '2.0.0',
+    'checks'  => {
+      '03_string check1' => {
+        'type'     => 'puppet-class-parameter',
+        'settings' => {
+          'parameter' => 'test_module_03::string_param',
+          'value'     => 'string value 1',
+        },
+        'ces'      => [
+          '03_profile_test1',
+        ],
+      },
+      '03_string check2' => {
+        'type'     => 'puppet-class-parameter',
+        'settings' => {
+          'parameter' => 'test_module_03::string_param',
+          'value'     => 'string value 2',
+        },
+        'ces'      => [
+          '03_profile_test2',
+        ],
+      },
+      '03_array check1'  => {
+        'type'     => 'puppet-class-parameter',
+        'settings' => {
+          'parameter' => 'test_module_03::array_param',
+          'value'     => [
+            'array value 1',
+          ],
+        },
+        'ces'      => [
+          '03_profile_test1',
+        ],
+      },
+      '03_array check2'  => {
+        'type'     => 'puppet-class-parameter',
+        'settings' => {
+          'parameter' => 'test_module_03::array_param',
+          'value'     => [
+            'array value 2',
+          ],
+        },
+        'ces'      => [
+          '03_profile_test2',
+        ],
+      },
+      '03_hash check1'   => {
+        'type'     => 'puppet-class-parameter',
+        'settings' => {
+          'parameter' => 'test_module_03::hash_param',
+          'value'     => {
+            'hash key 1' => 'hash value 1',
+          },
+        },
+        'ces'      => [
+          '03_profile_test1',
+        ],
+      },
+      '03_hash check2'   => {
+        'type'     => 'puppet-class-parameter',
+        'settings' => {
+          'parameter' => 'test_module_03::hash_param',
+          'value'     => {
+            'hash key 2' => 'hash value 2',
+          },
+        },
+        'ces'      => [
+          '03_profile_test2',
+        ],
+      },
+      '03_nested hash1'  => {
+        'type'     => 'puppet-class-parameter',
+        'settings' => {
+          'parameter' => 'test_module_03::nested_hash',
+          'value'     => {
+            'key' => {
+              'key1' => 'value1',
+            },
+          },
+        },
+        'ces'      => [
+          '03_profile_test1',
+        ],
+      },
+      '03_nested hash2'  => {
+        'type'     => 'puppet-class-parameter',
+        'settings' => {
+          'parameter' => 'test_module_03::nested_hash',
+          'value'     => {
+            'key' => {
+              'key1' => 'value2',
+              'key2' => 'value2',
+            },
+          },
+        },
+        'ces'      => [
+          '03_profile_test2',
+        ],
+      },
+    },
+  }.to_yaml
+
+  fixtures = File.expand_path('../../fixtures', __dir__)
+
+  compliance_dir = File.join(fixtures, 'modules', 'test_module_03', 'SIMP', 'compliance_profiles')
+  FileUtils.mkdir_p(compliance_dir)
+
+  File.open(File.join(compliance_dir, 'profile.yaml'), 'w') do |fh|
+    fh.puts profile_yaml
+  end
+
+  File.open(File.join(compliance_dir, 'ces.yaml'), 'w') do |fh|
+    fh.puts ces_yaml
+  end
+
+  File.open(File.join(compliance_dir, 'checks.yaml'), 'w') do |fh|
+    fh.puts checks_yaml
+  end
+
+  on_supported_os.each do |os, os_facts|
+    context "on #{os} with compliance_markup::enforcement merging profiles" do
+      before(:all) do
+        File.open(File.join(fixtures, 'hieradata', 'profile-merging.yaml'), 'w') do |fh|
+          test_hiera = {'compliance_markup::enforcement' => ['profile_test1', 'profile_test2']}.to_yaml
+          fh.puts test_hiera
+        end
+      end
+
+      let(:hieradata) { 'profile-merging' }
+
+      # Test a string.
+      it { is_expected.to run.with_params('test_module_03::string_param').and_return('string value 1') }
+
+      # Test a simple array.
+      it { is_expected.to run.with_params('test_module_03::array_param').and_return(['array value 2', 'array value 1']) }
+
+      # Test a simple hash.
+      it { is_expected.to run.with_params('test_module_03::hash_param').and_return({'hash key 1' => 'hash value 1', 'hash key 2' => 'hash value 2'}) }
+
+      # Test a nested hash.
+      it { is_expected.to run.with_params('test_module_03::nested_hash').and_return({'key' => { 'key1' => 'value1', 'key2' => 'value2'}}) }
+    end
+
+    context "on #{os} with compliance_markup::enforcement merging profiles in reverse order" do
+      before(:all) do
+        File.open(File.join(fixtures, 'hieradata', 'profile-merging.yaml'), 'w') do |fh|
+          test_hiera = {'compliance_markup::enforcement' => ['profile_test2', 'profile_test1']}.to_yaml
+          fh.puts test_hiera
+        end
+      end
+
+      let(:hieradata) { 'profile-merging' }
+
+      # Test a string.
+      it { is_expected.to run.with_params('test_module_03::string_param').and_return('string value 2') }
+
+      # Test a simple array.
+      it { is_expected.to run.with_params('test_module_03::array_param').and_return(['array value 1', 'array value 2']) }
+
+      # Test a simple hash.
+      it { is_expected.to run.with_params('test_module_03::hash_param').and_return({'hash key 2' => 'hash value 2', 'hash key 1' => 'hash value 1'}) }
+
+      # Test a nested hash.
+      it { is_expected.to run.with_params('test_module_03::nested_hash').and_return({'key' => { 'key1' => 'value2', 'key2' => 'value2'}}) }
+    end
+  end
+end

--- a/spec/functions/compliance_markup/10_enforce_spec.rb
+++ b/spec/functions/compliance_markup/10_enforce_spec.rb
@@ -1,0 +1,83 @@
+require 'spec_helper'
+
+def write_hieradata(policy_order)
+  data = {
+    'compliance_markup::enforcement'    => policy_order,
+    'compliance_markup::compliance_map' => {
+      'version' => '2.0.0',
+      'checks'  => {
+        'oval:com.puppet.test.disa.useradd_shells' => {
+          'type'        => 'puppet-class-parameter',
+          'controls'    => {
+            'disa_stig' => true,
+          },
+          'identifiers' => {
+            'FOO2' => ['FOO2'],
+            'BAR2' => ['BAR2']
+          },
+          'settings'    => {
+            'parameter' => 'useradd::shells',
+            'value'     => ['/bin/disa']
+          }
+        },
+        'oval:com.puppet.test.nist.useradd_shells' => {
+          'type'        => 'puppet-class-parameter',
+          'controls'    => {
+            'nist_800_53:rev4' => true
+          },
+          'identifiers' => {
+            'FOO2' => ['FOO2'],
+            'BAR2' => ['BAR2']
+          },
+          'settings'    => {
+            'parameter' => 'useradd::shells',
+            'value'     => ['/bin/nist']
+          }
+        }
+      }
+    }
+  }
+
+  fixtures = File.expand_path('../../fixtures', __dir__)
+
+  File.open(File.join(fixtures, 'hieradata', '10_enforce_spec.yaml'), 'w') do |fh|
+    fh.puts data.to_yaml
+  end
+end
+
+describe 'lookup' do
+  on_supported_os.each do |os, os_facts|
+    context "on #{os}" do
+      context 'with a single compliance map' do
+        let(:hieradata) { '10_enforce_spec' }
+        let(:policy_order) { ['disa_stig'] }
+
+        before(:each) do
+          write_hieradata(policy_order)
+        end
+
+        it 'returns /bin/disa' do
+          result = subject.execute('useradd::shells')
+          expect(result).to be_instance_of(Array)
+          expect(result).to include('/bin/disa')
+        end
+      end
+
+      context 'when disa is higher priority' do
+        let(:hieradata) { '10_enforce_spec' }
+        let(:policy_order) { ['disa_stig', 'nist_800_53:rev4'] }
+
+        before(:each) do
+          write_hieradata(policy_order)
+        end
+
+        it 'returns /bin/disa and /bin/nist' do
+          result = subject.execute('useradd::shells')
+          expect(result).to be_instance_of(Array)
+          expect(result).to include('/bin/disa')
+          expect(result).to include('/bin/nist')
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
* Add tests for profile merging
* Deduplicate profile, control, ce, and check names in enforcement tests
  to avoid cross-contamination of test data
* Remove useless loops in list_puppet_params function
* Fix calls to deep_merge!
* Fix logic for merging oval-ids, controls, and identifiers
* Add begin/rescue blocks around merges to avoid problems with incorrect
  data

SIMP-8375 #close