### PR TITLE
Note that compliance_markup is superseded by compliance_engine

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,6 +4,13 @@ This file provides guidance to AI agents when working with code in this reposito
 
 ## What this module does
 
+> **Note:** This module is the *original* implementation of the SIMP Compliance
+> Engine. It has been superseded by
+> [`compliance_engine`](https://github.com/simp/rubygem-simp-compliance_engine),
+> which is available both as a standalone Ruby gem and as a Puppet module
+> ([`simp-compliance_engine`](https://forge.puppet.com/modules/simp/compliance_engine)
+> on the Puppet Forge).
+
 `pupmod-simp-compliance_markup` is the SIMP **Compliance Engine** module. Unlike
 most SIMP modules it installs no packages and manages no services — it is almost
 entirely Ruby that plugs into Puppet in two ways:

--- a/README.md
+++ b/README.md
@@ -4,6 +4,13 @@
 [![Puppet Forge Downloads](https://img.shields.io/puppetforge/dt/simp/compliance_markup.svg)](https://forge.puppetlabs.com/simp/compliance_markup)
 [![Build Status](https://travis-ci.org/simp/pupmod-simp-compliance_markup.svg)](https://travis-ci.org/simp/pupmod-simp-compliance_markup)
 
+> **Note:** This module is the *original* implementation of the SIMP Compliance
+> Engine. It has been superseded by
+> [`compliance_engine`](https://github.com/simp/rubygem-simp-compliance_engine),
+> which is available both as a standalone Ruby gem and as a Puppet module
+> ([`simp-compliance_engine`](https://forge.puppet.com/modules/simp/compliance_engine)
+> on the Puppet Forge).
+
 Table of Contents
 
 <!-- vim-markdown-toc GFM -->


### PR DESCRIPTION
Adds a note to the top of README.md and AGENTS.md clarifying that this module is the original implementation of the SIMP Compliance Engine and has been superseded by [compliance_engine](https://github.com/simp/rubygem-simp-compliance_engine), which is available both as a standalone Ruby gem and as the [simp-compliance_engine](https://forge.puppet.com/modules/simp/compliance_engine) Puppet module on the Forge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)