### PR TITLE
(SIMP-9791) Add debug key to dump compiled data

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,6 @@
 * Mon Jun 14 2021 Steven Pritchard <steven.pritchard@onyxpoint.com> - 3.2.0
-- Add `compliance_markup::debug::profiles` key
+- Add `compliance_markup::debug::profiles` and
+  `compliance_markup::debug::compliance_data` keys
 
 * Wed May 19 2021 Trevor Vaughan <tvaughan@onyxpoint.com> - 3.1.6
 - Ensure that the same context scope is called throughout the compliance_mapper

--- a/README.md
+++ b/README.md
@@ -384,9 +384,10 @@ The Hiera backend exposes a debug interface to users via `lookup`. These can be 
 
 | Hiera key                                              | Purpose                                                    |
 | ---------                                              | -------                                                    |
-| `compliance_markup::debug::dump`                       | Returns a Hash of all data in the Hiera backend            |
+| `compliance_markup::debug::dump`                       | Returns a Hash of all output data from the Hiera backend   |
 | `compliance_markup::debug::hiera_backend_compile_time` | Returns the Hiera backend data compilation time in seconds |
 | `compliance_markup::debug::profiles`                   | Returns an Array of the available compliance profiles      |
+| `compliance_markup::debug::compliance_data`            | Returns a Hash of compiled input data to the Hiera backend |
 
 ## Limitations
 

--- a/lib/puppetx/simp/compliance_mapper.rb
+++ b/lib/puppetx/simp/compliance_mapper.rb
@@ -70,8 +70,16 @@ def enforcement(key, context=self, options={"mode" => "value"}, &block)
 
         profile_compiler.load(options, &block)
 
-        if key == 'compliance_markup::debug::profiles'
+        case key
+        when 'compliance_markup::debug::profiles'
           return profile_compiler.profile.keys
+        when 'compliance_markup::debug::compliance_data'
+          return {
+            'version'  => '2.0.0',
+            'profiles' => profile_compiler.profile,
+            'ce'       => profile_compiler.ce,
+            'checks'   => profile_compiler.check,
+          }
         end
 
         profile_map = profile_compiler.list_puppet_params(profile_list).cook do |item|

--- a/spec/functions/compliance_markup/06_enforcement_debug_spec.rb
+++ b/spec/functions/compliance_markup/06_enforcement_debug_spec.rb
@@ -8,7 +8,7 @@ require 'fileutils'
 
 describe 'lookup' do
   # Generate a fake module with dummy data for lookup().
-  profile_yaml = {
+  profile = {
     'version' => '2.0.0',
     'profiles' => {
       '06_profile_test' => {
@@ -17,9 +17,9 @@ describe 'lookup' do
         },
       },
     },
-  }.to_yaml
+  }
 
-  ces_yaml = {
+  ces = {
     'version' => '2.0.0',
     'ce' => {
       '06_ce1' => {
@@ -28,9 +28,9 @@ describe 'lookup' do
         },
       },
     },
-  }.to_yaml
+  }
 
-  checks_yaml = {
+  checks = {
     'version' => '2.0.0',
     'checks' => {
       '06_check1' => {
@@ -54,7 +54,7 @@ describe 'lookup' do
         ],
       },
     },
-  }.to_yaml
+  }
 
   fixtures = File.expand_path('../../fixtures', __dir__)
 
@@ -62,15 +62,15 @@ describe 'lookup' do
   FileUtils.mkdir_p(compliance_dir)
 
   File.open(File.join(compliance_dir, 'profile.yaml'), 'w') do |fh|
-    fh.puts profile_yaml
+    fh.puts profile.to_yaml
   end
 
   File.open(File.join(compliance_dir, 'ces.yaml'), 'w') do |fh|
-    fh.puts ces_yaml
+    fh.puts ces.to_yaml
   end
 
   File.open(File.join(compliance_dir, 'checks.yaml'), 'w') do |fh|
-    fh.puts checks_yaml
+    fh.puts checks.to_yaml
   end
 
   on_supported_os.each do |os, os_facts|
@@ -103,6 +103,15 @@ describe 'lookup' do
         result = subject.execute('compliance_markup::debug::profiles')
         expect(result).to be_a(Array)
         expect(result).to include('06_profile_test')
+      end
+
+      it do
+        result = subject.execute('compliance_markup::debug::compliance_data')
+        expect(result).to be_a(Hash)
+        expect(result.keys).to eq(['version', 'profiles', 'ce', 'checks'])
+        expect(result['profiles']).to include(profile['profiles'])
+        expect(result['ce']).to include(ces['ce'])
+        expect(result['checks']).to include(checks['checks'])
       end
     end
   end


### PR DESCRIPTION
Add `compliance_markup::debug::compliance_data` key that dumps compiled input data to the Hiera backend

[SIMP-9791] #close

[SIMP-9791]: https://simp-project.atlassian.net/browse/SIMP-9791