### PR TITLE
(SIMP-10633) Update standardized assets

### DIFF
--- a/.github/workflows/release_rpms.yml
+++ b/.github/workflows/release_rpms.yml
@@ -13,7 +13,8 @@
 #   GitHub Secret variable               Notes
 #   -------------------------------      ---------------------------------------
 #   SIMP_CORE_REF_FOR_BUILDING_RPMS      simp-core ref (tag) to use to build
-#                                        RPMs with `rake pkg:single`
+#                                        RPMs with `rake pkg:single` against
+#                                        `build/rpms/dependencies.yaml`
 #   SIMP_DEV_GPG_SIGNING_KEY             GPG signing key's secret key
 #   SIMP_DEV_GPG_SIGNING_KEY_ID          User ID (name) of signing key
 #   SIMP_DEV_GPG_SIGNING_KEY_PASSPHRASE  Passphrase to use GPG signing key
@@ -25,6 +26,7 @@
 #
 # * If triggered by another workflow, it will be necessary to provide a GitHub
 #   access token via the the `target_repo_token` parameter
+#
 #
 ---
 name: 'RELENG: Build + attach RPMs to GitHub Release'
@@ -61,8 +63,16 @@ on:
       target_repo_token:
         description: "API token for uploading to target repo"
         required: false
+      path_to_build:
+        # Example: simp-core builds pupmod from . and simp* from src/assets/simp
+        description: "Subpath to alternative RPM project"
+        required: false
       dry_run:
         description: "Dry run (Test-build RPMs)"
+        required: false
+        default: 'no'
+      verbose:
+        description: 'Verbose RPM builds when "yes"'
         required: false
         default: 'no'
 
@@ -72,28 +82,45 @@ env:
 
 jobs:
   create-and-attach-rpms-to-github-release:
-    name: Build and attach RPMs to Release
+    name: >
+      Build and attach RPMs to Release:
+      ${{ (github.event.inputs.target_repo != null && format('{0}/{1}', github.repository_owner, github.event.inputs.target_repo)) || github.repository }}
+      ${{ github.event.inputs.release_tag }}
+      (build os: ${{ github.event.inputs.build_container_os }})
     runs-on: ubuntu-20.04
     steps:
       - name: "Validate inputs"
+        id: validate-inputs
         run: |
           if ! [[ "$TARGET_REPO" =~ ^[a-z0-9][a-z0-9-]+/[a-z0-9][a-z0-9_-]+$ ]]; then
             printf '::error ::Target repository name has invalid format: %s\n' "$TARGET_REPO"
             exit 88
           fi
 
-          if ! [[ "$RELEASE_TAG" =~ ^v?[0-9]+\.[0-9]+\.[0-9]+(-(rc|alpha|beta|pre)?([0-9]+)?)?$ ]]; then
-            printf '::error ::Release Tag format is not SemVer or SemVer-ish RPM: %s\n' "$RELEASE_TAG"
+          if [[ "$RELEASE_TAG" =~ ^(simp-|v)?([0-9]+\.[0-9]+\.[0-9]+)(-(rc|RC|[Aa]lpha|[Bb]eta|pre|post)?([0-9]+)?)?$ ]]; then
+            if [ -n "${BASH_REMATCH[5]}" ]; then
+              echo "::set-output name=prebuild_number::${BASH_REMATCH[5]#-}"
+            fi
+            if [ -n "${BASH_REMATCH[3]}" ]; then
+              echo "::set-output name=prebuild_suffix::${BASH_REMATCH[3]#-}"
+            fi
+            if [ -n "${BASH_REMATCH[2]}" ]; then
+              echo "::set-output name=build_semver::${BASH_REMATCH[2]}"
+            fi
+          else
+            printf '::error ::Release Tag format is not SemVer, X.Y.Z-R, X.Y.Z-<prerelease>: "%s"\n' "$RELEASE_TAG"
             exit 88
           fi
 
       - name: >
           Query info for ${{ env.TARGET_REPO }}
-          release ${{ github.event.inputs.release_tag }}
+          release ${{ github.event.inputs.release_tag }} ${{ steps.validate-inputs.outputs.prebuild_suffix }}
+          build os ${{ github.event.inputs.build_container_os }}
           (autocreate_release = '${{ github.event.inputs.autocreate_release }}')
         id: release-api
         env:
           AUTOCREATE_RELEASE: ${{ github.event.inputs.autocreate_release }}
+          PREBUILD_TAG: ${{ steps.validate-inputs.outputs.prebuild_suffix }}
         uses: actions/github-script@v4
         with:
           github-token: ${{ github.event.inputs.target_repo_token || secrets.GITHUB_TOKEN }}
@@ -103,7 +130,8 @@ jobs:
             const autocreate_release = (process.env.AUTOCREATE_RELEASE == 'yes')
             const owner_data = { owner: owner, repo: repo }
             const release_data = Object.assign( {tag: tag}, owner_data )
-            const create_release_data = Object.assign( {tag_name: tag}, owner_data )
+            const prerelease = process.env.PREBUILD_TAG ? true : false
+            const create_release_data = Object.assign( {tag_name: tag, prerelease: prerelease}, owner_data )
             const tag_data = Object.assign( {ref: `tags/${tag}`}, owner_data )
 
             function id_from_release(data) {
@@ -168,7 +196,35 @@ jobs:
           clean: true
           fetch-depth: 0
 
-      - name: 'Build & Sign RPMs for ${{ github.event.inputs.release_tag }} Release'
+      - name: 'Customize RPM Release tag via build/rpm_metadata/release (pre-release only)'
+        if: steps.validate-inputs.outputs.prebuild_suffix
+        env:
+          BUILD_SEMVER: ${{ steps.validate-inputs.outputs.build_semver }}
+          PREBUILD_TAG: ${{ steps.validate-inputs.outputs.prebuild_suffix }}
+          PREBUILD_NUMBER: ${{ steps.validate-inputs.outputs.prebuild_number }}
+        # Note: To accomodate the capabilities of EL7's version of RPM, the
+        # release number is formatted according to the Fedora Packaging
+        # Guidelines' "Traditional versioning" conventions:
+        #
+        #   - https://fedoraproject.org/en-US/packaging-guidelines/Versioning/
+        #   - https://fedoraproject.org/wiki/Package_Versioning_Examples
+        #
+        run: |
+          mkdir -p build/rpm_metadata
+          # Special case for simp-doc's unique data format in /release
+          if [[ "$TARGET_REPO" =~ ^simp\/simp-doc$ ]]; then
+            echo "version: $BUILD_SEMVER" > build/rpm_metadata/release
+            echo "release: 0.${PREBUILD_NUMBER:-$GITHUB_RUN_NUMBER}.${PREBUILD_TAG}" >> build/rpm_metadata/release
+            printf '::warning ::Added file build/rpm_metadata/release with content "%s"\n' "$(cat build/rpm_metadata/release)"
+          else
+            echo "0.${PREBUILD_NUMBER:-$GITHUB_RUN_NUMBER}.${PREBUILD_TAG}" > build/rpm_metadata/release
+            printf '::warning ::Added file build/rpm_metadata/release with content "%s"\n' "$(cat build/rpm_metadata/release)"
+          fi
+
+      - name: >
+          Build & Sign RPMs for
+          ${{ github.event.inputs.release_tag }}
+          Release (${{ github.event.inputs.build_container_os }})
         uses: simp/github-action-build-and-sign-pkg-single-rpm@v2
         id: build-and-sign-rpm
         with:
@@ -177,6 +233,8 @@ jobs:
           gpg_signing_key_passphrase: ${{ secrets.SIMP_DEV_GPG_SIGNING_KEY_PASSPHRASE }}
           simp_core_ref_for_building_rpms: ${{ secrets.SIMP_CORE_REF_FOR_BUILDING_RPMS }}
           simp_builder_docker_image: 'docker.io/simpproject/simp_build_${{ github.event.inputs.build_container_os }}:latest'
+          path_to_build: "${{ (github.event.inputs.path_to_build != null && format('{0}/{1}', github.workspace, github.event.inputs.path_to_build)) || github.workspace }}"
+          verbose: ${{ github.event.inputs.verbose }}
 
       - name: "Wipe all previous assets from GitHub Release (when clean == 'yes')"
         if: ${{ github.event.inputs.clean == 'yes' && github.event.inputs.dry_run != 'yes' }}
@@ -197,7 +255,7 @@ jobs:
               await github.repos.deleteReleaseAsset({ owner, repo, asset_id })
             })
 
-      - name: 'Upload RPM file(s) to GitHub Release (github-script)'
+      - name: "Upload RPM file(s) to GitHub Release (dry_run != 'yes')"
         if: ${{ github.event.inputs.dry_run != 'yes' }}
         uses: actions/github-script@v4
         env:

--- a/.github/workflows/tag_deploy.yml
+++ b/.github/workflows/tag_deploy.yml
@@ -3,7 +3,7 @@
 #
 #             NOTICE: **This file is maintained with puppetsync**
 #
-# This file is updated automatically as part of a puppet module baseline.
+# This file is updated automatically as part of a standardized asset baseline.
 #
 # The next baseline sync will overwrite any local changes to this file!
 #
@@ -24,16 +24,19 @@
 #
 # NOTES:
 #
-# * The CHANGLOG text is altered to remove RPM-style date headers, which don't
+# * The CHANGELOG text is altered to remove RPM-style date headers, which don't
 #   render well as markdown on the GitHub release pages
 #
 ---
-name: 'Tag: Release to GitHub & Puppet Forge'
+name: 'Tag: Release to GitHub w/RPMs + Puppet Forge'
 
 on:
   push:
     tags:
+      # NOTE: These filter patterns aren't actually regexes:
+      #   https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#filter-pattern-cheat-sheet
       - '[0-9]+\.[0-9]+\.[0-9]+'
+      - '[0-9]+\.[0-9]+\.[0-9]+\-[a-z]+[0-9]+'
 
 env:
   PUPPET_VERSION: '~> 6'
@@ -42,7 +45,7 @@ jobs:
   releng-checks:
     name: "RELENG checks"
     if: github.repository_owner == 'simp'
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       - name: "Assert '${{ github.ref }}' is a tag"
         run: '[[ "$GITHUB_REF" =~ ^refs/tags/ ]] || { echo "::error ::GITHUB_REF is not a tag: ${GITHUB_REF}"; exit 1 ; }'
@@ -66,7 +69,9 @@ jobs:
     name: Deploy GitHub Release
     needs: [ releng-checks ]
     if: github.repository_owner == 'simp'
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
+    outputs:
+      prerelease: ${{ steps.tag-check.outputs.prerelease }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
@@ -82,7 +87,19 @@ jobs:
           annotation="$(git for-each-ref "$GITHUB_REF" --format='%(contents)' --count=1)"
           annotation_title="$(echo "$annotation" | head -1)"
 
+
+          if [[ "$tag" =~ ^(simp-|v)?[0-9]+\.[0-9]+\.[0-9]+(-(rc|alpha|beta|pre|post)?([0-9]+)?)?$ ]]; then
+            if [ -n "${BASH_REMATCH[2]}" ]; then
+              prerelease=yes
+              annotation_title="Pre-release of ${tag}"
+            fi
+          else
+            printf '::error ::Release Tag format is not SemVer, X.Y.Z-R, X.Y.Z-<prerelease>: "%s"\n' "$RELEASE_TAG"
+            exit 88
+          fi
+
           echo "::set-output name=tag::${tag}"
+          echo "::set-output name=prerelease::${prerelease}"
           echo "::set-output name=annotation_title::${annotation_title}"
 
           # Prepare annotation body as a file for the next step
@@ -104,21 +121,26 @@ jobs:
           tag_name: ${{ github.ref }}
           release_name: ${{ steps.tag-check.outputs.annotation_title }}
           body_path: /tmp/annotation.body
+          prerelease: ${{ steps.tag-check.outputs.prerelease  == 'yes'}}
           draft: false
-          prerelease: false
 
   build-and-attach-rpms:
     name: Trigger RPM release
     needs: [ create-github-release ]
     if: github.repository_owner == 'simp'
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     env:
       TARGET_REPO: ${{ github.repository }}
+    strategy:
+      matrix:
+        os:
+          - centos7
+          - centos8
     steps:
       - name: Get tag & annotation info (${{github.ref}})
         id: tag-check
         run: echo "::set-output name=tag::${GITHUB_REF/refs\/tags\//}"
-      - name: Trigger RPM release workflow
+      - name: Trigger RPM release workflow (${{ matrix.os }})
         uses: actions/github-script@v4
         env:
           DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
@@ -133,17 +155,20 @@ jobs:
               workflow_id: 'release_rpms.yml',
               ref: process.env.DEFAULT_BRANCH,
               inputs: {
-                release_tag: process.env.TARGET_TAG
+                release_tag: process.env.TARGET_TAG,
+                clean: 'no',
+                clobber: 'yes',
+                build_container_os: '${{ matrix.os }}'
               }
-            }).then( (result) => {
-              console.log( `== Submitted workflow dispatch: status ${result.status}` )
+            }).then((result) => {
+              console.log( `== Submitted workflow dispatch to build RPMs from ${{ matrix.os }}: status ${result.status}` )
             })
 
   deploy-to-puppet-forge:
     name: Deploy PuppetForge Release
     needs: [ create-github-release ]
-    if: github.repository_owner == 'simp'
-    runs-on: ubuntu-18.04
+    if: (github.repository_owner == 'simp') && (needs.create-github-release.outputs.prerelease != 'yes')
+    runs-on: ubuntu-latest
     env:
       PUPPETFORGE_API_TOKEN: ${{ secrets.PUPPETFORGE_API_TOKEN }}
       FORGE_USER_AGENT: GitHubActions-ForgeReleng-Workflow/0.4.0 (Purpose/forge-ops-for-${{ github.event.repository.name }})
@@ -160,7 +185,7 @@ jobs:
           bundler-cache: true
       - name: Build Puppet module (PDK)
         run: bundle exec pdk build --force
-      - name: Deploy to Puppet Forge
+      - name: Deploy to Puppet Forge (skipped when prerelease)
         run: |
           curl -X POST --silent --show-error --fail \
             --user-agent "$FORGE_USER_AGENT" \


### PR DESCRIPTION
This commit rolls up various improvements to the GHA tag & release
workflows, particularly:

  * Tagged releases build a matrix of RPMs: (EL8 *and* EL7)
  * Tagged release logic supports pre/post-release tag formats
  * New arguments in `release_rpms.yml`: `path_to_build` and `verbose`
  * Ensure jobs run on `ubuntu-latest`
  * Fixes for variable edge cases and inter-job dependencies

The patch enforces a standardized asset baseline using simp/puppetsync,
and may apply other updates to ensure conformity.

[SIMP-10655] #close
[SIMP-10633] #comment Add `release_rpms` to pupmod-simp-compliance_markup

[SIMP-10655]: https://simp-project.atlassian.net/browse/SIMP-10655?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SIMP-10633]: https://simp-project.atlassian.net/browse/SIMP-10633?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ