### PR TITLE
(SIMP-9278) Fix compliance enforcement

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+* Wed May 19 2021 Trevor Vaughan <tvaughan@onyxpoint.com> - 3.1.6
+- Ensure that the same context scope is called throughout the compliance_mapper
+  enforcement
+
 * Wed Apr 21 2021 Trevor Vaughan <tvaughan@onyxpoint.com> - 3.1.5-0
 - Ensure that using a string for 'compliance_markup::enforcement' will not cause
   the server to hang

--- a/lib/puppetx/simp/compliance_mapper.rb
+++ b/lib/puppetx/simp/compliance_mapper.rb
@@ -57,7 +57,7 @@ def enforcement(key, context=self, options={"mode" => "value"}, &block)
           # If we have a cache for this profile, we've already found
           # everything that we're going to find.
           if context.cache_has_key(key)
-            return cached_value(key)
+            return context.cached_value(key)
           else
             throw :no_such_key
           end
@@ -86,7 +86,7 @@ def enforcement(key, context=self, options={"mode" => "value"}, &block)
         compile_end_time = Time.now
 
         profile_map["compliance_markup::debug::hiera_backend_compile_time"] = (compile_end_time - compile_start_time)
-        cache("compliance_map_#{profile}", profile_map)
+        context.cache("compliance_map_#{profile}", profile_map)
         debug("debug: compiled compliance_map containing #{profile_map.size} keys in #{compile_end_time - compile_start_time} seconds")
 
         if key == "compliance_markup::debug::dump"

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-compliance_markup",
-  "version": "3.1.5",
+  "version": "3.1.6",
   "author": "SIMP Team",
   "summary": "Compliance-mapping annotation for Puppet code",
   "license": "Apache-2.0",


### PR DESCRIPTION
While testing the auditd module with a complex parameter, a bug surfaced in
compliance enforcement where the value would not be discovered in the context
cache.

This is due to the wrong cache being called based on two lines being missed
during the last code update.

While the previous code worked for simple data types, the more complex data
types appear to get lost for unknown reasons.

SIMP-9278 #comment fix compliance enforcement